### PR TITLE
feat: enable offline mode for local embedding by default

### DIFF
--- a/memoria/cli.py
+++ b/memoria/cli.py
@@ -75,6 +75,10 @@ def _mcp_entry(
         "EMBEDDING_DIM": embed.get("EMBEDDING_DIM", ""),
         "EMBEDDING_API_KEY": embed.get("EMBEDDING_API_KEY", ""),
         "EMBEDDING_BASE_URL": embed.get("EMBEDDING_BASE_URL", ""),
+        "HF_HUB_OFFLINE": "1",
+        "TRANSFORMERS_OFFLINE": "1",
+        "_HF_ENDPOINT": "https://hf-mirror.com",
+        "_comment_HF_ENDPOINT": "Uncomment and rename to HF_ENDPOINT to use HuggingFace mirror (remove leading underscore)",
     }
     return {"command": cmd, "args": args, "env": env}
 


### PR DESCRIPTION

## What type of PR is this?

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [x] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes #

## What this PR does / why we need it

- Add HF_HUB_OFFLINE=1 and TRANSFORMERS_OFFLINE=1 to MCP config env
- Prevents unnecessary network checks on every MCP server startup
- Add _HF_ENDPOINT placeholder for users in regions with slow HuggingFace access
- Users can uncomment and rename to HF_ENDPOINT to use mirrors like hf-mirror.com