### PR TITLE
docs: add CPU-only PyTorch installation guide for non-GPU environments

### DIFF
--- a/.kiro/steering/setup.md
+++ b/.kiro/steering/setup.md
@@ -93,6 +93,10 @@ source .venv/bin/activate
 ```bash
 # Step 5: Install Memoria (run alone)
 # If using local embedding:
+# - With NVIDIA GPU:
+pip install 'mo-memoria[local-embedding]'
+# - Without GPU (CPU-only, avoids large CUDA dependencies):
+pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install 'mo-memoria[local-embedding]'
 # If using an existing embedding service (no 900MB download):
 pip install mo-memoria
@@ -125,9 +129,14 @@ source .venv/bin/activate
 ```
 ```bash
 # 4. Install
+# If using local embedding:
+# - With NVIDIA GPU:
 pip install 'mo-memoria[local-embedding]'
-# or, if using an existing embedding service:
-# pip install mo-memoria
+# - Without GPU (CPU-only):
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install 'mo-memoria[local-embedding]'
+# If using an existing embedding service:
+pip install mo-memoria
 ```
 ```bash
 # 5. Configure with cloud URL
@@ -147,9 +156,14 @@ source .venv/bin/activate
 ```
 ```bash
 # 2. Install
+# If using local embedding:
+# - With NVIDIA GPU:
 pip install 'mo-memoria[local-embedding]'
-# or, if using an existing embedding service:
-# pip install mo-memoria
+# - Without GPU (CPU-only):
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install 'mo-memoria[local-embedding]'
+# If using an existing embedding service:
+pip install mo-memoria
 ```
 ```bash
 # 3. Configure with existing DB

--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ pip install mo-memoria
 
 # Only needed if using local embedding model (no external API):
 pip install "mo-memoria[local-embedding]"    # Local sentence-transformers (~900MB download)
+
+# If no NVIDIA GPU available, install CPU-only PyTorch first to avoid large CUDA dependencies:
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install "mo-memoria[local-embedding]"
 ```
 
 **⚠️ Configure embedding BEFORE the MCP server starts for the first time.** Tables are created on first startup with the configured embedding dimension. Changing it later requires re-creating the embedding column.

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -31,6 +31,10 @@ pip install memoria
 # Self-hosted embedded mode — choose an embedding provider:
 pip install "memoria[openai-embedding]"   # OpenAI / SiliconFlow / any OpenAI-compatible endpoint
 pip install "memoria[local-embedding]"    # Local sentence-transformers (~900MB download)
+
+# If no NVIDIA GPU available, install CPU-only PyTorch first to avoid large CUDA dependencies:
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install "memoria[local-embedding]"
 ```
 
 ---

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -187,6 +187,10 @@ python3 -m venv .venv && source .venv/bin/activate
 Then install:
 ```bash
 # Install with local embedding support (recommended)
+# - With NVIDIA GPU:
+pip install 'memoria[local-embedding]'
+# - Without GPU (CPU-only, avoids large CUDA dependencies):
+pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install 'memoria[local-embedding]'
 ```
 
@@ -278,6 +282,10 @@ memoria init
 
 ### "sentence-transformers not installed"
 ```bash
+# With NVIDIA GPU:
+pip install 'memoria[local-embedding]'
+# Without GPU (CPU-only):
+pip install torch --index-url https://download.pytorch.org/whl/cpu
 pip install 'memoria[local-embedding]'
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -59,6 +59,10 @@ pip install mo-memoria
 
 # Only needed if using local embedding model (no external API):
 pip install "mo-memoria[local-embedding]"    # Local sentence-transformers (~900MB download)
+
+# If no NVIDIA GPU available, install CPU-only PyTorch first to avoid large CUDA dependencies:
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install "mo-memoria[local-embedding]"
 ```
 
 ### Start the MCP server


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [x] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

N/A

## What this PR does / why we need it

When installing `mo-memoria[local-embedding]` on machines without NVIDIA GPU, pip downloads large CUDA dependencies (~2GB+) that are unnecessary. This wastes bandwidth and disk space.

This PR adds installation instructions to install CPU-only PyTorch first:
```bash
pip install torch --index-url https://download.pytorch.org/whl/cpu
pip install 'mo-memoria[local-embedding]'
```

Updated all documentation files:
- README.md
- README.pypi.md
- SETUP_GUIDE.md
- docs/user-guide.md
- .kiro/steering/setup.md