### PR TITLE
fix: sync version to 0.1.14 and remove 500-char limit in rule version…

### DIFF
--- a/memoria/cli.py
+++ b/memoria/cli.py
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-_VERSION = "0.1.12"
+_VERSION = "0.1.14"
 _MCP_KEY = "memoria"
 
 
@@ -107,7 +107,7 @@ def _detect(project_dir: Path) -> list[str]:
 def _installed_version(path: Path) -> str | None:
     if not path.exists():
         return None
-    m = re.search(r"memoria-version:\s*([\d.]+)", path.read_text()[:500])
+    m = re.search(r"memoria-version:\s*([\d.]+)", path.read_text())
     return m.group(1) if m else None
 
 

--- a/memoria/templates/claude_rule.md
+++ b/memoria/templates/claude_rule.md
@@ -1,4 +1,4 @@
-<!-- memoria-version: 0.1.12-->
+<!-- memoria-version: 0.1.14-->
 
 # Memory Integration (Memoria Lite)
 

--- a/memoria/templates/cursor_rule.md
+++ b/memoria/templates/cursor_rule.md
@@ -1,4 +1,4 @@
-<!-- memoria-version: 0.1.12-->
+<!-- memoria-version: 0.1.14-->
 
 # Memory Integration (Memoria Lite)
 

--- a/memoria/templates/kiro_steering.md
+++ b/memoria/templates/kiro_steering.md
@@ -2,7 +2,7 @@
 inclusion: always
 ---
 
-<!-- memoria-version: 0.1.12-->
+<!-- memoria-version: 0.1.14-->
 
 # Memory Integration (Memoria Lite)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mo-memoria"
-version = "0.1.12"
+version = "0.1.14"
 description = "Multi-tenant memory service for AI assistants"
 readme = "README.pypi.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
… detection

_installed_version() only searched the first 500 characters for the memoria-version marker, but _configure_claude() appends the rule to the end of existing CLAUDE.md files, placing the marker well past that limit. Remove the slice so the marker is found regardless of position. Also bump _VERSION, pyproject.toml, and all templates from 0.1.12 to 0.1.14 to match the published package.

## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes #19 

## What this PR does / why we need it

Claude related script has version mismatch.