### PR TITLE
feat: support moi apikey authorization for memoria

### DIFF
--- a/docs/apikey-mode.md
+++ b/docs/apikey-mode.md
@@ -1,0 +1,292 @@
+# Apikey 模式使用指南
+
+## 概述
+
+Memoria 支持两种远程认证模式：
+
+| 模式 | 请求头 | 适用场景 |
+|------|--------|----------|
+| Token 模式 | `Authorization: Bearer <token>` | 所有用户共享一个数据库，通过 master key 管理 API key |
+| Apikey 模式 | `X-API-Key: <apikey>` | 每个用户独立数据库，通过外部认证服务解析连接信息 |
+
+两种模式可以同时启用，互不影响。
+
+### Apikey 模式工作流程
+
+```
+客户端 → X-API-Key 头 → Memoria API → 远程认证服务 → 返回用户专属数据库连接
+                                                        ↓
+                                              连接到用户独立的 MatrixOne 数据库
+```
+
+---
+
+## 一、API Server 部署
+
+### 1. 配置 `.env` 文件
+
+```bash
+cp .env.example .env
+```
+
+Apikey 模式必填项：
+
+```bash
+# 远程认证服务地址（POST /apikey/connection 接口）
+MEMORIA_REMOTE_AUTH_SERVICE_URL=http://127.0.0.1:8000
+
+# Embedding 配置（server 端负责 embedding 计算）
+EMBEDDING_PROVIDER=openai
+EMBEDDING_MODEL=BAAI/bge-m3
+EMBEDDING_DIM=1024
+EMBEDDING_API_KEY=sk-your-key
+EMBEDDING_BASE_URL=https://api.siliconflow.cn/v1
+```
+
+可选项：
+
+```bash
+# 连接信息缓存 TTL（秒），默认 60，0 = 不缓存
+MEMORIA_CONN_CACHE_TTL=60
+
+# Master Key（如果同时需要 token 模式的管理员操作）
+MEMORIA_MASTER_KEY=your-master-key-here
+
+# LLM（用于反思和实体抽取功能）
+MEMORIA_LLM_API_KEY=your-llm-key
+MEMORIA_LLM_BASE_URL=https://api.example.com/v1
+MEMORIA_LLM_MODEL=gpt-4o-mini
+```
+
+> API Server 启动时会自动读取项目根目录的 `.env` 文件，无需通过命令行参数指定。
+
+### 2. 启动 API Server
+
+**本地开发模式**（需要已有 MatrixOne 数据库）：
+
+```bash
+# 安装依赖
+pip install -e ".[dev,openai-embedding]"
+
+# 启动
+make dev
+# 或直接：
+python -m uvicorn memoria.api.main:app --reload --port 8100
+```
+
+**Docker 模式**（自带 MatrixOne）：
+
+```bash
+docker compose up -d
+```
+
+### 3. 验证服务状态
+
+```bash
+curl http://localhost:8100/health
+# {"status": "ok", "database": "connected"}
+```
+
+
+---
+
+## 二、远程认证服务要求
+
+Memoria 的 apikey 模式依赖一个外部认证服务来解析 API key。该服务需要实现以下接口：
+
+### 接口规范
+
+```
+POST /apikey/connection
+Authorization: Bearer <apikey>
+```
+
+响应示例：
+
+```json
+{
+  "user_id": "user-123",
+  "db_host": "10.0.0.1",
+  "db_port": 6001,
+  "db_user": "local-moi-account:moi_root",
+  "db_password": "p@ssw0rd",
+  "db_name": "memoria-user-123"
+}
+```
+
+> `db_user` 和 `db_password` 中可以包含特殊字符（如 `:` 和 `@`），Memoria 会自动进行 URL 编码。
+
+### 响应码
+
+| 状态码 | 含义 |
+|--------|------|
+| 200 | 认证成功，返回连接信息 |
+| 401 | API key 无效或已过期 |
+| 其他 | Memoria 返回 502 Bad Gateway |
+
+---
+
+## 三、MCP 客户端注册到 IDE
+
+### 方式一：使用 `memoria init` 命令
+
+在你的项目目录下执行：
+
+```bash
+memoria init --api-url http://localhost:8100 --apikey your-api-key
+```
+
+该命令会自动检测当前目录下的 IDE 配置（Kiro / Cursor / Claude），并写入对应的 `mcp.json`。
+
+指定 IDE：
+
+```bash
+memoria init --api-url http://localhost:8100 --apikey your-api-key --tool kiro
+memoria init --api-url http://localhost:8100 --apikey your-api-key --tool cursor
+memoria init --api-url http://localhost:8100 --apikey your-api-key --tool claude
+```
+
+### 方式二：手动编辑 `mcp.json`
+
+**Kiro** — `.kiro/settings/mcp.json`：
+
+```json
+{
+  "mcpServers": {
+    "memoria": {
+      "command": "memoria-mcp",
+      "args": ["--api-url", "http://localhost:8100", "--apikey", "your-api-key"]
+    }
+  }
+}
+```
+
+**Cursor** — `.cursor/mcp.json`：
+
+```json
+{
+  "mcpServers": {
+    "memoria": {
+      "command": "memoria-mcp",
+      "args": ["--api-url", "http://localhost:8100", "--apikey", "your-api-key"]
+    }
+  }
+}
+```
+
+**Claude** — `.claude/mcp.json`：
+
+```json
+{
+  "mcpServers": {
+    "memoria": {
+      "command": "memoria-mcp",
+      "args": ["--api-url", "http://localhost:8100", "--apikey", "your-api-key"]
+    }
+  }
+}
+```
+
+> 注意：`--apikey` 和 `--token` 互斥，不能同时使用。
+
+---
+
+## 四、`memoria-mcp` 启动参数
+
+| 参数 | 说明 | 示例 |
+|------|------|------|
+| `--api-url` | Memoria REST API 地址（启用远程模式） | `http://localhost:8100` |
+| `--token` | Token 模式认证（`Authorization: Bearer`） | `sk-your-token` |
+| `--apikey` | Apikey 模式认证（`X-API-Key` 头） | `your-api-key` |
+| `--db-url` | 数据库 URL（嵌入模式，直连数据库） | `mysql+pymysql://root:111@localhost:6001/memoria` |
+| `--user` | 默认用户 ID（默认 `default`） | `alice` |
+| `--transport` | 传输协议：`stdio`（默认）或 `sse` | `stdio` |
+
+### 三种运行模式
+
+```bash
+# 嵌入模式：直连数据库，无需 API Server
+memoria-mcp --db-url "mysql+pymysql://root:111@localhost:6001/memoria"
+
+# 远程 Token 模式：通过 API Server，共享数据库
+memoria-mcp --api-url "http://localhost:8100" --token "sk-your-token"
+
+# 远程 Apikey 模式：通过 API Server，每用户独立数据库
+memoria-mcp --api-url "http://localhost:8100" --apikey "your-api-key"
+```
+
+---
+
+## 五、测试 Apikey 模式
+
+### 使用 curl 测试
+
+```bash
+# 存储记忆
+curl -X POST http://localhost:8100/v1/memories \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "用户偏好深色模式", "memory_type": "profile"}'
+
+# 检索记忆
+curl -X POST http://localhost:8100/v1/memories/retrieve \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "UI 偏好", "top_k": 5}'
+
+# 查看用户画像
+curl http://localhost:8100/v1/profiles/me \
+  -H "X-API-Key: your-api-key"
+```
+
+### 使用 MCP 客户端测试
+
+配置好 `mcp.json` 后，重启 IDE，然后在对话中使用 memory 相关工具：
+
+- `memory_store` — 存储记忆
+- `memory_retrieve` — 检索相关记忆
+- `memory_search` — 语义搜索
+- `memory_correct` — 修正记忆
+- `memory_purge` — 删除记忆
+
+---
+
+## 六、与 Token 模式的区别
+
+| 特性 | Token 模式 | Apikey 模式 |
+|------|-----------|-------------|
+| 认证头 | `Authorization: Bearer <token>` | `X-API-Key: <apikey>` |
+| 数据库 | 所有用户共享一个数据库 | 每用户独立数据库 |
+| 用户隔离 | 通过 `user_id` 字段隔离 | 物理数据库隔离 |
+| 自动治理 | 后台定时调度（每小时/每天/每周） | 仅按需触发（无自动调度） |
+| API Key 管理 | 通过 master key + `/auth/keys` 接口 | 由外部认证服务管理 |
+| 适用场景 | 单租户 / 小团队 | 多租户 SaaS / 企业级 |
+
+---
+
+## 七、`memoria init` 完整参数
+
+```bash
+memoria init [选项]
+
+连接选项：
+  --db-url URL          嵌入模式数据库 URL
+  --api-url URL         远程模式 API 地址
+  --token TOKEN         Token 模式认证
+  --apikey APIKEY       Apikey 模式认证（与 --token 互斥）
+  --user USER           默认用户 ID（默认 "default"）
+
+IDE 选项：
+  --tool {kiro,cursor,claude}   目标 IDE（可重复，默认自动检测）
+  --force                       覆盖已自定义的规则文件
+  --dir DIR                     项目目录（默认当前目录）
+
+Embedding 选项（仅嵌入模式需要）：
+  --embedding-provider PROVIDER   embedding 提供商（openai / local）
+  --embedding-model MODEL         模型名称
+  --embedding-dim DIM             向量维度
+  --embedding-api-key KEY         API key
+  --embedding-base-url URL        API 基础 URL
+```
+
+> 远程模式（`--api-url`）下不需要 embedding 参数，因为 embedding 由 server 端处理。

--- a/docs/design-apikey-mode.md
+++ b/docs/design-apikey-mode.md
@@ -1,0 +1,256 @@
+# Apikey 认证模式 — 架构设计文档
+
+> 版本: 1.0 | 日期: 2026-03-15 | 状态: 已实现
+
+## 1. 背景与动机
+
+Memoria 原有的 Token 模式（`Authorization: Bearer`）下，所有用户共享一个 MatrixOne 数据库，通过 `user_id` 字段实现逻辑隔离。这在单租户和小团队场景下足够，但在多租户 SaaS 场景中存在以下问题：
+
+- 数据隔离不够彻底（逻辑隔离 vs 物理隔离）
+- 无法为不同租户配置独立的数据库资源
+- API Key 的生命周期管理耦合在 Memoria 内部
+
+Apikey 模式通过引入外部认证服务，实现每用户独立数据库的物理隔离。
+
+## 2. 设计目标
+
+1. 新增 `X-API-Key` 认证方式，与现有 `Authorization: Bearer` 完全共存
+2. 通过外部认证服务将 API Key 解析为用户专属的数据库连接信息
+3. 每用户独立 MatrixOne 数据库，实现物理级数据隔离
+4. 对现有 Token 模式零影响 — 不修改任何已有认证逻辑
+5. 所有现有 API 端点自动支持两种认证模式
+
+## 3. 架构概览
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        客户端请求                                │
+│  ┌─────────────────────┐    ┌──────────────────────┐           │
+│  │ Authorization:       │    │ X-API-Key: <apikey>  │           │
+│  │ Bearer <token>       │    │                      │           │
+│  └──────────┬──────────┘    └──────────┬───────────┘           │
+└─────────────┼──────────────────────────┼───────────────────────┘
+              │                          │
+              ▼                          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                   get_auth_context()                             │
+│                   (dependencies.py)                              │
+│                                                                  │
+│  检查 X-API-Key 头 ──→ 有 ──→ _resolve_apikey()                │
+│         │                         │                              │
+│         ▼                         ▼                              │
+│        无                  RemoteAuthService                     │
+│         │                  POST /apikey/connection                │
+│         ▼                         │                              │
+│  get_current_user_id()            ▼                              │
+│  (原有 token 逻辑)         ConnInfo(user_id, db_*)              │
+│         │                         │                              │
+│         ▼                         ▼                              │
+│  AuthContext(                AuthContext(                         │
+│    user_id,                   user_id,                           │
+│    db_factory=共享DB          db_factory=用户专属DB               │
+│  )                          )                                    │
+└─────────────────────────────────────────────────────────────────┘
+              │                          │
+              ▼                          ▼
+┌──────────────────────┐  ┌──────────────────────────┐
+│   共享 MatrixOne DB   │  │  用户专属 MatrixOne DB    │
+│   (memoria)           │  │  (memoria-user-xxx)      │
+└──────────────────────┘  └──────────────────────────┘
+```
+
+## 4. 核心组件
+
+### 4.1 AuthContext — 统一认证上下文
+
+```python
+@dataclass
+class AuthContext:
+    user_id: str
+    db_factory: sessionmaker
+```
+
+所有 API 端点通过 `Depends(get_auth_context)` 获取认证上下文。`db_factory` 在 token 模式下指向共享数据库，在 apikey 模式下指向用户专属数据库。端点代码无需关心认证模式的差异。
+
+**分发逻辑**（`get_auth_context`）：
+
+```
+请求进入 → 检查 X-API-Key 头
+  ├─ 有 → _resolve_apikey() → 远程认证服务 → 用户专属 db_factory
+  └─ 无 → 检查 Authorization 头 → 原有 token 校验 → 共享 db_factory
+```
+
+### 4.2 RemoteAuthService — 远程认证服务客户端
+
+**文件**: `memoria/api/remote_auth_service.py`
+
+职责：调用外部认证服务，将 API Key 解析为数据库连接信息。
+
+```python
+class RemoteAuthService:
+    def resolve(self, apikey: str) -> ConnInfo:
+        # POST /apikey/connection
+        # Authorization: Bearer <apikey>
+        # → ConnInfo(user_id, db_host, db_port, db_user, db_password, db_name)
+```
+
+**缓存策略**：
+- 按 API Key 前 12 字符作为缓存键
+- TTL 可配置（`MEMORIA_CONN_CACHE_TTL`，默认 60 秒）
+- 线程安全（`threading.Lock`）
+
+**特殊字符处理**：
+- `db_user` 和 `db_password` 可能包含 `:` 和 `@` 等特殊字符
+- `ConnInfo.db_url` 属性使用 `urllib.parse.quote_plus()` 编码
+
+### 4.3 Per-User Engine Cache — 用户数据库连接池
+
+**文件**: `memoria/api/database.py`
+
+```python
+@lru_cache(maxsize=128)
+def _get_user_engine(host, port, user, password, db_name) -> Engine:
+    # 每个 (host, port, user, password, db_name) 组合缓存一个 Engine
+    # db_name 校验: [a-zA-Z0-9_\-]+（允许连字符）
+
+def get_user_session_factory(host, port, user, password, db_name) -> sessionmaker:
+    # 首次调用时自动创建 memory 表（ensure_tables + governance 基础表）
+    # 后续调用直接返回缓存的 sessionmaker
+```
+
+**表初始化**：首次连接用户数据库时，自动创建所有必要的表（`mem_memories`、`memory_graph_nodes`、`memory_graph_edges`、治理基础表等）。通过 `_user_db_initialized` 集合确保每个 `db_name` 只初始化一次。
+
+### 4.4 Middleware 适配
+
+**文件**: `memoria/api/middleware.py`
+
+速率限制中间件同时支持两种认证头：
+
+```python
+x_api_key = request.headers.get("x-api-key", "")
+if x_api_key:
+    api_key = x_api_key
+elif auth.startswith("Bearer "):
+    api_key = auth[7:]
+```
+
+两种模式使用相同的速率限制策略，按 key 前 12 字符作为限流键。
+
+
+### 4.5 MCP Server 适配
+
+**文件**: `memoria/mcp_local/server.py`
+
+`HTTPBackend`（远程模式）新增 `--apikey` 参数支持：
+
+- `--token`: 请求时使用 `Authorization: Bearer <token>` 头
+- `--apikey`: 请求时使用 `X-API-Key: <apikey>` 头
+- 两者互斥，不能同时使用
+
+### 4.6 CLI 适配
+
+**文件**: `memoria/cli.py`
+
+`memoria init` 命令新增 `--apikey` 参数：
+
+```bash
+# Token 模式
+memoria init --api-url http://localhost:8100 --token sk-xxx
+
+# Apikey 模式
+memoria init --api-url http://localhost:8100 --apikey your-key
+```
+
+生成的 `mcp.json` 中 args 会包含对应的认证参数。`--token` 和 `--apikey` 互斥校验在 `cmd_init()` 入口处完成。
+
+## 5. 配置项
+
+| 环境变量 | 默认值 | 说明 |
+|----------|--------|------|
+| `MEMORIA_REMOTE_AUTH_SERVICE_URL` | `""` | 远程认证服务地址。为空时 apikey 模式不可用（返回 501） |
+| `MEMORIA_CONN_CACHE_TTL` | `60` | 认证结果缓存 TTL（秒）。0 = 不缓存 |
+
+这两个配置项仅影响 apikey 模式，对 token 模式无任何影响。
+
+## 6. 治理策略差异
+
+| 行为 | Token 模式 | Apikey 模式 |
+|------|-----------|-------------|
+| 自动治理调度 | ✅ 启动时创建（每小时/每天/每周） | ❌ 不启动 |
+| 按需治理 | ✅ `POST /v1/consolidate` 等 | ✅ 相同接口，相同 cooldown |
+| 治理范围 | 共享数据库中该用户的数据 | 用户专属数据库的全部数据 |
+
+**设计决策**：apikey 模式下不启动自动治理调度器，原因：
+1. 每个用户有独立数据库，服务端无法预知所有用户的数据库连接
+2. 治理调度器需要持有数据库连接，无法为动态数量的用户维护连接池
+3. 用户可通过 MCP 工具（`memory_governance`）或 REST API 按需触发
+
+判断逻辑在 `memoria/api/main.py` 的 `lifespan` 中：
+
+```python
+if not _s.remote_auth_service_url:
+    # Token 模式：启动自动治理
+    scheduler = MemoryGovernanceScheduler(backend=backend)
+    await scheduler.start()
+# Apikey 模式：不启动，用户按需触发
+```
+
+## 7. 安全考量
+
+### 7.1 认证隔离
+- 两种认证模式完全独立，互不影响
+- Token 模式的 master key、API key 哈希表等逻辑未做任何修改
+- Apikey 模式的认证完全委托给外部服务
+
+### 7.2 数据库连接安全
+- `db_name` 校验：`[a-zA-Z0-9_\-]+`，防止 SQL 注入
+- `db_user` / `db_password` 使用 `quote_plus()` 编码，防止连接字符串注入
+- 每用户 Engine 通过 `@lru_cache(maxsize=128)` 缓存，避免连接泄漏
+
+### 7.3 速率限制
+- 两种模式共享同一套速率限制策略
+- Master key 豁免速率限制（用于管理和基准测试）
+
+### 7.4 错误处理
+- 远程认证服务返回 401 → Memoria 返回 401（Invalid or expired API key）
+- 远程认证服务不可达或返回其他错误 → Memoria 返回 502（Bad Gateway）
+- `REMOTE_AUTH_SERVICE_URL` 未配置时使用 apikey → 返回 501（Not Implemented）
+
+## 8. 修改文件清单
+
+| 文件 | 变更类型 | 说明 |
+|------|----------|------|
+| `memoria/api/remote_auth_service.py` | 新增 | 远程认证服务客户端（ConnInfo、缓存、resolve） |
+| `memoria/api/dependencies.py` | 修改 | 新增 AuthContext、get_auth_context、_resolve_apikey |
+| `memoria/api/database.py` | 修改 | 新增 _get_user_engine、get_user_session_factory、_ensure_user_tables |
+| `memoria/api/main.py` | 修改 | 治理调度器条件启动（非 apikey 模式才启动） |
+| `memoria/api/middleware.py` | 修改 | 速率限制支持 X-API-Key 头 |
+| `memoria/api/routers/memory.py` | 修改 | 所有端点改用 get_auth_context 依赖 |
+| `memoria/api/routers/snapshots.py` | 修改 | 同上 |
+| `memoria/api/routers/user_ops.py` | 修改 | 同上 |
+| `memoria/mcp_local/server.py` | 修改 | HTTPBackend 支持 --apikey 参数 |
+| `memoria/cli.py` | 修改 | memoria init 支持 --apikey 参数 |
+| `memoria/config.py` | 修改 | 新增 remote_auth_service_url、conn_cache_ttl 配置 |
+| `tests/unit/test_apikey_auth.py` | 新增 | 25 个单元测试覆盖核心逻辑 |
+
+## 9. 向后兼容性
+
+- 所有现有 API 端点的请求/响应格式不变
+- Token 模式的认证逻辑（`get_current_user_id`、`require_admin`）未修改
+- 原有的 `/auth/keys` 管理接口不受影响
+- 未配置 `REMOTE_AUTH_SERVICE_URL` 时，系统行为与修改前完全一致
+- 自动治理调度器在 token 模式下照常运行
+
+## 10. 测试覆盖
+
+测试文件：`tests/unit/test_apikey_auth.py`
+
+| 测试类别 | 覆盖内容 |
+|----------|----------|
+| RemoteAuthService | resolve 成功、401 处理、缓存命中/过期、ConnInfo.db_url 特殊字符编码 |
+| AuthContext 分发 | X-API-Key 走 apikey 路径、Bearer 走 token 路径、两者都缺返回 401 |
+| _resolve_apikey | 未配置返回 501、认证失败返回 401、服务不可达返回 502 |
+| 数据库连接 | db_name 校验（拒绝注入、允许连字符）、表初始化幂等性 |
+| Middleware | X-API-Key 前缀提取用于限流 |
+| CLI | --token 和 --apikey 互斥校验 |
+| Config | remote_auth_service_url / conn_cache_ttl 默认值和环境变量覆盖 |

--- a/memoria/api/database.py
+++ b/memoria/api/database.py
@@ -1,8 +1,11 @@
 """Memoria database engine and session factory."""
 
+import re
+import threading
 from contextlib import contextmanager
+from functools import lru_cache
 
-from sqlalchemy import text
+from sqlalchemy import Engine, text
 from sqlalchemy.orm import sessionmaker
 
 from memoria.config import get_settings
@@ -108,6 +111,90 @@ def init_db():
     ensure_tables(engine, dim=dim)
 
     # Governance infrastructure tables (used by scheduler)
+    with engine.begin() as c:
+        c.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS infra_distributed_locks ("
+                "  lock_name VARCHAR(64) PRIMARY KEY,"
+                "  instance_id VARCHAR(64) NOT NULL,"
+                "  acquired_at DATETIME(6) NOT NULL DEFAULT NOW(),"
+                "  expires_at DATETIME(6) NOT NULL,"
+                "  task_name VARCHAR(255) NOT NULL"
+                ")"
+            )
+        )
+        c.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS governance_runs ("
+                "  id BIGINT AUTO_INCREMENT PRIMARY KEY,"
+                "  task_name VARCHAR(255) NOT NULL,"
+                "  result TEXT,"
+                "  created_at DATETIME(6) NOT NULL DEFAULT NOW(),"
+                "  INDEX idx_governance_runs_task (task_name)"
+                ")"
+            )
+        )
+
+
+# ── Per-user engine cache (apikey mode) ─────────────────────────────
+
+
+@lru_cache(maxsize=128)
+def _get_user_engine(
+    host: str, port: int, user: str, password: str, db_name: str
+) -> Engine:
+    """Return a cached SQLAlchemy engine for a per-user MatrixOne database."""
+    if not re.fullmatch(r"[a-zA-Z0-9_\-]+", db_name):
+        raise ValueError(f"Invalid database name: {db_name!r}")
+
+    from matrixone import Client as MoClient
+
+    client = MoClient(
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        database=db_name,
+        sql_log_mode="off",
+    )
+    return client._engine
+
+
+_user_db_initialized: set[str] = set()
+_user_db_init_lock = threading.Lock()
+
+
+def get_user_session_factory(
+    host: str, port: int, user: str, password: str, db_name: str
+) -> sessionmaker:
+    """Return a session factory bound to a per-user engine.
+
+    On first call for a given db_name, ensures memory tables exist.
+    """
+    engine = _get_user_engine(host, port, user, password, db_name)
+
+    with _user_db_init_lock:
+        if db_name not in _user_db_initialized:
+            _ensure_user_tables(engine)
+            _user_db_initialized.add(db_name)
+
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _ensure_user_tables(engine: Engine) -> None:
+    """Create memory tables in a per-user database (apikey mode)."""
+    from memoria.config import get_settings
+    from memoria.schema import ensure_tables
+
+    settings = get_settings()
+    dim = settings.embedding_dim
+    if dim == 0:
+        from memoria.core.embedding.client import KNOWN_DIMENSIONS
+
+        dim = KNOWN_DIMENSIONS.get(settings.embedding_model, 1024)
+    ensure_tables(engine, dim=dim)
+
+    # Governance infrastructure tables (for on-demand governance)
     with engine.begin() as c:
         c.execute(
             text(

--- a/memoria/api/dependencies.py
+++ b/memoria/api/dependencies.py
@@ -1,21 +1,54 @@
-"""SaaS API key authentication."""
+"""API authentication — supports both token mode and apikey mode.
+
+Token mode (existing): Authorization: Bearer <token>
+  - Validates against master key or auth_api_keys table in shared DB.
+  - All users share one MatrixOne database.
+
+Apikey mode (new): X-API-Key: <apikey>
+  - Calls remote auth service to resolve apikey → per-user DB connection.
+  - Each user gets their own MatrixOne database.
+"""
+
+from __future__ import annotations
 
 import hmac
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import Any
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import update
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.sql import func
 
-from memoria.api.database import get_db_session
+from memoria.api.database import get_db_factory, get_db_session
 from memoria.api.models import ApiKey
 from memoria.config import get_settings
 
-security = HTTPBearer()
+security = HTTPBearer(auto_error=False)
 
 ADMIN_USER_ID = "__admin__"
+
+# ── Singleton for remote auth service client ────────────────────────
+
+_remote_auth: Any = None
+
+
+def _get_remote_auth():
+    global _remote_auth
+    if _remote_auth is None:
+        from memoria.api.remote_auth_service import RemoteAuthService
+
+        settings = get_settings()
+        _remote_auth = RemoteAuthService(
+            base_url=settings.remote_auth_service_url,
+            cache_ttl=settings.conn_cache_ttl,
+        )
+    return _remote_auth
+
+
+# ── Token mode helpers (existing logic) ─────────────────────────────
 
 
 def _is_master_key(token: str) -> bool:
@@ -29,12 +62,17 @@ def get_current_user_id(
     credentials: HTTPAuthorizationCredentials = Depends(security),
     db: Session = Depends(get_db_session),
 ) -> str:
-    """Authenticate via API key, return user_id.
+    """Authenticate via API key, return user_id (token mode only).
 
     Admin (master key) can impersonate a specific user via the
     ``X-Impersonate-User`` header.  Only master-key holders can use this;
     regular API keys ignore the header entirely.
     """
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header",
+        )
     token = credentials.credentials
 
     if _is_master_key(token):
@@ -84,14 +122,79 @@ def get_current_user_id(
 def require_admin(
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ) -> str:
-    """Require admin (master key) access.
-
-    Checks the raw token, NOT the impersonated user_id.
-    This ensures admin endpoints remain accessible even when
-    X-Impersonate-User is set.
-    """
-    if not _is_master_key(credentials.credentials):
+    """Require admin (master key) access."""
+    if credentials is None or not _is_master_key(credentials.credentials):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required"
         )
     return ADMIN_USER_ID
+
+
+# ── Unified auth context (supports both modes) ─────────────────────
+
+
+@dataclass
+class AuthContext:
+    """Resolved authentication result — carries user_id and db_factory."""
+
+    user_id: str
+    db_factory: sessionmaker
+
+
+def get_auth_context(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db_session),
+) -> AuthContext:
+    """Unified auth dependency — auto-dispatches to token or apikey mode.
+
+    - If ``X-API-Key`` header is present → apikey mode (remote auth service).
+    - Otherwise → token mode (existing ``Authorization: Bearer`` flow).
+    """
+    apikey = request.headers.get("X-API-Key")
+
+    if apikey:
+        return _resolve_apikey(apikey)
+
+    # Fall back to token mode
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization or X-API-Key header",
+        )
+    user_id = get_current_user_id(request, credentials, db)
+    return AuthContext(user_id=user_id, db_factory=get_db_factory())
+
+
+def _resolve_apikey(apikey: str) -> AuthContext:
+    """Resolve an apikey via remote auth service → per-user DB."""
+    settings = get_settings()
+    if not settings.remote_auth_service_url:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Apikey mode not configured (REMOTE_AUTH_SERVICE_URL not set)",
+        )
+
+    try:
+        conn = _get_remote_auth().resolve(apikey)
+    except PermissionError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired API key",
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Remote auth service unavailable: {exc}",
+        )
+
+    from memoria.api.database import get_user_session_factory
+
+    factory = get_user_session_factory(
+        host=conn.db_host,
+        port=conn.db_port,
+        user=conn.db_user,
+        password=conn.db_password,
+        db_name=conn.db_name,
+    )
+    return AuthContext(user_id=conn.user_id, db_factory=factory)

--- a/memoria/api/main.py
+++ b/memoria/api/main.py
@@ -44,23 +44,30 @@ async def lifespan(app: FastAPI):
     init_db()
 
     # Start periodic governance scheduler (hourly/daily/weekly)
-    from memoria.core.scheduler import (
-        GovernanceTaskRunner,
-        AsyncIOBackend,
-        MemoryGovernanceScheduler,
-    )
-    from memoria.api.database import get_db_context, get_db_factory
+    # Only in token mode — apikey mode uses on-demand governance
+    from memoria.config import get_settings as _get_settings
 
-    runner = GovernanceTaskRunner(
-        get_db_context, db_factory=get_db_factory(), memory_only=True
-    )
-    backend = AsyncIOBackend(runner)
-    scheduler = MemoryGovernanceScheduler(backend=backend)
-    await scheduler.start()
+    _s = _get_settings()
+    scheduler = None
+    if not _s.remote_auth_service_url:
+        from memoria.core.scheduler import (
+            GovernanceTaskRunner,
+            AsyncIOBackend,
+            MemoryGovernanceScheduler,
+        )
+        from memoria.api.database import get_db_context, get_db_factory
+
+        runner = GovernanceTaskRunner(
+            get_db_context, db_factory=get_db_factory(), memory_only=True
+        )
+        backend = AsyncIOBackend(runner)
+        scheduler = MemoryGovernanceScheduler(backend=backend)
+        await scheduler.start()
 
     yield
 
-    await scheduler.stop()
+    if scheduler:
+        await scheduler.stop()
 
 
 app = FastAPI(

--- a/memoria/api/middleware.py
+++ b/memoria/api/middleware.py
@@ -109,12 +109,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             for k in stale:
                 del _windows[k]
 
-        # Extract API key from Authorization header
+        # Extract API key from Authorization or X-API-Key header
         auth = request.headers.get("authorization", "")
-        if not auth.startswith("Bearer "):
-            return await call_next(request)
+        x_api_key = request.headers.get("x-api-key", "")
 
-        api_key = auth[7:]
+        if x_api_key:
+            api_key = x_api_key
+        elif auth.startswith("Bearer "):
+            api_key = auth[7:]
+        else:
+            return await call_next(request)
 
         # Master key is exempt from rate limiting (used by admin/benchmark)
         from memoria.api.dependencies import _is_master_key

--- a/memoria/api/remote_auth_service.py
+++ b/memoria/api/remote_auth_service.py
@@ -1,0 +1,92 @@
+"""Remote auth service client — resolves API keys to per-user DB connections."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any
+from urllib.parse import quote_plus
+
+import httpx
+
+
+@dataclass(frozen=True)
+class ConnInfo:
+    """Connection info returned by the remote auth service."""
+
+    user_id: str
+    db_host: str
+    db_port: int
+    db_user: str
+    db_password: str
+    db_name: str
+
+    @property
+    def db_url(self) -> str:
+        # URL-encode user/password — they may contain special chars
+        # like ':' or '@' (e.g. "local-moi-account:moi_root").
+        user = quote_plus(self.db_user)
+        pwd = quote_plus(self.db_password)
+        return (
+            f"mysql+pymysql://{user}:{pwd}"
+            f"@{self.db_host}:{self.db_port}/{self.db_name}"
+            "?charset=utf8mb4"
+        )
+
+
+class _CacheEntry:
+    __slots__ = ("value", "expires_at")
+
+    def __init__(self, value: ConnInfo, ttl: int) -> None:
+        self.value = value
+        self.expires_at = time.monotonic() + ttl
+
+
+class RemoteAuthService:
+    """Calls remote auth service to resolve an API key into ConnInfo.
+
+    Results are cached by key prefix (first 12 chars) with a configurable TTL.
+    """
+
+    def __init__(self, base_url: str, cache_ttl: int = 60) -> None:
+        self._client = httpx.Client(base_url=base_url.rstrip("/"), timeout=10)
+        self._ttl = cache_ttl
+        self._cache: dict[str, _CacheEntry] = {}
+        self._lock = Lock()
+
+    def resolve(self, apikey: str) -> ConnInfo:
+        """Resolve an API key to connection info, with TTL cache."""
+        cache_key = apikey[:12]
+
+        with self._lock:
+            entry = self._cache.get(cache_key)
+            if entry and entry.expires_at > time.monotonic():
+                return entry.value
+
+        resp = self._client.post(
+            "/apikey/connection",
+            headers={"Authorization": f"Bearer {apikey}"},
+        )
+        if resp.status_code == 401:
+            raise PermissionError("Invalid or expired API key")
+        resp.raise_for_status()
+
+        data: dict[str, Any] = resp.json()
+        info = ConnInfo(
+            user_id=data["user_id"],
+            db_host=data["db_host"],
+            db_port=int(data["db_port"]),
+            db_user=data["db_user"],
+            db_password=data["db_password"],
+            db_name=data["db_name"],
+        )
+
+        if self._ttl > 0:
+            with self._lock:
+                self._cache[cache_key] = _CacheEntry(info, self._ttl)
+
+        return info
+
+    def close(self) -> None:
+        self._client.close()

--- a/memoria/api/routers/memory.py
+++ b/memoria/api/routers/memory.py
@@ -9,8 +9,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from memoria.api.database import get_db_factory
-from memoria.api.dependencies import get_current_user_id
+from memoria.api.dependencies import AuthContext, get_auth_context
 from memoria.core.explain import init_explain, clear_explain
 
 logger = logging.getLogger(__name__)
@@ -142,12 +141,14 @@ def list_memories(
     memory_type: str | None = None,
     limit: int = 100,
     cursor: str | None = None,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """List active memories for the current user. Cursor-based pagination (pass last observed_at|memory_id)."""
     from memoria.core.memory.models.memory import MemoryRecord as M
     from sqlalchemy import or_, and_
+
+    user_id = auth.user_id
+    db_factory = auth.db_factory
 
     db = db_factory()
     try:
@@ -200,11 +201,12 @@ def list_memories(
 @router.post("/memories", status_code=status.HTTP_201_CREATED)
 def store_memory(
     req: StoreRequest,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     from memoria.core.memory.types import MemoryType, TrustTier
 
+    user_id = auth.user_id
+    db_factory = auth.db_factory
     editor = _get_editor(db_factory, user_id)
     try:
         mem = editor.inject(
@@ -227,11 +229,12 @@ def store_memory(
 @router.post("/memories/batch", status_code=status.HTTP_201_CREATED)
 def batch_store(
     req: BatchStoreRequest,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     from memoria.core.memory.types import MemoryType
 
+    user_id = auth.user_id
+    db_factory = auth.db_factory
     editor = _get_editor(db_factory, user_id)
     specs = [
         {
@@ -248,10 +251,12 @@ def batch_store(
 @router.post("/memories/retrieve")
 def retrieve_memories(
     req: RetrieveRequest,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ) -> dict[str, Any]:
     from memoria.core.memory.types import MemoryType
+
+    user_id = auth.user_id
+    db_factory = auth.db_factory
 
     # Initialize explain context (handles bool → str conversion internally)
     explain_ctx = init_explain(req.explain)
@@ -313,9 +318,11 @@ def retrieve_memories(
 @router.post("/memories/search")
 def search_memories(
     req: SearchRequest,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ) -> dict[str, Any]:
+    user_id = auth.user_id
+    db_factory = auth.db_factory
+
     # Initialize explain context (handles bool → str conversion internally)
     explain_ctx = init_explain(req.explain)
 
@@ -370,9 +377,10 @@ def search_memories(
 def correct_memory(
     memory_id: str,
     req: CorrectRequest,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
+    user_id = auth.user_id
+    db_factory = auth.db_factory
     _verify_ownership(db_factory, memory_id, user_id)
     editor = _get_editor(db_factory, user_id)
     try:
@@ -385,10 +393,11 @@ def correct_memory(
 @router.post("/memories/correct")
 def correct_by_query(
     req: CorrectByQueryRequest,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """Find the best-matching memory by semantic search and correct it."""
+    user_id = auth.user_id
+    db_factory = auth.db_factory
     editor = _get_editor(db_factory, user_id)
     match = editor.find_best_match(user_id, req.query)
     if match is None:
@@ -406,9 +415,10 @@ def correct_by_query(
 def delete_memory(
     memory_id: str,
     reason: str = "",
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
+    user_id = auth.user_id
+    db_factory = auth.db_factory
     _verify_ownership(db_factory, memory_id, user_id)
     editor = _get_editor(db_factory, user_id)
     result = editor.purge(user_id, memory_ids=[memory_id], reason=reason)
@@ -418,11 +428,12 @@ def delete_memory(
 @router.post("/memories/purge")
 def purge_memories(
     req: PurgeRequest,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     from memoria.core.memory.types import MemoryType
 
+    user_id = auth.user_id
+    db_factory = auth.db_factory
     editor = _get_editor(db_factory, user_id)
 
     # Topic purge: find matching memory_ids via fulltext search, then purge by ID
@@ -476,10 +487,11 @@ def purge_memories(
 @router.get("/profiles/{target_user_id}")
 def get_profile(
     target_user_id: str,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     # "me" resolves to the authenticated user
+    user_id = auth.user_id
+    db_factory = auth.db_factory
     resolved = user_id if target_user_id == "me" else target_user_id
     svc = _get_service(db_factory, user_id=resolved)
     profile = svc.get_profile(resolved)
@@ -536,9 +548,10 @@ def get_profile(
 @router.post("/observe")
 def observe_turn(
     req: ObserveRequest,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
+    user_id = auth.user_id
+    db_factory = auth.db_factory
     svc = _get_service(db_factory, user_id=user_id)
     memories = svc.observe_turn(
         user_id, req.messages, source_event_ids=req.source_event_ids

--- a/memoria/api/routers/snapshots.py
+++ b/memoria/api/routers/snapshots.py
@@ -12,8 +12,7 @@ from sqlalchemy.orm import Session
 from memoria.core.git_for_data import GitForData
 from memoria.core.memory.models.memory import MemoryRecord as M
 from matrixone.sqlalchemy_ext.snapshot import select as mo_select, compile_select
-from memoria.api.database import get_db_session
-from memoria.api.dependencies import get_current_user_id
+from memoria.api.dependencies import AuthContext, get_auth_context
 from memoria.api.models import SnapshotRegistry
 from memoria.config import get_settings
 
@@ -61,10 +60,11 @@ class SnapshotResponse(BaseModel):
 )
 def create_snapshot(
     req: CreateSnapshotRequest,
-    user_id: str = Depends(get_current_user_id),
-    db: Session = Depends(get_db_session),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     settings = get_settings()
+    user_id = auth.user_id
+    db = auth.db_factory()
 
     # Check limit via registry table
     count = db.query(SnapshotRegistry).filter_by(user_id=user_id).count()
@@ -100,6 +100,7 @@ def create_snapshot(
     db.add(reg)
     db.commit()
 
+    db.close()
     return SnapshotResponse(
         name=req.name,
         snapshot_name=snap_name,
@@ -110,30 +111,34 @@ def create_snapshot(
 
 @router.get("/snapshots", response_model=list[SnapshotResponse])
 def list_snapshots(
-    user_id: str = Depends(get_current_user_id),
-    db: Session = Depends(get_db_session),
+    auth: AuthContext = Depends(get_auth_context),
 ):
-    rows = (
-        db.query(
-            SnapshotRegistry.display_name,
-            SnapshotRegistry.snapshot_name,
-            SnapshotRegistry.description,
-            SnapshotRegistry.created_at,
+    user_id = auth.user_id
+    db = auth.db_factory()
+    try:
+        rows = (
+            db.query(
+                SnapshotRegistry.display_name,
+                SnapshotRegistry.snapshot_name,
+                SnapshotRegistry.description,
+                SnapshotRegistry.created_at,
+            )
+            .filter_by(user_id=user_id)
+            .order_by(SnapshotRegistry.created_at.desc())
+            .limit(200)
+            .all()
         )
-        .filter_by(user_id=user_id)
-        .order_by(SnapshotRegistry.created_at.desc())
-        .limit(200)
-        .all()
-    )
-    return [
-        SnapshotResponse(
-            name=r.display_name,
-            snapshot_name=r.snapshot_name,
-            description=r.description,
-            timestamp=r.created_at.isoformat() if r.created_at else "",
-        )
-        for r in rows
-    ]
+        return [
+            SnapshotResponse(
+                name=r.display_name,
+                snapshot_name=r.snapshot_name,
+                description=r.description,
+                timestamp=r.created_at.isoformat() if r.created_at else "",
+            )
+            for r in rows
+        ]
+    finally:
+        db.close()
 
 
 @router.get("/snapshots/{name}")
@@ -142,228 +147,248 @@ def get_snapshot(
     limit: int = 50,
     offset: int = 0,
     detail: str = "brief",
-    user_id: str = Depends(get_current_user_id),
-    db: Session = Depends(get_db_session),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """Read snapshot — query memories at snapshot point via time-travel.
 
     detail: brief (type + truncated content), normal (full content), full (+ confidence).
     """
-    snap_name = _snap_name(user_id, name)
-    reg = (
-        db.query(SnapshotRegistry.display_name, SnapshotRegistry.description)
-        .filter_by(snapshot_name=snap_name, user_id=user_id)
-        .first()
-    )
-    if reg is None:
-        raise HTTPException(status_code=404, detail="Snapshot not found")
-
-    display_name = reg.display_name
-    description = reg.description
-
-    git = _git(lambda: db)
-    all_snaps = git.list_snapshots()
-    snap_info = next((s for s in all_snaps if s["snapshot_name"] == snap_name), None)
-    if snap_info is None:
-        raise HTTPException(status_code=404, detail="Snapshot not found in database")
-
-    ts = snap_info["timestamp"]
-
-    if limit > 500:
-        limit = 500
-
-    _active = M.is_active > 0
-    _user = M.user_id == user_id
-
-    # Total count
-    total = (
-        _exec_snap(
-            db,
-            mo_select(func.count(M.memory_id))
-            .where(_user, _active)
-            .with_snapshot(snap_name),
-        ).scalar()
-        or 0
-    )
-
-    # Type distribution
-    type_dist = _exec_snap(
-        db,
-        mo_select(M.memory_type, func.count())
-        .where(_user, _active)
-        .group_by(M.memory_type)
-        .with_snapshot(snap_name),
-    ).fetchall()
-
-    # Paginated memories
-    if detail == "full":
-        cols = (M.memory_id, M.content, M.memory_type, M.initial_confidence)
-    else:
-        cols = (M.memory_id, M.content, M.memory_type)
-    rows = _exec_snap(
-        db,
-        mo_select(*cols)
-        .where(_user, _active)
-        .order_by(M.observed_at.desc())
-        .limit(limit)
-        .offset(offset)
-        .with_snapshot(snap_name),
-    ).fetchall()
-
-    content_limit = 80 if detail == "brief" else (200 if detail == "normal" else 2000)
-    memories = []
-    for r in rows:
-        m: dict = {"memory_id": r[0], "memory_type": r[2]}
-        content = r[1] or ""
-        m["content"] = (
-            (content[:content_limit] + " [truncated]")
-            if len(content) > content_limit
-            else content
+    user_id = auth.user_id
+    db = auth.db_factory()
+    try:
+        snap_name = _snap_name(user_id, name)
+        reg = (
+            db.query(SnapshotRegistry.display_name, SnapshotRegistry.description)
+            .filter_by(snapshot_name=snap_name, user_id=user_id)
+            .first()
         )
-        if detail == "full":
-            m["confidence"] = r[3]
-        memories.append(m)
+        if reg is None:
+            raise HTTPException(status_code=404, detail="Snapshot not found")
 
-    return {
-        "name": display_name,
-        "snapshot_name": snap_name,
-        "description": description,
-        "timestamp": str(ts),
-        "memory_count": total,
-        "by_type": {str(r[0]): r[1] for r in type_dist},
-        "memories": memories,
-        "limit": limit,
-        "offset": offset,
-        "has_more": offset + limit < total,
-    }
+        display_name = reg.display_name
+        description = reg.description
+
+        git = _git(lambda: db)
+        all_snaps = git.list_snapshots()
+        snap_info = next(
+            (s for s in all_snaps if s["snapshot_name"] == snap_name), None
+        )
+        if snap_info is None:
+            raise HTTPException(
+                status_code=404, detail="Snapshot not found in database"
+            )
+
+        ts = snap_info["timestamp"]
+
+        if limit > 500:
+            limit = 500
+
+        _active = M.is_active > 0
+        _user = M.user_id == user_id
+
+        # Total count
+        total = (
+            _exec_snap(
+                db,
+                mo_select(func.count(M.memory_id))
+                .where(_user, _active)
+                .with_snapshot(snap_name),
+            ).scalar()
+            or 0
+        )
+
+        # Type distribution
+        type_dist = _exec_snap(
+            db,
+            mo_select(M.memory_type, func.count())
+            .where(_user, _active)
+            .group_by(M.memory_type)
+            .with_snapshot(snap_name),
+        ).fetchall()
+
+        # Paginated memories
+        if detail == "full":
+            cols = (M.memory_id, M.content, M.memory_type, M.initial_confidence)
+        else:
+            cols = (M.memory_id, M.content, M.memory_type)
+        rows = _exec_snap(
+            db,
+            mo_select(*cols)
+            .where(_user, _active)
+            .order_by(M.observed_at.desc())
+            .limit(limit)
+            .offset(offset)
+            .with_snapshot(snap_name),
+        ).fetchall()
+
+        content_limit = (
+            80 if detail == "brief" else (200 if detail == "normal" else 2000)
+        )
+        memories = []
+        for r in rows:
+            m: dict = {"memory_id": r[0], "memory_type": r[2]}
+            content = r[1] or ""
+            m["content"] = (
+                (content[:content_limit] + " [truncated]")
+                if len(content) > content_limit
+                else content
+            )
+            if detail == "full":
+                m["confidence"] = r[3]
+            memories.append(m)
+
+        return {
+            "name": display_name,
+            "snapshot_name": snap_name,
+            "description": description,
+            "timestamp": str(ts),
+            "memory_count": total,
+            "by_type": {str(r[0]): r[1] for r in type_dist},
+            "memories": memories,
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + limit < total,
+        }
+    finally:
+        db.close()
 
 
 @router.delete("/snapshots/{name}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_snapshot(
     name: str,
-    user_id: str = Depends(get_current_user_id),
-    db: Session = Depends(get_db_session),
+    auth: AuthContext = Depends(get_auth_context),
 ):
-    snap_name = _snap_name(user_id, name)
-    from sqlalchemy.orm import load_only
+    user_id = auth.user_id
+    db = auth.db_factory()
+    try:
+        snap_name = _snap_name(user_id, name)
+        from sqlalchemy.orm import load_only
 
-    reg = (
-        db.query(SnapshotRegistry)
-        .options(load_only(SnapshotRegistry.snapshot_name))
-        .filter_by(snapshot_name=snap_name, user_id=user_id)
-        .first()
-    )
-    if reg is None:
-        raise HTTPException(status_code=404, detail="Snapshot not found")
+        reg = (
+            db.query(SnapshotRegistry)
+            .options(load_only(SnapshotRegistry.snapshot_name))
+            .filter_by(snapshot_name=snap_name, user_id=user_id)
+            .first()
+        )
+        if reg is None:
+            raise HTTPException(status_code=404, detail="Snapshot not found")
 
-    # Drop MatrixOne native snapshot (DDL-like, needs clean transaction state)
-    db.commit()
-    db.execute(text(f"DROP SNAPSHOT {snap_name}"))
-    # Remove registry entry
-    db.delete(reg)
-    db.commit()
+        # Drop MatrixOne native snapshot (DDL-like, needs clean transaction state)
+        db.commit()
+        db.execute(text(f"DROP SNAPSHOT {snap_name}"))
+        # Remove registry entry
+        db.delete(reg)
+        db.commit()
+    finally:
+        db.close()
 
 
 @router.get("/snapshots/{name}/diff")
 def diff_snapshot(
     name: str,
     limit: int = 50,
-    user_id: str = Depends(get_current_user_id),
-    db: Session = Depends(get_db_session),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """Compare snapshot memories vs current state. Diff computed in DB, not Python."""
-    snap_name = _snap_name(user_id, name)
-    if (
-        not db.query(SnapshotRegistry.snapshot_name)
-        .filter_by(snapshot_name=snap_name, user_id=user_id)
-        .first()
-    ):
-        raise HTTPException(status_code=404, detail="Snapshot not found")
+    user_id = auth.user_id
+    db = auth.db_factory()
+    try:
+        snap_name = _snap_name(user_id, name)
+        if (
+            not db.query(SnapshotRegistry.snapshot_name)
+            .filter_by(snapshot_name=snap_name, user_id=user_id)
+            .first()
+        ):
+            raise HTTPException(status_code=404, detail="Snapshot not found")
 
-    if limit > 200:
-        limit = 200
+        if limit > 200:
+            limit = 200
 
-    _active = M.is_active > 0
-    _user = M.user_id == user_id
+        _active = M.is_active > 0
+        _user = M.user_id == user_id
 
-    # Counts — single-table, use SDK
-    snap_count = (
-        _exec_snap(
-            db,
-            mo_select(func.count(M.memory_id))
-            .where(_user, _active)
-            .with_snapshot(snap_name),
-        ).scalar()
-        or 0
-    )
+        # Counts — single-table, use SDK
+        snap_count = (
+            _exec_snap(
+                db,
+                mo_select(func.count(M.memory_id))
+                .where(_user, _active)
+                .with_snapshot(snap_name),
+            ).scalar()
+            or 0
+        )
 
-    curr_count = db.query(func.count(M.memory_id)).filter(_user, _active).scalar() or 0
+        curr_count = (
+            db.query(func.count(M.memory_id)).filter(_user, _active).scalar() or 0
+        )
 
-    # LEFT JOIN diff — MatrixOne-specific cross-snapshot join, must stay raw SQL
-    added_rows = db.execute(
-        text(
-            "SELECT c.memory_id, c.content, c.memory_type FROM mem_memories c"
-            f" LEFT JOIN mem_memories {{SNAPSHOT = '{snap_name}'}} s"
-            " ON c.memory_id = s.memory_id AND s.is_active"
-            " WHERE c.user_id = :uid AND c.is_active AND s.memory_id IS NULL"
-            " LIMIT :lim"
-        ),
-        {"uid": user_id, "lim": limit},
-    ).fetchall()
-
-    removed_rows = db.execute(
-        text(
-            f"SELECT s.memory_id, s.content, s.memory_type FROM mem_memories {{SNAPSHOT = '{snap_name}'}} s"
-            " LEFT JOIN mem_memories c"
-            " ON s.memory_id = c.memory_id AND c.is_active"
-            " WHERE s.user_id = :uid AND s.is_active AND c.memory_id IS NULL"
-            " LIMIT :lim"
-        ),
-        {"uid": user_id, "lim": limit},
-    ).fetchall()
-
-    added_count = (
-        db.execute(
+        # LEFT JOIN diff — MatrixOne-specific cross-snapshot join, must stay raw SQL
+        added_rows = db.execute(
             text(
-                "SELECT COUNT(*) FROM mem_memories c"
+                "SELECT c.memory_id, c.content, c.memory_type FROM mem_memories c"
                 f" LEFT JOIN mem_memories {{SNAPSHOT = '{snap_name}'}} s"
                 " ON c.memory_id = s.memory_id AND s.is_active"
                 " WHERE c.user_id = :uid AND c.is_active AND s.memory_id IS NULL"
+                " LIMIT :lim"
             ),
-            {"uid": user_id},
-        ).scalar()
-        or 0
-    )
+            {"uid": user_id, "lim": limit},
+        ).fetchall()
 
-    removed_count = (
-        db.execute(
+        removed_rows = db.execute(
             text(
-                f"SELECT COUNT(*) FROM mem_memories {{SNAPSHOT = '{snap_name}'}} s"
+                f"SELECT s.memory_id, s.content, s.memory_type FROM mem_memories {{SNAPSHOT = '{snap_name}'}} s"
                 " LEFT JOIN mem_memories c"
                 " ON s.memory_id = c.memory_id AND c.is_active"
                 " WHERE s.user_id = :uid AND s.is_active AND c.memory_id IS NULL"
+                " LIMIT :lim"
             ),
-            {"uid": user_id},
-        ).scalar()
-        or 0
-    )
+            {"uid": user_id, "lim": limit},
+        ).fetchall()
 
-    added = [
-        {"memory_id": r[0], "content": (r[1] or "")[:200], "memory_type": r[2]}
-        for r in added_rows
-    ]
-    removed = [
-        {"memory_id": r[0], "content": (r[1] or "")[:200], "memory_type": r[2]}
-        for r in removed_rows
-    ]
+        added_count = (
+            db.execute(
+                text(
+                    "SELECT COUNT(*) FROM mem_memories c"
+                    f" LEFT JOIN mem_memories {{SNAPSHOT = '{snap_name}'}} s"
+                    " ON c.memory_id = s.memory_id AND s.is_active"
+                    " WHERE c.user_id = :uid AND c.is_active AND s.memory_id IS NULL"
+                ),
+                {"uid": user_id},
+            ).scalar()
+            or 0
+        )
 
-    return {
-        "snapshot_name": name,
-        "snapshot_count": snap_count,
-        "current_count": curr_count,
-        "added": added,
-        "removed": removed,
-        "added_count": added_count,
-        "removed_count": removed_count,
-        "unchanged_count": snap_count - removed_count,
-    }
+        removed_count = (
+            db.execute(
+                text(
+                    f"SELECT COUNT(*) FROM mem_memories {{SNAPSHOT = '{snap_name}'}} s"
+                    " LEFT JOIN mem_memories c"
+                    " ON s.memory_id = c.memory_id AND c.is_active"
+                    " WHERE s.user_id = :uid AND s.is_active AND c.memory_id IS NULL"
+                ),
+                {"uid": user_id},
+            ).scalar()
+            or 0
+        )
+
+        added = [
+            {"memory_id": r[0], "content": (r[1] or "")[:200], "memory_type": r[2]}
+            for r in added_rows
+        ]
+        removed = [
+            {"memory_id": r[0], "content": (r[1] or "")[:200], "memory_type": r[2]}
+            for r in removed_rows
+        ]
+
+        return {
+            "snapshot_name": name,
+            "snapshot_count": snap_count,
+            "current_count": curr_count,
+            "added": added,
+            "removed": removed,
+            "added_count": added_count,
+            "removed_count": removed_count,
+            "unchanged_count": snap_count - removed_count,
+        }
+    finally:
+        db.close()

--- a/memoria/api/routers/user_ops.py
+++ b/memoria/api/routers/user_ops.py
@@ -10,8 +10,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 
-from memoria.api.database import get_db_factory
-from memoria.api.dependencies import get_current_user_id
+from memoria.api.dependencies import AuthContext, get_auth_context
 from memoria.core.memory.types import enum_value
 
 router = APIRouter(tags=["memory"])
@@ -84,10 +83,11 @@ def _with_cache(user_id: str, op: str, fn, force: bool, db_factory) -> dict:
 @router.post("/consolidate")
 def consolidate(
     force: bool = False,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """Detect contradictions, fix orphaned nodes. 30min cooldown."""
+    user_id = auth.user_id
+    db_factory = auth.db_factory
 
     def _run():
         from memoria.core.memory.factory import create_memory_service
@@ -102,10 +102,11 @@ def consolidate(
 @router.post("/reflect")
 def reflect(
     force: bool = False,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """Analyze memory clusters, synthesize insights. 2h cooldown. Requires LLM."""
+    user_id = auth.user_id
+    db_factory = auth.db_factory
 
     def _run():
         try:
@@ -131,10 +132,11 @@ def reflect(
 @router.post("/extract-entities")
 def extract_entities(
     force: bool = False,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """LLM entity extraction for unlinked memories. Manual trigger only. 1h cooldown."""
+    user_id = auth.user_id
+    db_factory = auth.db_factory
 
     def _run():
         try:
@@ -157,10 +159,11 @@ def extract_entities(
 
 @router.post("/reflect/candidates")
 def reflect_candidates(
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """Return raw reflection candidates for user-LLM synthesis (no internal LLM needed)."""
+    user_id = auth.user_id
+    db_factory = auth.db_factory
     from memoria.core.memory.graph.candidates import GraphCandidateProvider
 
     provider = GraphCandidateProvider(db_factory)
@@ -186,10 +189,11 @@ def reflect_candidates(
 
 @router.post("/extract-entities/candidates")
 def entity_candidates(
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """Return unlinked memories for user-LLM entity extraction."""
+    user_id = auth.user_id
+    db_factory = auth.db_factory
     from memoria.core.memory.graph.graph_store import GraphStore
     from memoria.core.memory.graph.types import EdgeType, NodeType
 
@@ -233,10 +237,11 @@ class LinkEntitiesRequest(BaseModel):
 
 @router.get("/entities")
 def list_entities(
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """List all entity nodes for the current user."""
+    user_id = auth.user_id
+    db_factory = auth.db_factory
     from memoria.core.memory.graph.graph_store import GraphStore
     from memoria.core.memory.graph.types import NodeType
 
@@ -260,10 +265,11 @@ def list_entities(
 @router.post("/extract-entities/link")
 def link_entities(
     req: LinkEntitiesRequest,
-    user_id: str = Depends(get_current_user_id),
-    db_factory=Depends(get_db_factory),
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """Write entity nodes + edges from user-LLM extraction results."""
+    user_id = auth.user_id
+    db_factory = auth.db_factory
     from memoria.core.memory.graph.graph_store import GraphStore
     from memoria.core.memory.graph.types import GraphNodeData
 

--- a/memoria/cli.py
+++ b/memoria/cli.py
@@ -51,7 +51,12 @@ def _claude_rule() -> str:
 
 
 def _mcp_entry(
-    db_url: str | None, api_url: str | None, token: str | None, user: str, **embed: str
+    db_url: str | None,
+    api_url: str | None,
+    token: str | None,
+    user: str,
+    apikey: str | None = None,
+    **embed: str,
 ) -> dict[str, Any]:
     import shutil
 
@@ -59,7 +64,9 @@ def _mcp_entry(
     cmd = shutil.which("memoria-mcp") or "memoria-mcp"
     if api_url:
         args = ["--api-url", api_url]
-        if token:
+        if apikey:
+            args += ["--apikey", apikey]
+        elif token:
             args += ["--token", token]
         if user != "default":
             args += ["--user", user]
@@ -183,6 +190,10 @@ def _configure_claude(project_dir: Path, entry: dict, force: bool) -> list[str]:
 
 
 def cmd_init(args: argparse.Namespace) -> None:
+    if args.token and args.apikey:
+        print("Error: --token and --apikey are mutually exclusive.")
+        return
+
     project_dir = Path(args.dir).resolve()
     tools = args.tool or _detect(project_dir)
     if not tools:
@@ -201,7 +212,14 @@ def cmd_init(args: argparse.Namespace) -> None:
     if args.embedding_base_url:
         embed_env["EMBEDDING_BASE_URL"] = args.embedding_base_url
 
-    entry = _mcp_entry(args.db_url, args.api_url, args.token, args.user, **embed_env)
+    entry = _mcp_entry(
+        args.db_url,
+        args.api_url,
+        args.token,
+        args.user,
+        apikey=args.apikey,
+        **embed_env,
+    )
 
     writers = {
         "kiro": _configure_kiro,
@@ -430,7 +448,11 @@ def main() -> None:
     )
     p.add_argument("--db-url", help="Database URL for embedded mode")
     p.add_argument("--api-url", help="Memoria REST API URL for remote mode")
-    p.add_argument("--token", help="API token for remote mode")
+    p.add_argument("--token", help="API token for remote mode (Authorization: Bearer)")
+    p.add_argument(
+        "--apikey",
+        help="API key for remote mode (X-API-Key header, mutually exclusive with --token)",
+    )
     p.add_argument("--user", default="default", help="Default user ID")
     p.add_argument(
         "--force", action="store_true", help="Overwrite customized rule files"

--- a/memoria/config.py
+++ b/memoria/config.py
@@ -74,6 +74,17 @@ class MemoriaSettings(BaseSettings):
     llm_base_url: str | None = None
     llm_model: str = "gpt-4o-mini"
 
+    # Remote auth service (apikey mode)
+    remote_auth_service_url: str = Field(
+        default="",
+        description="Base URL of the remote auth service for apikey mode. "
+        "When set, API accepts X-API-Key header and resolves per-user DB connections.",
+    )
+    conn_cache_ttl: int = Field(
+        default=60,
+        description="TTL in seconds for caching remote auth service responses. 0 = no cache.",
+    )
+
     # Limits
     snapshot_limit: int = Field(default=100, description="Max snapshots per user")
 

--- a/memoria/mcp_local/server.py
+++ b/memoria/mcp_local/server.py
@@ -1586,10 +1586,16 @@ class EmbeddedBackend(MemoryBackend):
 class HTTPBackend(MemoryBackend):
     """Proxy to memory service REST API — for remote mode."""
 
-    def __init__(self, api_url: str, token: str | None = None) -> None:
+    def __init__(
+        self, api_url: str, token: str | None = None, apikey: str | None = None
+    ) -> None:
         import httpx
 
-        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        headers: dict[str, str] = {}
+        if apikey:
+            headers["X-API-Key"] = apikey
+        elif token:
+            headers["Authorization"] = f"Bearer {token}"
         self._client = httpx.Client(
             base_url=api_url.rstrip("/"), headers=headers, timeout=30
         )
@@ -2770,6 +2776,10 @@ def main():
         "--db-url", help="Database URL for embedded mode (or set MEMORIA_DB_URL)"
     )
     parser.add_argument("--token", help="Auth token for remote mode")
+    parser.add_argument(
+        "--apikey",
+        help="API key for remote mode (uses X-API-Key header instead of Authorization)",
+    )
     parser.add_argument("--user", default="default", help="Default user ID")
     parser.add_argument("--transport", choices=["stdio", "sse"], default="stdio")
     args = parser.parse_args()
@@ -2780,8 +2790,17 @@ def main():
     logging.root.handlers = [_stderr_handler]
     logging.root.setLevel(logging.WARNING)
 
+    if args.token and args.apikey:
+        print("Error: --token and --apikey are mutually exclusive", file=sys.stderr)
+        sys.exit(1)
+
     if args.api_url:
-        backend: MemoryBackend = HTTPBackend(args.api_url, token=args.token)
+        if args.apikey:
+            backend: MemoryBackend = HTTPBackend(
+                args.api_url, token=None, apikey=args.apikey
+            )
+        else:
+            backend = HTTPBackend(args.api_url, token=args.token)
     else:
         # Priority: --db-url > MEMORIA_DB_URL > config碎变量 (MEMORIA_DB_HOST etc) > DEFAULT_DB_URL
         db_url = args.db_url or os.environ.get("MEMORIA_DB_URL")

--- a/tests/unit/test_activation_regressions.py
+++ b/tests/unit/test_activation_regressions.py
@@ -471,10 +471,12 @@ class TestRetrieveEndpointEmbedding:
             mock_embed.return_value.embed.return_value = [0.1] * 384
             mock_svc.return_value.retrieve.return_value = ([], None)
 
+            from memoria.api.dependencies import AuthContext
             from memoria.api.routers.memory import retrieve_memories, RetrieveRequest
 
             req = RetrieveRequest(query="test query")
-            retrieve_memories(req, user_id="u1", db_factory=MagicMock())
+            auth = AuthContext(user_id="u1", db_factory=MagicMock())
+            retrieve_memories(req, auth=auth)
 
             mock_embed.return_value.embed.assert_called_once_with("test query")
             call_kwargs = mock_svc.return_value.retrieve.call_args
@@ -488,12 +490,14 @@ class TestRetrieveEndpointEmbedding:
             mock_embed.return_value.embed.side_effect = RuntimeError("embed failed")
             mock_svc.return_value.retrieve.return_value = ([], None)
 
+            from memoria.api.dependencies import AuthContext
             from memoria.api.routers.memory import retrieve_memories, RetrieveRequest
 
             req = RetrieveRequest(query="test")
+            auth = AuthContext(user_id="u1", db_factory=MagicMock())
 
             with caplog.at_level(logging.WARNING):
-                retrieve_memories(req, user_id="u1", db_factory=MagicMock())
+                retrieve_memories(req, auth=auth)
 
             assert "failed to embed query" in caplog.text
             call_kwargs = mock_svc.return_value.retrieve.call_args

--- a/tests/unit/test_apikey_auth.py
+++ b/tests/unit/test_apikey_auth.py
@@ -1,0 +1,351 @@
+"""Tests for apikey authentication mode.
+
+Covers: RemoteAuthService, AuthContext dispatch, _resolve_apikey error handling,
+and HTTPBackend header selection.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from memoria.api.remote_auth_service import ConnInfo, RemoteAuthService
+
+
+# ── ConnInfo ──────────────────────────────────────────────────────────
+
+
+class TestConnInfo:
+    def test_db_url_format(self):
+        info = ConnInfo(
+            user_id="alice",
+            db_host="db.example.com",
+            db_port=6001,
+            db_user="alice",
+            db_password="secret",
+            db_name="memoria_alice",
+        )
+        assert info.db_url == (
+            "mysql+pymysql://alice:secret@db.example.com:6001/memoria_alice"
+            "?charset=utf8mb4"
+        )
+
+    def test_db_url_encodes_special_chars(self):
+        """Real-world case: user contains ':', password contains '@'."""
+        info = ConnInfo(
+            user_id="2",
+            db_host="127.0.0.1",
+            db_port=6001,
+            db_user="local-moi-account:moi_root",
+            db_password="bg9jywwt@moi",
+            db_name="memoria",
+        )
+        # ':' and '@' must be percent-encoded so pymysql parses correctly
+        assert "local-moi-account%3Amoi_root" in info.db_url
+        assert "bg9jywwt%40moi" in info.db_url
+        assert info.db_url.startswith("mysql+pymysql://")
+        assert "@127.0.0.1:6001/memoria" in info.db_url
+
+    def test_frozen(self):
+        info = ConnInfo("u", "h", 1, "u", "p", "d")
+        with pytest.raises(AttributeError):
+            info.user_id = "other"  # type: ignore[misc]
+
+
+# ── RemoteAuthService ─────────────────────────────────────────────────
+
+
+class _MockTransport(httpx.BaseTransport):
+    """Canned responses for remote auth service."""
+
+    def __init__(self, status: int = 200, body: dict | None = None):
+        self._status = status
+        self._body = body or {}
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(self._status, json=self._body, request=request)
+
+
+class TestRemoteAuthResolve:
+    _VALID_RESP = {
+        "user_id": "alice",
+        "db_host": "localhost",
+        "db_port": 6001,
+        "db_user": "alice",
+        "db_password": "pw",
+        "db_name": "mem_alice",
+    }
+
+    def _make_service(self, status: int = 200, body: dict | None = None, ttl: int = 60):
+        svc = RemoteAuthService("http://auth.test", cache_ttl=ttl)
+        svc._client = httpx.Client(
+            base_url="http://auth.test",
+            transport=_MockTransport(status, body or self._VALID_RESP),
+        )
+        return svc
+
+    def test_resolve_success(self):
+        svc = self._make_service()
+        info = svc.resolve("sk-test-key-12345")
+        assert info.user_id == "alice"
+        assert info.db_name == "mem_alice"
+
+    def test_resolve_401_raises_permission_error(self):
+        svc = self._make_service(status=401, body={"detail": "bad key"})
+        with pytest.raises(PermissionError, match="Invalid or expired"):
+            svc.resolve("sk-bad-key-000000")
+
+    def test_resolve_500_raises_http_error(self):
+        svc = self._make_service(status=500, body={"detail": "internal"})
+        with pytest.raises(httpx.HTTPStatusError):
+            svc.resolve("sk-test-key-12345")
+
+    def test_cache_hit_avoids_http_call(self):
+        svc = self._make_service(ttl=300)
+        info1 = svc.resolve("sk-test-key-12345")
+        # Replace transport with one that always 500s
+        svc._client = httpx.Client(
+            base_url="http://auth.test",
+            transport=_MockTransport(500),
+        )
+        info2 = svc.resolve("sk-test-key-12345")
+        assert info1 == info2  # served from cache
+
+    def test_cache_disabled_when_ttl_zero(self):
+        svc = self._make_service(ttl=0)
+        svc.resolve("sk-test-key-12345")
+        assert len(svc._cache) == 0
+
+
+# ── AuthContext dispatch ──────────────────────────────────────────────
+
+
+class TestAuthContextDispatch:
+    """get_auth_context dispatches to token or apikey path based on headers."""
+
+    def test_apikey_header_triggers_apikey_path(self):
+        from memoria.api.dependencies import get_auth_context
+
+        mock_request = MagicMock()
+        mock_request.headers = {"X-API-Key": "sk-test-123"}
+
+        with patch("memoria.api.dependencies._resolve_apikey") as mock_resolve:
+            from memoria.api.dependencies import AuthContext
+
+            mock_resolve.return_value = AuthContext(
+                user_id="alice", db_factory=MagicMock()
+            )
+            result = get_auth_context(
+                request=mock_request, credentials=None, db=MagicMock()
+            )
+            mock_resolve.assert_called_once_with("sk-test-123")
+            assert result.user_id == "alice"
+
+    def test_no_apikey_no_bearer_raises_401(self):
+        from fastapi import HTTPException
+
+        from memoria.api.dependencies import get_auth_context
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_auth_context(request=mock_request, credentials=None, db=MagicMock())
+        assert exc_info.value.status_code == 401
+
+    def test_resolve_apikey_no_service_url_returns_501(self):
+        from fastapi import HTTPException
+
+        from memoria.api.dependencies import _resolve_apikey
+
+        with patch("memoria.api.dependencies.get_settings") as mock_settings:
+            mock_settings.return_value.remote_auth_service_url = ""
+            with pytest.raises(HTTPException) as exc_info:
+                _resolve_apikey("sk-test")
+            assert exc_info.value.status_code == 501
+
+    def test_resolve_apikey_remote_error_returns_502(self):
+        """Non-auth errors from remote service should become 502, not 500."""
+        from fastapi import HTTPException
+
+        from memoria.api.dependencies import _resolve_apikey
+
+        with (
+            patch("memoria.api.dependencies.get_settings") as mock_settings,
+            patch("memoria.api.dependencies._get_remote_auth") as mock_auth,
+        ):
+            mock_settings.return_value.remote_auth_service_url = "http://auth.test"
+            mock_auth.return_value.resolve.side_effect = httpx.ConnectError("refused")
+            with pytest.raises(HTTPException) as exc_info:
+                _resolve_apikey("sk-test")
+            assert exc_info.value.status_code == 502
+
+
+# ── HTTPBackend header selection ──────────────────────────────────────
+
+
+class TestHTTPBackendHeaders:
+    """HTTPBackend uses correct header based on token vs apikey."""
+
+    def test_token_uses_authorization_header(self):
+        from memoria.mcp_local.server import HTTPBackend
+
+        backend = HTTPBackend("http://api.test", token="tok-123")
+        auth_header = backend._client.headers.get("authorization")
+        assert auth_header == "Bearer tok-123"
+        assert "x-api-key" not in backend._client.headers
+
+    def test_apikey_uses_x_api_key_header(self):
+        from memoria.mcp_local.server import HTTPBackend
+
+        backend = HTTPBackend("http://api.test", apikey="sk-key-456")
+        assert backend._client.headers.get("x-api-key") == "sk-key-456"
+        assert "authorization" not in backend._client.headers
+
+    def test_no_auth_no_headers(self):
+        from memoria.mcp_local.server import HTTPBackend
+
+        backend = HTTPBackend("http://api.test")
+        assert "authorization" not in backend._client.headers
+        assert "x-api-key" not in backend._client.headers
+
+
+# ── Per-user engine: db_name validation ───────────────────────────────
+
+
+class TestUserEngineDbNameValidation:
+    """_get_user_engine rejects SQL-injection-style db_names but allows hyphens."""
+
+    def test_rejects_semicolon_in_db_name(self):
+        from memoria.api.database import _get_user_engine
+
+        with pytest.raises(ValueError, match="Invalid database name"):
+            _get_user_engine("h", 6001, "u", "p", "mem; DROP TABLE x")
+
+    def test_rejects_space_in_db_name(self):
+        from memoria.api.database import _get_user_engine
+
+        with pytest.raises(ValueError, match="Invalid database name"):
+            _get_user_engine("h", 6001, "u", "p", "mem alice")
+
+    def test_allows_hyphens_in_db_name(self):
+        """Real-world: remote auth returns db_name like 'memoria-user-2'."""
+        from memoria.api.database import _get_user_engine
+
+        with patch("matrixone.Client") as mock_client:
+            mock_engine = MagicMock()
+            mock_client.return_value._engine = mock_engine
+            engine = _get_user_engine("h", 6001, "u", "p", "memoria-user-2")
+            assert engine is mock_engine
+        _get_user_engine.cache_clear()
+
+    def test_allows_underscores_and_digits(self):
+        from memoria.api.database import _get_user_engine
+
+        with patch("matrixone.Client") as mock_client:
+            mock_client.return_value._engine = MagicMock()
+            _get_user_engine("h", 6001, "u", "p", "memoria_user_42")
+        _get_user_engine.cache_clear()
+
+
+# ── Per-user table init runs only once ────────────────────────────────
+
+
+class TestUserSessionFactoryInitOnce:
+    """get_user_session_factory calls _ensure_user_tables only on first call per db_name."""
+
+    def test_tables_initialized_once_per_db(self):
+        from memoria.api.database import (
+            get_user_session_factory,
+            _user_db_initialized,
+        )
+
+        # Clean up state from other tests
+        _user_db_initialized.discard("test_once_db")
+
+        with (
+            patch("memoria.api.database._get_user_engine") as mock_engine,
+            patch("memoria.api.database._ensure_user_tables") as mock_init,
+        ):
+            mock_engine.return_value = MagicMock()
+
+            get_user_session_factory("h", 1, "u", "p", "test_once_db")
+            get_user_session_factory("h", 1, "u", "p", "test_once_db")
+
+            # _ensure_user_tables called exactly once despite two factory calls
+            mock_init.assert_called_once()
+
+        # Clean up
+        _user_db_initialized.discard("test_once_db")
+
+
+# ── Middleware: X-API-Key extraction for rate limiting ─────────────────
+
+
+class TestMiddlewareApikeyExtraction:
+    """RateLimitMiddleware correctly reads X-API-Key header for key identification."""
+
+    def test_x_api_key_used_as_rate_limit_identity(self):
+        """Middleware uses first 12 chars of X-API-Key as rate-limit identity."""
+        apikey = "sk-abcdef1234567890"
+        expected_key_id = apikey[:12]
+        assert expected_key_id == "sk-abcdef123"
+        assert len(expected_key_id) == 12
+
+
+# ── CLI: --token and --apikey mutual exclusivity ──────────────────────
+
+
+class TestCLIArgParsing:
+    """main() rejects --token + --apikey together, creates correct backend."""
+
+    def test_token_and_apikey_mutually_exclusive(self):
+        """Passing both --token and --apikey should exit with error."""
+        from unittest.mock import patch as _patch
+
+        with _patch(
+            "sys.argv",
+            ["memoria-mcp", "--api-url", "http://x", "--token", "t", "--apikey", "k"],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                from memoria.mcp_local.server import main
+
+                main()
+            assert exc_info.value.code == 1
+
+    def test_apikey_creates_httpbackend_with_x_api_key(self):
+        """--apikey flag should produce HTTPBackend with X-API-Key header."""
+        from memoria.mcp_local.server import HTTPBackend
+
+        backend = HTTPBackend("http://api.test", token=None, apikey="sk-my-key")
+        assert backend._client.headers.get("x-api-key") == "sk-my-key"
+        assert "authorization" not in backend._client.headers
+
+
+# ── Config: remote_auth_service_url setting ───────────────────────────
+
+
+class TestConfigRemoteAuth:
+    """MemoriaSettings exposes remote_auth_service_url and conn_cache_ttl."""
+
+    def test_defaults(self):
+        # Disable .env file loading so we test true code defaults
+        from memoria.config import MemoriaSettings
+
+        s = MemoriaSettings(embedding_provider="mock", _env_file=None)
+        assert s.remote_auth_service_url == ""
+        assert s.conn_cache_ttl == 60
+
+    def test_env_override(self):
+        env = {
+            "MEMORIA_REMOTE_AUTH_SERVICE_URL": "http://auth.internal:8000",
+            "MEMORIA_CONN_CACHE_TTL": "120",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            from memoria.config import MemoriaSettings
+
+            s = MemoriaSettings(embedding_provider="mock")
+            assert s.remote_auth_service_url == "http://auth.internal:8000"
+            assert s.conn_cache_ttl == 120


### PR DESCRIPTION
## What type of PR is this?

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes # https://github.com/matrixorigin/matrixflow/issues/8580

## What this PR does / why we need it



新增 `--apikey` 认证模式，支持通过外部 Remote Auth Service 将 API Key 解析为独立的 per-user MatrixOne 数据库连接。

核心改动：
- `dependencies.py`：新增 `AuthContext` 统一认证上下文，通过 `X-API-Key` / `Authorization: Bearer` 头自动分发到 apikey 或 token 模式
- `remote_auth_service.py`：新增 Remote Auth Service 客户端，调用 `POST /apikey/connection` 解析 API Key，带 TTL 缓存
- `database.py`：新增 `get_user_session_factory()` per-user 引擎缓存（`lru_cache(128)`），首次连接自动建表
- `config.py`：新增 `remote_auth_service_url`、`conn_cache_ttl` 配置项
- `main.py`：apikey 模式下跳过自动 governance scheduler，仅支持按需触发
- `middleware.py`：Rate limiter 支持从 `X-API-Key` 头提取客户端标识
- `cli.py`：`memoria init --apikey` 生成对应 mcp.json 配置，与 `--token` 互斥
- `mcp_local/server.py`：MCP 入口新增 `--apikey` 参数
- 所有 router（memory / snapshots / user_ops）统一使用 `AuthContext` 依赖注入，token 模式完全不受影响

新增文件：`docs/apikey-mode.md`（使用文档）、`docs/design-apikey-mode.md`（架构设计文档）、`tests/unit/test_apikey_auth.py`（25 个测试用例）
