### PR TITLE
fix: remove hardcoded version in memoria-git dependency

### DIFF
--- a/memoria/crates/memoria-service/Cargo.toml
+++ b/memoria/crates/memoria-service/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 sqlx = { workspace = true, features = ["mysql", "runtime-tokio-native-tls"] }
-memoria-git = { version = "0.1.0", path = "../memoria-git" }
+memoria-git = { path = "../memoria-git" }
 
 [dev-dependencies]
 tokio = { workspace = true }


### PR DESCRIPTION
The hardcoded version = "0.1.0" in memoria-service's dependency on memoria-git causes cargo check to fail when bumping workspace version for release (e.g. 0.1.0-rc1). Path dependencies don't need version.

## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes #

## What this PR does / why we need it

remove hardcoded version in memoria-git dependency