### PR TITLE
feat: add installer script and improve release workflow

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -1,19 +1,29 @@
 name: Release Rust Binaries
 
+# Trigger: push a tag v*.*.* or v*.*.*-* (e.g. v0.1.0, v0.1.0-rc1), or run manually from Actions tab.
 on:
   push:
     tags:
       - 'v*.*.*'
+      - 'v*.*.*-*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.1.0-rc1); must already exist'
+        required: true
+        type: string
 
 jobs:
   test:
     name: Test gate
+    if: github.event_name != 'workflow_dispatch'
     uses: ./.github/workflows/test-gate.yml
     secrets: inherit
 
   build:
     name: Build ${{ matrix.target }}
-    needs: test
+    needs: [test]
+    if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -30,6 +40,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - uses: dtolnay/rust-toolchain@1.85.0
         with:
@@ -97,8 +109,9 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
           files: |
             artifacts/*.tar.gz
             artifacts/SHA256SUMS.txt
           generate_release_notes: true
-          prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}

--- a/README.md
+++ b/README.md
@@ -115,7 +115,15 @@ Don't want Docker? Use [MatrixOne Cloud](https://cloud.matrixorigin.cn) (free ti
 
 ### 2. Install Memoria
 
-Download from [GitHub Releases](https://github.com/matrixorigin/Memoria/releases):
+**Option A — Install script (detects OS/arch, verifies checksum):**
+
+```bash
+curl -sSL https://raw.githubusercontent.com/matrixorigin/Memoria/main/scripts/install.sh | bash
+# Or install a specific version:
+curl -sSL https://raw.githubusercontent.com/matrixorigin/Memoria/main/scripts/install.sh | bash -s -- -v v0.1.0-rc1
+```
+
+**Option B — Manual download** from [GitHub Releases](https://github.com/matrixorigin/Memoria/releases):
 
 ```bash
 # Linux (x86_64)

--- a/memoria/Cargo.lock
+++ b/memoria/Cargo.lock
@@ -1890,6 +1890,7 @@ dependencies = [
  "memoria-mcp",
  "memoria-service",
  "memoria-storage",
+ "openssl",
  "reqwest",
  "serde",
  "serde_json",
@@ -2303,6 +2304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,6 +2320,7 @@ checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/memoria/crates/memoria-cli/Cargo.toml
+++ b/memoria/crates/memoria-cli/Cargo.toml
@@ -30,3 +30,5 @@ tracing-subscriber = { workspace = true }
 tower-http = { workspace = true }
 sqlx = { workspace = true }
 reqwest = { version = "0.12", features = ["json", "blocking"] }
+# Vendored OpenSSL for cross-compilation (aarch64-linux has no system OpenSSL in CI)
+openssl = { version = "0.10", features = ["vendored"] }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Install memoria binary from GitHub releases.
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/matrixorigin/Memoria/main/scripts/install.sh | bash
+#   curl -sSL ... | bash -s -- -v v0.1.0-rc1
+#   MEMORIA_VERSION=v0.1.0-rc1 curl -sSL ... | bash
+#
+# Options:
+#   -v, --version TAG   Version to install (default: latest release)
+#   -d, --dir DIR       Install binary to DIR (default: /usr/local/bin or ~/.local/bin)
+#   -n, --dry-run       Print download URL and exit
+#
+# Env:
+#   MEMORIA_REPO        GitHub repo (default: matrixorigin/Memoria)
+#   MEMORIA_VERSION     Version tag (default: latest)
+
+set -e
+
+cat << "EOF"
+
+███╗   ███╗███████╗███╗   ███╗ ██████╗ ██████╗ ██╗ █████╗ 
+████╗ ████║██╔════╝████╗ ████║██╔═══██╗██╔══██╗██║██╔══██╗
+██╔████╔██║█████╗  ██╔████╔██║██║   ██║██████╔╝██║███████║
+██║╚██╔╝██║██╔══╝  ██║╚██╔╝██║██║   ██║██╔══██╗██║██╔══██║
+██║ ╚═╝ ██║███████╗██║ ╚═╝ ██║╚██████╔╝██║  ██║██║██║  ██║
+╚═╝     ╚═╝╚══════╝╚═╝     ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝╚═╝  ╚═╝
+            Memoria - Secure · Auditable · Programmable Memory
+EOF
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "error: curl is required" >&2
+  exit 1
+fi
+
+REPO="${MEMORIA_REPO:-matrixorigin/Memoria}"
+VERSION="${MEMORIA_VERSION:-}"
+INSTALL_DIR=""
+DRY_RUN=false
+
+# Map (os, arch) -> Rust target triple used in release artifacts
+get_target() {
+  local os arch
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  arch=$(uname -m)
+  case "$arch" in
+    x86_64|amd64) arch="x86_64" ;;
+    aarch64|arm64) arch="aarch64" ;;
+    *) arch="" ;;
+  esac
+  case "$os" in
+    linux)
+      [[ "$arch" == "x86_64" ]] && echo "x86_64-unknown-linux-gnu" && return
+      [[ "$arch" == "aarch64" ]] && echo "aarch64-unknown-linux-gnu" && return
+      ;;
+    darwin)
+      [[ "$arch" == "x86_64" ]] && echo "x86_64-apple-darwin" && return
+      [[ "$arch" == "aarch64" ]] && echo "aarch64-apple-darwin" && return
+      ;;
+  esac
+  echo ""
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -v|--version) VERSION="$2"; shift 2 ;;
+    -d|--dir)     INSTALL_DIR="$2"; shift 2 ;;
+    -n|--dry-run) DRY_RUN=true; shift ;;
+    *) shift ;;
+  esac
+done
+
+TARGET=$(get_target)
+if [[ -z "$TARGET" ]]; then
+  echo "error: unsupported platform $(uname -s) $(uname -m)" >&2
+  exit 1
+fi
+
+# Use "latest" so GitHub redirects to the latest release; or a specific tag
+TAG="${VERSION:-latest}"
+ASSET="memoria-${TARGET}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET}"
+
+if $DRY_RUN; then
+  echo "URL: $URL"
+  exit 0
+fi
+
+if [[ -z "$INSTALL_DIR" ]]; then
+  if [[ -w /usr/local/bin ]]; then
+    INSTALL_DIR=/usr/local/bin
+  else
+    INSTALL_DIR="${HOME}/.local/bin"
+    mkdir -p "$INSTALL_DIR"
+  fi
+fi
+
+echo "Installing memoria ${TAG} (${TARGET}) to ${INSTALL_DIR}"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+echo "Downloading: $URL"
+curl -fL# -o "$TMP/$ASSET" "$URL"
+# Verify checksum if SHA256SUMS.txt exists for this release
+SUM_URL="https://github.com/${REPO}/releases/download/${TAG}/SHA256SUMS.txt"
+if curl -sSLf -o "$TMP/SHA256SUMS.txt" "$SUM_URL" 2>/dev/null; then
+  (cd "$TMP" && grep -F "$ASSET" SHA256SUMS.txt | (sha256sum -c 2>/dev/null || shasum -a 256 -c 2>/dev/null)) || { echo "error: checksum verification failed" >&2; exit 1; }
+fi
+tar -xzf "$TMP/$ASSET" -C "$TMP"
+mkdir -p "$INSTALL_DIR"
+cp "$TMP/memoria" "$INSTALL_DIR/memoria"
+chmod +x "$INSTALL_DIR/memoria"
+echo "Installed: $INSTALL_DIR/memoria"
+if ! command -v memoria >/dev/null 2>&1; then
+  echo "Note: ensure ${INSTALL_DIR} is in your PATH"
+fi


### PR DESCRIPTION
## What type of PR is this?

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes #

## What this PR does / why we need it

- Add a `scripts/install.sh` convenience installer that:
  - Detects OS/arch (Linux/macOS, x86_64/aarch64) and picks the correct prebuilt `memoria` binary from GitHub Releases.
  - Optionally verifies downloads against `SHA256SUMS.txt` when present.
  - Installs into `/usr/local/bin` or `~/.local/bin`, with a dry-run mode for debugging.
- Update `README.md` Quick Start to recommend the one-line installer while keeping manual download instructions.
- Improve `Release Rust Binaries` workflow so that:
  - It triggers for both `v*.*.*` and pre-release tags like `v*.*.*-*` (e.g. `v0.1.0-rc1`).
  - It supports manual runs via `workflow_dispatch` with an explicit `tag` input.
  - It uses `github.ref_name`/`tag_name` correctly when creating releases.
- Add `openssl` with the `vendored` feature to `memoria-cli` so cross-compiling `aarch64-unknown-linux-gnu` in CI no longer depends on system OpenSSL headers.

## Test plan

- `cargo check -p memoria-cli`
- `bash scripts/install.sh -n` to verify installer output, target detection, and download URL generation.
