### PR TITLE
fix: install.sh Text file busy error when upgrading

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -266,6 +266,7 @@ fi
 # ── Install ─────────────────────────────────────────────────────────
 
 tar -xzf "$TMP/$ASSET" -C "$TMP"
+$SUDO rm -f "$INSTALL_DIR/memoria"
 $SUDO cp "$TMP/memoria" "$INSTALL_DIR/memoria"
 $SUDO chmod +x "$INSTALL_DIR/memoria"
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

N/A

## What this PR does / why we need it

When upgrading memoria while an MCP server process is still running (e.g. started by Kiro/Cursor), `cp` fails with `Text file busy` (ETXTBSY) because Linux prevents writing to a running executable.

Fix: `rm -f` the old binary before `cp`. This unlinks the filename without affecting the running process (which keeps its open fd), allowing the new binary to be written.
