### PR TITLE
feat(benchmark): separate official LongMemEval and BEAM reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help check-env up down status logs logs-db \
         up-db down-db up-api down-api rebuild-api health \
         dev build build-local check \
-        test test-unit test-integration test-e2e bench \
+        test test-unit test-integration test-e2e bench bench-rollup \
         new-key list-keys revoke-keys \
         clean reset
 
@@ -48,6 +48,7 @@ help:
 	@echo "  make test-unit          Unit tests (no DB)"
 	@echo "  make test-e2e           E2E API tests (needs DB)"
 	@echo "  make bench              Run benchmark (needs: make up)"
+	@echo "  make bench-rollup REPORT=path/to/report.json"
 	@echo ""
 	@echo "API Keys:"
 	@echo "  make new-key USER=alice NAME=dev-key"
@@ -213,6 +214,10 @@ bench: check-env
 		SQLX_OFFLINE=true cargo run -p memoria-cli -- benchmark \
 			--api-url "$(BENCH_URL)" --token "$(BENCH_TOKEN)" --dataset $$ds || true; \
 	done
+
+bench-rollup:
+	@if [ -z "$(REPORT)" ]; then echo "❌ Usage: make bench-rollup REPORT=path/to/report-or-dir"; exit 1; fi
+	@uv run python scripts/rollup_benchmark_report.py "$(REPORT)"
 
 # ── API Keys ────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -361,6 +361,47 @@ AI:  → calls memory_diff(source="eval_sqlite")   ← preview first
 
 ---
 
+## Benchmark Reporting
+
+For LongMemEval and BEAM, the primary reporting path is to keep each benchmark's official
+categories separate:
+
+- LongMemEval: report by official LongMemEval category
+- BEAM: report by official BEAM ability
+
+If you need a secondary internal rollup, you can also normalize reports into a shared
+6-bucket memory taxonomy:
+
+- `Single-Session Grounding`
+- `Preference Understanding`
+- `Multi-Session Synthesis`
+- `Temporal State Tracking`
+- `Knowledge Update And Conflict Handling`
+- `Abstention And Constraint Following`
+
+Use the rollup helper after generating JSON benchmark reports:
+
+```bash
+uv run python scripts/rollup_benchmark_report.py path/to/report.json
+```
+
+Or recursively over a results directory:
+
+```bash
+uv run python scripts/rollup_benchmark_report.py benchmarks/results/
+```
+
+This optional post-processing augments each report with:
+
+- top-level `memory_ability_taxonomy`
+- top-level `by_memory_ability_bucket`
+- per-result `memory_ability_bucket`
+- per-result `memory_ability_bucket_label`
+
+See [Memory Ability Taxonomy](docs/memory-ability-taxonomy.md) for the LongMemEval and BEAM mapping and the rationale behind the 6-bucket summary.
+
+---
+
 ## Modifying the MCP Config
 
 `memoria init` generates the config once. To change settings afterwards, edit the config file directly:

--- a/docs/memory-ability-taxonomy.md
+++ b/docs/memory-ability-taxonomy.md
@@ -1,0 +1,127 @@
+# Memory Ability Taxonomy For LongMemEval And BEAM
+
+这份说明定义了一个统一的 6-bucket taxonomy，用来把 LongMemEval 和 BEAM 的原始能力标签归一化。
+
+注意：
+
+- **主汇报路径** 仍然应该是 LongMemEval 和 BEAM 各自按官方能力分类分别汇报
+- 这个 taxonomy 更适合作为内部分析、横向比较、回归观察的辅助视角
+
+原则：
+
+- 原始 benchmark 标签保留，不替代官方分类
+- 统一 bucket 是辅助视角，不作为主分数来源
+- 做 Memoria 公平评估时，要同时保留 retrieval 指标和 end-to-end QA 指标
+
+## 六个统一能力桶
+
+1. `Single-Session Grounding`
+   - 单会话内的事实、上下文或显式信息提取
+
+2. `Preference Understanding`
+   - 用户偏好理解，不只是关键词命中
+
+3. `Multi-Session Synthesis`
+   - 跨会话整合、综合、总结
+
+4. `Temporal State Tracking`
+   - 时间、顺序、状态演化、事件先后
+
+5. `Knowledge Update And Conflict Handling`
+   - 新旧知识更新、冲突处理、矛盾消解
+
+6. `Abstention And Constraint Following`
+   - 无证据时拒答，以及记住并遵守约束/指令
+
+## LongMemEval 映射
+
+- `single-session-user` -> `Single-Session Grounding`
+- `single-session-assistant` -> `Single-Session Grounding`
+- `single-session-preference` -> `Preference Understanding`
+- `multi-session` -> `Multi-Session Synthesis`
+- `temporal-reasoning` -> `Temporal State Tracking`
+- `knowledge-update` -> `Knowledge Update And Conflict Handling`
+- `abstention` / `_abs` -> `Abstention And Constraint Following`
+
+说明：
+
+- 你之前说的 `single session`，在 LongMemEval 里其实是三类：
+  `single-session-user`、`single-session-assistant`、`single-session-preference`
+- `Preference Understanding Beyond Keyword Matching`
+  对应 `single-session-preference`
+- `Temporal State Tracking`
+  对应 `temporal-reasoning`
+- `Knowledge Evolution and Conflict Resolution`
+  在 LongMemEval 里更接近 `knowledge-update`
+
+## BEAM 映射
+
+- `Information Extraction` -> `Single-Session Grounding`
+- `Preference Following` -> `Preference Understanding`
+- `Multi-Session Reasoning` -> `Multi-Session Synthesis`
+- `Summarization` -> `Multi-Session Synthesis`
+- `Temporal Reasoning` -> `Temporal State Tracking`
+- `Event Ordering` -> `Temporal State Tracking`
+- `Knowledge Update` -> `Knowledge Update And Conflict Handling`
+- `Contradiction Resolution` -> `Knowledge Update And Conflict Handling`
+- `Abstention` -> `Abstention And Constraint Following`
+- `Instruction Following` -> `Abstention And Constraint Following`
+
+说明：
+
+- BEAM 没有官方 `single session` 桶
+- 你说的 `Temporal State Tracking` 在 BEAM 里通常覆盖
+  `Temporal Reasoning`，有时也会包含 `Event Ordering`
+- 你说的 `Knowledge Evolution and Conflict Resolution` 在 BEAM 里应拆成
+  `Knowledge Update` 和 `Contradiction Resolution`
+
+## 为什么仍然保留这个辅助视角
+
+4 个大桶太粗，会把一些关键能力压扁：
+
+- LongMemEval `multi-session`
+- LongMemEval `abstention`
+- BEAM `instruction following`
+- BEAM `summarization`
+- BEAM `event ordering`
+
+所以更适合：
+
+- 对外主报告：按 LongMemEval / BEAM 官方分类分别展示
+- 对内辅助分析：再看这 6 个 bucket 的统一视角
+
+## 报告建议
+
+对每个 benchmark 报告保留三层：
+
+1. 官方原始标签分布
+2. 可选的统一 6-bucket 汇总
+3. 顶层 retrieval / QA / end-to-end 总分
+
+这样做的好处：
+
+- 便于 LongMemEval 和 BEAM 横向比较
+- 不会丢失 benchmark 原始语义
+- 更适合做 Memoria 的版本对比和回归跟踪
+
+## 使用方式
+
+对已有 report JSON 做归一化：
+
+```bash
+uv run python scripts/rollup_benchmark_report.py path/to/report.json
+```
+
+对一个结果目录递归处理：
+
+```bash
+uv run python scripts/rollup_benchmark_report.py benchmarks/results/
+```
+
+处理后，每个报告会新增：
+
+- `memory_ability_taxonomy`
+- `by_memory_ability_bucket`
+- 每条 result 的
+  - `memory_ability_bucket`
+  - `memory_ability_bucket_label`

--- a/memoria/crates/memoria-cli/src/benchmark.rs
+++ b/memoria/crates/memoria-cli/src/benchmark.rs
@@ -1,607 +1,26 @@
-//! Native Rust benchmark — schema, executor, scorer.
-//! Replaces the Python benchmark dependency.
+//! Native Rust benchmark — schema, executor, taxonomy, and scorer.
+//! Kept inside `memoria-cli` so benchmark evolution stays isolated from core service logic.
 
-use reqwest::blocking::Client;
-use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
-use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
+#[path = "benchmark_executor.rs"]
+mod benchmark_executor;
+#[path = "benchmark_scoring.rs"]
+mod benchmark_scoring;
+#[path = "benchmark_schema.rs"]
+mod benchmark_schema;
+#[path = "benchmark_taxonomy.rs"]
+mod benchmark_taxonomy;
 
-// ── Schema ────────────────────────────────────────────────────────────────────
+pub use benchmark_executor::BenchmarkExecutor;
+pub use benchmark_scoring::{score_dataset, score_scenario};
+#[allow(unused_imports)]
+pub use benchmark_schema::{
+    AssertionResult, BenchmarkReport, CategoryBreakdown, MemoryAssertion, Scenario,
+    ScenarioDataset, ScenarioExecution, ScenarioResult, ScenarioStep, SeedMemory, StepResult,
+};
+#[allow(unused_imports)]
+pub use benchmark_taxonomy::{official_category, scenario_question_type, scenario_source_family};
 
-#[derive(Deserialize)]
-pub struct ScenarioDataset {
-    pub dataset_id: String,
-    pub version: String,
-    pub scenarios: Vec<Scenario>,
-}
-
-#[derive(Deserialize)]
-pub struct Scenario {
-    pub scenario_id: String,
-    pub title: String,
-    pub difficulty: String,
-    pub horizon: String,
-    pub tags: Vec<String>,
-    pub seed_memories: Vec<SeedMemory>,
-    #[serde(default)]
-    pub maturation: Vec<String>,
-    #[serde(default)]
-    pub steps: Vec<ScenarioStep>,
-    pub assertions: Vec<MemoryAssertion>,
-}
-
-#[derive(Deserialize)]
-pub struct SeedMemory {
-    pub content: String,
-    #[serde(default = "default_semantic")]
-    pub memory_type: String,
-    #[serde(default)]
-    pub is_outdated: bool,
-    pub age_days: Option<f64>,
-    pub initial_confidence: Option<f64>,
-    pub trust_tier: Option<String>,
-}
-
-fn default_semantic() -> String {
-    "semantic".into()
-}
-
-#[derive(Deserialize)]
-pub struct ScenarioStep {
-    pub action: String,
-    pub content: Option<String>,
-    pub memory_type: Option<String>,
-    pub query: Option<String>,
-    pub top_k: Option<i64>,
-    pub reason: Option<String>,
-    pub topic: Option<String>,
-    pub age_days: Option<f64>,
-    pub initial_confidence: Option<f64>,
-    pub trust_tier: Option<String>,
-}
-
-#[derive(Deserialize)]
-pub struct MemoryAssertion {
-    pub query: String,
-    #[serde(default = "default_top_k")]
-    pub top_k: i64,
-    pub expected_contents: Vec<String>,
-    #[serde(default)]
-    pub excluded_contents: Vec<String>,
-}
-
-fn default_top_k() -> i64 {
-    5
-}
-
-// ── Execution results ─────────────────────────────────────────────────────────
-
-pub struct StepResult {
-    pub _action: String,
-    pub success: bool,
-    pub _error: Option<String>,
-}
-
-pub struct AssertionResult {
-    pub _query: String,
-    pub returned_contents: Vec<String>,
-    pub _error: Option<String>,
-}
-
-pub struct ScenarioExecution {
-    pub _scenario_id: String,
-    pub step_results: Vec<StepResult>,
-    pub assertion_results: Vec<AssertionResult>,
-    pub error: Option<String>,
-}
-
-// ── Scoring results ───────────────────────────────────────────────────────────
-
-#[derive(Serialize)]
-pub struct ScenarioResult {
-    pub scenario_id: String,
-    pub title: String,
-    pub difficulty: String,
-    pub horizon: String,
-    pub tags: Vec<String>,
-    pub total_score: f64,
-    pub grade: String,
-    pub mqs_precision: f64,
-    pub mqs_recall: f64,
-    pub mqs_noise_rejection: f64,
-    pub aus_step_success: f64,
-    pub aus_assertion_pass: f64,
-}
-
-#[derive(Serialize)]
-pub struct BenchmarkReport {
-    pub dataset_id: String,
-    pub version: String,
-    pub scenario_count: usize,
-    pub overall_score: f64,
-    pub overall_grade: String,
-    pub by_difficulty: HashMap<String, f64>,
-    pub by_tag: HashMap<String, f64>,
-    pub results: Vec<ScenarioResult>,
-}
-
-fn grade(score: f64) -> &'static str {
-    if score >= 90.0 {
-        "S"
-    } else if score >= 80.0 {
-        "A"
-    } else if score >= 70.0 {
-        "B"
-    } else if score >= 60.0 {
-        "C"
-    } else {
-        "D"
-    }
-}
-
-// ── Executor ──────────────────────────────────────────────────────────────────
-
-pub struct BenchmarkExecutor {
-    base_url: String,
-    token: String,
-    run_id: String,
-}
-
-impl BenchmarkExecutor {
-    pub fn new(api_url: &str, token: &str) -> Self {
-        let run_id = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs().to_string())
-            .unwrap_or_default();
-        Self {
-            base_url: api_url.trim_end_matches('/').into(),
-            token: token.into(),
-            run_id,
-        }
-    }
-
-    fn client(&self, scenario_suffix: &str) -> Client {
-        let user_id = format!("bench-{}-{}", self.run_id, scenario_suffix);
-        Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .no_proxy()
-            .default_headers({
-                let mut h = reqwest::header::HeaderMap::new();
-                h.insert(
-                    "Authorization",
-                    format!("Bearer {}", self.token).parse().unwrap(),
-                );
-                h.insert("X-Impersonate-User", user_id.parse().unwrap());
-                h
-            })
-            .build()
-            .unwrap()
-    }
-
-    pub fn execute(&self, scenario: &Scenario) -> ScenarioExecution {
-        let sid = scenario.scenario_id.to_lowercase();
-        let client = self.client(&sid);
-        let session_id = format!("bench-{}-{}", self.run_id, sid);
-        let user_id = format!("bench-{}-{}", self.run_id, sid);
-        let mut exec = ScenarioExecution {
-            _scenario_id: scenario.scenario_id.clone(),
-            step_results: vec![],
-            assertion_results: vec![],
-            error: None,
-        };
-
-        // Phase 1: seed
-        for seed in &scenario.seed_memories {
-            match self.store(
-                &client,
-                &seed.content,
-                &seed.memory_type,
-                &session_id,
-                seed.age_days,
-                seed.initial_confidence,
-                seed.trust_tier.as_deref(),
-            ) {
-                Ok(mid) => {
-                    if seed.is_outdated && !mid.is_empty() {
-                        let _ = self.purge_ids(&client, &[mid], "seed is_outdated");
-                    }
-                }
-                Err(e) => {
-                    exec.error = Some(format!("seed failed: {e}"));
-                    return exec;
-                }
-            }
-        }
-
-        // Phase 2: maturation
-        for op in &scenario.maturation {
-            let _ = client
-                .post(format!(
-                    "{}/admin/governance/{}/trigger",
-                    self.base_url, user_id
-                ))
-                .query(&[("op", op.as_str())])
-                .send();
-        }
-
-        // Phase 3: steps
-        for step in &scenario.steps {
-            exec.step_results
-                .push(self.run_step(&client, step, &session_id));
-        }
-
-        // Phase 4: assertions
-        for assertion in &scenario.assertions {
-            exec.assertion_results
-                .push(self.run_assertion(&client, assertion, &session_id));
-        }
-        exec
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn store(
-        &self,
-        client: &Client,
-        content: &str,
-        memory_type: &str,
-        session_id: &str,
-        age_days: Option<f64>,
-        confidence: Option<f64>,
-        trust_tier: Option<&str>,
-    ) -> anyhow::Result<String> {
-        let mut body = json!({
-            "content": content, "memory_type": memory_type,
-            "session_id": session_id, "source": "benchmark",
-        });
-        if let Some(days) = age_days {
-            let secs = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs_f64()
-                - days * 86400.0;
-            let dt = chrono_like_iso(secs);
-            body["observed_at"] = json!(dt);
-        }
-        if let Some(c) = confidence {
-            body["initial_confidence"] = json!(c);
-        }
-        if let Some(t) = trust_tier {
-            body["trust_tier"] = json!(t);
-        }
-
-        let resp = client
-            .post(format!("{}/v1/memories", self.base_url))
-            .json(&body)
-            .send()?;
-        let data: Value = resp.json()?;
-        Ok(data["memory_id"].as_str().unwrap_or("").to_string())
-    }
-
-    fn retrieve(&self, client: &Client, query: &str, session_id: &str, top_k: i64) -> Vec<String> {
-        let resp = client
-            .post(format!("{}/v1/memories/retrieve", self.base_url))
-            .json(&json!({"query": query, "top_k": top_k, "session_id": session_id}))
-            .send();
-        let data: Value = match resp.and_then(|r| r.json()) {
-            Ok(v) => v,
-            Err(_) => return vec![],
-        };
-        let items = if data.is_array() {
-            data.as_array()
-        } else {
-            data["results"].as_array()
-        };
-        items
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|i| i["content"].as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default()
-    }
-
-    fn run_step(&self, client: &Client, step: &ScenarioStep, session_id: &str) -> StepResult {
-        let action = step.action.clone();
-        let result = (|| -> anyhow::Result<()> {
-            match action.as_str() {
-                "store" => {
-                    self.store(
-                        client,
-                        step.content.as_deref().unwrap_or(""),
-                        step.memory_type.as_deref().unwrap_or("semantic"),
-                        session_id,
-                        step.age_days,
-                        step.initial_confidence,
-                        step.trust_tier.as_deref(),
-                    )?;
-                }
-                "retrieve" => {
-                    self.retrieve(
-                        client,
-                        step.query.as_deref().unwrap_or(""),
-                        session_id,
-                        step.top_k.unwrap_or(5),
-                    );
-                }
-                "search" => {
-                    client
-                        .post(format!("{}/v1/memories/search", self.base_url))
-                        .json(&json!({"query": step.query, "top_k": step.top_k.unwrap_or(10)}))
-                        .send()?
-                        .error_for_status()?;
-                }
-                "correct" => {
-                    client
-                        .post(format!("{}/v1/memories/correct", self.base_url))
-                        .json(&json!({"query": step.query, "new_content": step.content,
-                            "reason": step.reason.as_deref().unwrap_or("benchmark")}))
-                        .send()?
-                        .error_for_status()?;
-                }
-                "purge" => {
-                    let mut body = json!({"reason": step.reason.as_deref().unwrap_or("benchmark")});
-                    if let Some(t) = &step.topic {
-                        body["topic"] = json!(t);
-                    }
-                    client
-                        .post(format!("{}/v1/memories/purge", self.base_url))
-                        .json(&body)
-                        .send()?
-                        .error_for_status()?;
-                }
-                _ => {}
-            }
-            Ok(())
-        })();
-        match result {
-            Ok(()) => StepResult {
-                _action: action,
-                success: true,
-                _error: None,
-            },
-            Err(e) => StepResult {
-                _action: action,
-                success: false,
-                _error: Some(e.to_string()),
-            },
-        }
-    }
-
-    fn run_assertion(
-        &self,
-        client: &Client,
-        assertion: &MemoryAssertion,
-        session_id: &str,
-    ) -> AssertionResult {
-        let contents = self.retrieve(client, &assertion.query, session_id, assertion.top_k);
-        AssertionResult {
-            _query: assertion.query.clone(),
-            returned_contents: contents,
-            _error: None,
-        }
-    }
-
-    fn purge_ids(&self, client: &Client, ids: &[String], reason: &str) -> anyhow::Result<()> {
-        client
-            .post(format!("{}/v1/memories/purge", self.base_url))
-            .json(&json!({"memory_ids": ids, "reason": reason}))
-            .send()?
-            .error_for_status()?;
-        Ok(())
-    }
-}
-
-fn chrono_like_iso(epoch_secs: f64) -> String {
-    let secs = epoch_secs as i64;
-    let d = secs / 86400 + 719468;
-    let era = if d >= 0 { d } else { d - 146096 } / 146097;
-    let doe = (d - era * 146097) as u32;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let day = doy - (153 * mp + 2) / 5 + 1;
-    let month = if mp < 10 { mp + 3 } else { mp - 9 };
-    let year = if month <= 2 { y + 1 } else { y };
-    let rem = secs.rem_euclid(86400);
-    let h = rem / 3600;
-    let m = (rem % 3600) / 60;
-    let s = rem % 60;
-    format!("{year:04}-{month:02}-{day:02}T{h:02}:{m:02}:{s:02}Z")
-}
-
-// ── Scorer ────────────────────────────────────────────────────────────────────
-
-fn score_contents(assertion: &MemoryAssertion, returned: &[String]) -> (f64, f64, f64, bool) {
-    let hits = assertion
-        .expected_contents
-        .iter()
-        .filter(|exp| {
-            returned
-                .iter()
-                .any(|c| c.to_lowercase().contains(&exp.to_lowercase()))
-        })
-        .count();
-    let recall = if assertion.expected_contents.is_empty() {
-        100.0
-    } else {
-        100.0 * hits as f64 / assertion.expected_contents.len() as f64
-    };
-
-    let precision = if returned.is_empty() {
-        0.0
-    } else {
-        let relevant = returned
-            .iter()
-            .filter(|c| {
-                assertion
-                    .expected_contents
-                    .iter()
-                    .any(|exp| c.to_lowercase().contains(&exp.to_lowercase()))
-            })
-            .count();
-        100.0 * relevant as f64 / returned.len() as f64
-    };
-
-    let noise_rejection = if assertion.excluded_contents.is_empty() {
-        100.0
-    } else {
-        let noise_hits = assertion
-            .excluded_contents
-            .iter()
-            .filter(|exc| {
-                returned
-                    .iter()
-                    .any(|c| c.to_lowercase().contains(&exc.to_lowercase()))
-            })
-            .count();
-        100.0 * (assertion.excluded_contents.len() - noise_hits) as f64
-            / assertion.excluded_contents.len() as f64
-    };
-
-    let passed = recall >= 80.0 && noise_rejection >= 80.0;
-    (precision, recall, noise_rejection, passed)
-}
-
-pub fn score_scenario(scenario: &Scenario, exec: &ScenarioExecution) -> ScenarioResult {
-    if let Some(_err) = &exec.error {
-        return ScenarioResult {
-            scenario_id: scenario.scenario_id.clone(),
-            title: scenario.title.clone(),
-            difficulty: scenario.difficulty.clone(),
-            horizon: scenario.horizon.clone(),
-            tags: scenario.tags.clone(),
-            total_score: 0.0,
-            grade: "D".into(),
-            mqs_precision: 0.0,
-            mqs_recall: 0.0,
-            mqs_noise_rejection: 100.0,
-            aus_step_success: 0.0,
-            aus_assertion_pass: 0.0,
-        };
-    }
-
-    let mut precisions = vec![];
-    let mut recalls = vec![];
-    let mut noises = vec![];
-    let mut passed_count = 0usize;
-    for (i, assertion) in scenario.assertions.iter().enumerate() {
-        let returned = exec
-            .assertion_results
-            .get(i)
-            .map(|r| r.returned_contents.as_slice())
-            .unwrap_or(&[]);
-        let (p, r, n, ok) = score_contents(assertion, returned);
-        precisions.push(p);
-        recalls.push(r);
-        noises.push(n);
-        if ok {
-            passed_count += 1;
-        }
-    }
-
-    let avg = |v: &[f64]| {
-        if v.is_empty() {
-            0.0
-        } else {
-            v.iter().sum::<f64>() / v.len() as f64
-        }
-    };
-    let mqs_p = avg(&precisions);
-    let mqs_r = avg(&recalls);
-    let mqs_n = avg(&noises);
-    let assertion_pass = if scenario.assertions.is_empty() {
-        0.0
-    } else {
-        100.0 * passed_count as f64 / scenario.assertions.len() as f64
-    };
-    let step_success = if exec.step_results.is_empty() {
-        100.0
-    } else {
-        100.0 * exec.step_results.iter().filter(|s| s.success).count() as f64
-            / exec.step_results.len() as f64
-    };
-
-    let mqs = (mqs_p + mqs_r + mqs_n) / 3.0;
-    let aus = (step_success + assertion_pass) / 2.0;
-    let total = 0.65 * mqs + 0.35 * aus;
-
-    ScenarioResult {
-        scenario_id: scenario.scenario_id.clone(),
-        title: scenario.title.clone(),
-        difficulty: scenario.difficulty.clone(),
-        horizon: scenario.horizon.clone(),
-        tags: scenario.tags.clone(),
-        total_score: (total * 100.0).round() / 100.0,
-        grade: grade(total).into(),
-        mqs_precision: (mqs_p * 100.0).round() / 100.0,
-        mqs_recall: (mqs_r * 100.0).round() / 100.0,
-        mqs_noise_rejection: (mqs_n * 100.0).round() / 100.0,
-        aus_step_success: (step_success * 100.0).round() / 100.0,
-        aus_assertion_pass: (assertion_pass * 100.0).round() / 100.0,
-    }
-}
-
-pub fn score_dataset(
-    dataset: &ScenarioDataset,
-    executions: &HashMap<String, ScenarioExecution>,
-) -> BenchmarkReport {
-    let mut results = vec![];
-    let mut by_diff: HashMap<String, Vec<f64>> = HashMap::new();
-    let mut by_tag: HashMap<String, Vec<f64>> = HashMap::new();
-
-    for scenario in &dataset.scenarios {
-        let empty = ScenarioExecution {
-            _scenario_id: scenario.scenario_id.clone(),
-            step_results: vec![],
-            assertion_results: vec![],
-            error: Some("no execution".into()),
-        };
-        let exec = executions.get(&scenario.scenario_id).unwrap_or(&empty);
-        let result = score_scenario(scenario, exec);
-        by_diff
-            .entry(scenario.difficulty.clone())
-            .or_default()
-            .push(result.total_score);
-        for tag in &scenario.tags {
-            by_tag
-                .entry(tag.clone())
-                .or_default()
-                .push(result.total_score);
-        }
-        results.push(result);
-    }
-
-    let avg = |v: &[f64]| {
-        if v.is_empty() {
-            0.0
-        } else {
-            v.iter().sum::<f64>() / v.len() as f64
-        }
-    };
-    let all: Vec<f64> = results.iter().map(|r| r.total_score).collect();
-    let overall = avg(&all);
-
-    BenchmarkReport {
-        dataset_id: dataset.dataset_id.clone(),
-        version: dataset.version.clone(),
-        scenario_count: results.len(),
-        overall_score: (overall * 100.0).round() / 100.0,
-        overall_grade: grade(overall).into(),
-        by_difficulty: by_diff
-            .iter()
-            .map(|(k, v)| (k.clone(), (avg(v) * 100.0).round() / 100.0))
-            .collect(),
-        by_tag: by_tag
-            .iter()
-            .map(|(k, v)| (k.clone(), (avg(v) * 100.0).round() / 100.0))
-            .collect(),
-        results,
-    }
-}
-
-// ── Validator ─────────────────────────────────────────────────────────────────
+use std::collections::HashSet;
 
 pub fn validate_dataset(content: &str) -> Vec<String> {
     let mut errors = vec![];
@@ -612,7 +31,7 @@ pub fn validate_dataset(content: &str) -> Vec<String> {
             return errors;
         }
     };
-    let mut ids = std::collections::HashSet::new();
+    let mut ids = HashSet::new();
     for s in &dataset.scenarios {
         if !ids.insert(&s.scenario_id) {
             errors.push(format!("duplicate scenario_id: {}", s.scenario_id));
@@ -652,4 +71,126 @@ pub fn validate_dataset(content: &str) -> Vec<String> {
         }
     }
     errors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    fn scenario_with_metadata(
+        scenario_id: &str,
+        source_family: &str,
+        question_type: &str,
+    ) -> Scenario {
+        Scenario {
+            scenario_id: scenario_id.into(),
+            title: "test".into(),
+            description: String::new(),
+            domain: if source_family == "beam" { "beam" } else { "longmem" }.into(),
+            difficulty: "L1".into(),
+            horizon: "short".into(),
+            tags: vec![],
+            source_family: None,
+            question_type: None,
+            metadata: HashMap::from([
+                ("source_family".into(), json!(source_family)),
+                ("question_type".into(), json!(question_type)),
+            ]),
+            seed_memories: vec![SeedMemory {
+                content: "memory".into(),
+                memory_type: "semantic".into(),
+                is_outdated: false,
+                age_days: None,
+                initial_confidence: None,
+                trust_tier: None,
+            }],
+            maturation: vec![],
+            steps: vec![],
+            assertions: vec![MemoryAssertion {
+                query: "query".into(),
+                top_k: 3,
+                expected_contents: vec!["memory".into()],
+                excluded_contents: vec![],
+            }],
+        }
+    }
+
+    fn pass_exec(id: &str) -> ScenarioExecution {
+        ScenarioExecution {
+            _scenario_id: id.into(),
+            step_results: vec![],
+            assertion_results: vec![AssertionResult {
+                _query: "query".into(),
+                returned_contents: vec!["memory".into()],
+                _error: None,
+            }],
+            error: None,
+        }
+    }
+
+    #[test]
+    fn groups_longmemeval_by_official_category() {
+        let scenarios = vec![
+            scenario_with_metadata("lme-1", "longmemeval", "single-session-preference"),
+            scenario_with_metadata("lme-2", "longmemeval", "knowledge-update"),
+        ];
+        let dataset = ScenarioDataset {
+            dataset_id: "longmemeval-oracle".into(),
+            version: "v1".into(),
+            scenarios,
+        };
+        let executions = HashMap::from([
+            ("lme-1".into(), pass_exec("lme-1")),
+            (
+                "lme-2".into(),
+                ScenarioExecution {
+                    _scenario_id: "lme-2".into(),
+                    step_results: vec![],
+                    assertion_results: vec![AssertionResult {
+                        _query: "query".into(),
+                        returned_contents: vec![],
+                        _error: None,
+                    }],
+                    error: None,
+                },
+            ),
+        ]);
+        let report = score_dataset(&dataset, &executions);
+        assert!(report
+            .by_longmemeval_category
+            .contains_key("single-session-preference"));
+        assert!(report
+            .by_longmemeval_category
+            .contains_key("knowledge-update"));
+        assert_eq!(
+            report.results[0].official_category.as_deref(),
+            Some("single-session-preference")
+        );
+    }
+
+    #[test]
+    fn groups_beam_by_official_ability() {
+        let scenarios = vec![
+            scenario_with_metadata("beam-1", "beam", "event_ordering"),
+            scenario_with_metadata("beam-2", "beam", "instruction_following"),
+        ];
+        let dataset = ScenarioDataset {
+            dataset_id: "beam-100k".into(),
+            version: "v1".into(),
+            scenarios,
+        };
+        let executions = HashMap::from([
+            ("beam-1".into(), pass_exec("beam-1")),
+            ("beam-2".into(), pass_exec("beam-2")),
+        ]);
+        let report = score_dataset(&dataset, &executions);
+        assert!(report.by_beam_ability.contains_key("event_ordering"));
+        assert!(report.by_beam_ability.contains_key("instruction_following"));
+        assert_eq!(
+            report.results[1].official_category_label.as_deref(),
+            Some("Instruction Following")
+        );
+    }
 }

--- a/memoria/crates/memoria-cli/src/benchmark_executor.rs
+++ b/memoria/crates/memoria-cli/src/benchmark_executor.rs
@@ -1,0 +1,270 @@
+use crate::benchmark::{
+    AssertionResult, MemoryAssertion, Scenario, ScenarioExecution, ScenarioStep, StepResult,
+};
+use reqwest::blocking::Client;
+use serde_json::{json, Value};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub struct BenchmarkExecutor {
+    base_url: String,
+    token: String,
+    run_id: String,
+}
+
+impl BenchmarkExecutor {
+    pub fn new(api_url: &str, token: &str) -> Self {
+        let run_id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs().to_string())
+            .unwrap_or_default();
+        Self {
+            base_url: api_url.trim_end_matches('/').into(),
+            token: token.into(),
+            run_id,
+        }
+    }
+
+    fn client(&self, scenario_suffix: &str) -> Client {
+        let user_id = format!("bench-{}-{}", self.run_id, scenario_suffix);
+        Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .no_proxy()
+            .default_headers({
+                let mut h = reqwest::header::HeaderMap::new();
+                h.insert(
+                    "Authorization",
+                    format!("Bearer {}", self.token).parse().unwrap(),
+                );
+                h.insert("X-Impersonate-User", user_id.parse().unwrap());
+                h
+            })
+            .build()
+            .unwrap()
+    }
+
+    pub fn execute(&self, scenario: &Scenario) -> ScenarioExecution {
+        let sid = scenario.scenario_id.to_lowercase();
+        let client = self.client(&sid);
+        let session_id = format!("bench-{}-{}", self.run_id, sid);
+        let user_id = format!("bench-{}-{}", self.run_id, sid);
+        let mut exec = ScenarioExecution {
+            _scenario_id: scenario.scenario_id.clone(),
+            step_results: vec![],
+            assertion_results: vec![],
+            error: None,
+        };
+
+        for seed in &scenario.seed_memories {
+            match self.store(
+                &client,
+                &seed.content,
+                &seed.memory_type,
+                &session_id,
+                seed.age_days,
+                seed.initial_confidence,
+                seed.trust_tier.as_deref(),
+            ) {
+                Ok(mid) => {
+                    if seed.is_outdated && !mid.is_empty() {
+                        let _ = self.purge_ids(&client, &[mid], "seed is_outdated");
+                    }
+                }
+                Err(e) => {
+                    exec.error = Some(format!("seed failed: {e}"));
+                    return exec;
+                }
+            }
+        }
+
+        for op in &scenario.maturation {
+            let _ = client
+                .post(format!(
+                    "{}/admin/governance/{}/trigger",
+                    self.base_url, user_id
+                ))
+                .query(&[("op", op.as_str())])
+                .send();
+        }
+
+        for step in &scenario.steps {
+            exec.step_results
+                .push(self.run_step(&client, step, &session_id));
+        }
+
+        for assertion in &scenario.assertions {
+            exec.assertion_results
+                .push(self.run_assertion(&client, assertion, &session_id));
+        }
+        exec
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn store(
+        &self,
+        client: &Client,
+        content: &str,
+        memory_type: &str,
+        session_id: &str,
+        age_days: Option<f64>,
+        confidence: Option<f64>,
+        trust_tier: Option<&str>,
+    ) -> anyhow::Result<String> {
+        let mut body = json!({
+            "content": content, "memory_type": memory_type,
+            "session_id": session_id, "source": "benchmark",
+        });
+        if let Some(days) = age_days {
+            let secs = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs_f64()
+                - days * 86400.0;
+            body["observed_at"] = json!(chrono_like_iso(secs));
+        }
+        if let Some(c) = confidence {
+            body["initial_confidence"] = json!(c);
+        }
+        if let Some(t) = trust_tier {
+            body["trust_tier"] = json!(t);
+        }
+
+        let resp = client
+            .post(format!("{}/v1/memories", self.base_url))
+            .json(&body)
+            .send()?;
+        let data: Value = resp.json()?;
+        Ok(data["memory_id"].as_str().unwrap_or("").to_string())
+    }
+
+    fn retrieve(&self, client: &Client, query: &str, session_id: &str, top_k: i64) -> Vec<String> {
+        let resp = client
+            .post(format!("{}/v1/memories/retrieve", self.base_url))
+            .json(&json!({"query": query, "top_k": top_k, "session_id": session_id}))
+            .send();
+        let data: Value = match resp.and_then(|r| r.json()) {
+            Ok(v) => v,
+            Err(_) => return vec![],
+        };
+        let items = if data.is_array() {
+            data.as_array()
+        } else {
+            data["results"].as_array()
+        };
+        items
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|i| i["content"].as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn run_step(&self, client: &Client, step: &ScenarioStep, session_id: &str) -> StepResult {
+        let action = step.action.clone();
+        let result = (|| -> anyhow::Result<()> {
+            match action.as_str() {
+                "store" => {
+                    self.store(
+                        client,
+                        step.content.as_deref().unwrap_or(""),
+                        step.memory_type.as_deref().unwrap_or("semantic"),
+                        session_id,
+                        step.age_days,
+                        step.initial_confidence,
+                        step.trust_tier.as_deref(),
+                    )?;
+                }
+                "retrieve" => {
+                    self.retrieve(
+                        client,
+                        step.query.as_deref().unwrap_or(""),
+                        session_id,
+                        step.top_k.unwrap_or(5),
+                    );
+                }
+                "search" => {
+                    client
+                        .post(format!("{}/v1/memories/search", self.base_url))
+                        .json(&json!({"query": step.query, "top_k": step.top_k.unwrap_or(10)}))
+                        .send()?
+                        .error_for_status()?;
+                }
+                "correct" => {
+                    client
+                        .post(format!("{}/v1/memories/correct", self.base_url))
+                        .json(&json!({"query": step.query, "new_content": step.content,
+                            "reason": step.reason.as_deref().unwrap_or("benchmark")}))
+                        .send()?
+                        .error_for_status()?;
+                }
+                "purge" => {
+                    let mut body = json!({"reason": step.reason.as_deref().unwrap_or("benchmark")});
+                    if let Some(t) = &step.topic {
+                        body["topic"] = json!(t);
+                    }
+                    client
+                        .post(format!("{}/v1/memories/purge", self.base_url))
+                        .json(&body)
+                        .send()?
+                        .error_for_status()?;
+                }
+                _ => {}
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => StepResult {
+                _action: action,
+                success: true,
+                _error: None,
+            },
+            Err(e) => StepResult {
+                _action: action,
+                success: false,
+                _error: Some(e.to_string()),
+            },
+        }
+    }
+
+    fn run_assertion(
+        &self,
+        client: &Client,
+        assertion: &MemoryAssertion,
+        session_id: &str,
+    ) -> AssertionResult {
+        let contents = self.retrieve(client, &assertion.query, session_id, assertion.top_k);
+        AssertionResult {
+            _query: assertion.query.clone(),
+            returned_contents: contents,
+            _error: None,
+        }
+    }
+
+    fn purge_ids(&self, client: &Client, ids: &[String], reason: &str) -> anyhow::Result<()> {
+        client
+            .post(format!("{}/v1/memories/purge", self.base_url))
+            .json(&json!({"memory_ids": ids, "reason": reason}))
+            .send()?
+            .error_for_status()?;
+        Ok(())
+    }
+}
+
+fn chrono_like_iso(epoch_secs: f64) -> String {
+    let secs = epoch_secs as i64;
+    let d = secs / 86400 + 719468;
+    let era = if d >= 0 { d } else { d - 146096 } / 146097;
+    let doe = (d - era * 146097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { y + 1 } else { y };
+    let rem = secs.rem_euclid(86400);
+    let h = rem / 3600;
+    let m = (rem % 3600) / 60;
+    let s = rem % 60;
+    format!("{year:04}-{month:02}-{day:02}T{h:02}:{m:02}:{s:02}Z")
+}

--- a/memoria/crates/memoria-cli/src/benchmark_schema.rs
+++ b/memoria/crates/memoria-cli/src/benchmark_schema.rs
@@ -1,0 +1,144 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Deserialize)]
+pub struct ScenarioDataset {
+    pub dataset_id: String,
+    pub version: String,
+    pub scenarios: Vec<Scenario>,
+}
+
+#[derive(Deserialize)]
+pub struct Scenario {
+    pub scenario_id: String,
+    pub title: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub domain: String,
+    pub difficulty: String,
+    pub horizon: String,
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub source_family: Option<String>,
+    #[serde(default)]
+    pub question_type: Option<String>,
+    #[serde(default)]
+    pub metadata: HashMap<String, Value>,
+    pub seed_memories: Vec<SeedMemory>,
+    #[serde(default)]
+    pub maturation: Vec<String>,
+    #[serde(default)]
+    pub steps: Vec<ScenarioStep>,
+    pub assertions: Vec<MemoryAssertion>,
+}
+
+#[derive(Deserialize)]
+pub struct SeedMemory {
+    pub content: String,
+    #[serde(default = "default_semantic")]
+    pub memory_type: String,
+    #[serde(default)]
+    pub is_outdated: bool,
+    pub age_days: Option<f64>,
+    pub initial_confidence: Option<f64>,
+    pub trust_tier: Option<String>,
+}
+
+fn default_semantic() -> String {
+    "semantic".into()
+}
+
+#[derive(Deserialize)]
+pub struct ScenarioStep {
+    pub action: String,
+    pub content: Option<String>,
+    pub memory_type: Option<String>,
+    pub query: Option<String>,
+    pub top_k: Option<i64>,
+    pub reason: Option<String>,
+    pub topic: Option<String>,
+    pub age_days: Option<f64>,
+    pub initial_confidence: Option<f64>,
+    pub trust_tier: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct MemoryAssertion {
+    pub query: String,
+    #[serde(default = "default_top_k")]
+    pub top_k: i64,
+    pub expected_contents: Vec<String>,
+    #[serde(default)]
+    pub excluded_contents: Vec<String>,
+}
+
+fn default_top_k() -> i64 {
+    5
+}
+
+pub struct StepResult {
+    pub _action: String,
+    pub success: bool,
+    pub _error: Option<String>,
+}
+
+pub struct AssertionResult {
+    pub _query: String,
+    pub returned_contents: Vec<String>,
+    pub _error: Option<String>,
+}
+
+pub struct ScenarioExecution {
+    pub _scenario_id: String,
+    pub step_results: Vec<StepResult>,
+    pub assertion_results: Vec<AssertionResult>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ScenarioResult {
+    pub scenario_id: String,
+    pub title: String,
+    pub domain: String,
+    pub difficulty: String,
+    pub horizon: String,
+    pub tags: Vec<String>,
+    pub source_family: Option<String>,
+    pub question_type: Option<String>,
+    pub official_category: Option<String>,
+    pub official_category_label: Option<String>,
+    pub total_score: f64,
+    pub grade: String,
+    pub mqs_precision: f64,
+    pub mqs_recall: f64,
+    pub mqs_noise_rejection: f64,
+    pub aus_step_success: f64,
+    pub aus_assertion_pass: f64,
+}
+
+#[derive(Serialize)]
+pub struct CategoryBreakdown {
+    pub label: String,
+    pub scenario_count: usize,
+    pub score: f64,
+    pub grade: String,
+}
+
+#[derive(Serialize)]
+pub struct BenchmarkReport {
+    pub dataset_id: String,
+    pub version: String,
+    pub scenario_count: usize,
+    pub overall_score: f64,
+    pub overall_grade: String,
+    pub by_difficulty: HashMap<String, f64>,
+    pub by_tag: HashMap<String, f64>,
+    pub by_domain: HashMap<String, f64>,
+    pub by_source_family: HashMap<String, CategoryBreakdown>,
+    pub by_longmemeval_category: HashMap<String, CategoryBreakdown>,
+    pub by_beam_ability: HashMap<String, CategoryBreakdown>,
+    pub results: Vec<ScenarioResult>,
+}

--- a/memoria/crates/memoria-cli/src/benchmark_scoring.rs
+++ b/memoria/crates/memoria-cli/src/benchmark_scoring.rs
@@ -1,0 +1,258 @@
+use super::benchmark_schema::{
+    BenchmarkReport, MemoryAssertion, Scenario, ScenarioDataset, ScenarioExecution, ScenarioResult,
+};
+use super::benchmark_taxonomy::{
+    category_breakdown, grade, official_category, scenario_question_type, scenario_source_family,
+};
+use std::collections::HashMap;
+
+fn score_contents(assertion: &MemoryAssertion, returned: &[String]) -> (f64, f64, f64, bool) {
+    let hits = assertion
+        .expected_contents
+        .iter()
+        .filter(|exp| {
+            returned
+                .iter()
+                .any(|c| c.to_lowercase().contains(&exp.to_lowercase()))
+        })
+        .count();
+    let recall = if assertion.expected_contents.is_empty() {
+        100.0
+    } else {
+        100.0 * hits as f64 / assertion.expected_contents.len() as f64
+    };
+
+    let precision = if returned.is_empty() {
+        0.0
+    } else {
+        let relevant = returned
+            .iter()
+            .filter(|c| {
+                assertion
+                    .expected_contents
+                    .iter()
+                    .any(|exp| c.to_lowercase().contains(&exp.to_lowercase()))
+            })
+            .count();
+        100.0 * relevant as f64 / returned.len() as f64
+    };
+
+    let noise_rejection = if assertion.excluded_contents.is_empty() {
+        100.0
+    } else {
+        let noise_hits = assertion
+            .excluded_contents
+            .iter()
+            .filter(|exc| {
+                returned
+                    .iter()
+                    .any(|c| c.to_lowercase().contains(&exc.to_lowercase()))
+            })
+            .count();
+        100.0 * (assertion.excluded_contents.len() - noise_hits) as f64
+            / assertion.excluded_contents.len() as f64
+    };
+
+    let passed = recall >= 80.0 && noise_rejection >= 80.0;
+    (precision, recall, noise_rejection, passed)
+}
+
+pub fn score_scenario(scenario: &Scenario, exec: &ScenarioExecution) -> ScenarioResult {
+    let source_family = scenario_source_family("", scenario);
+    let question_type = scenario_question_type(scenario);
+    let official = official_category(source_family.as_deref(), question_type.as_deref());
+    if exec.error.is_some() {
+        return ScenarioResult {
+            scenario_id: scenario.scenario_id.clone(),
+            title: scenario.title.clone(),
+            domain: scenario.domain.clone(),
+            difficulty: scenario.difficulty.clone(),
+            horizon: scenario.horizon.clone(),
+            tags: scenario.tags.clone(),
+            source_family,
+            question_type,
+            official_category: official.as_ref().map(|(key, _)| key.clone()),
+            official_category_label: official.as_ref().map(|(_, label)| label.clone()),
+            total_score: 0.0,
+            grade: "D".into(),
+            mqs_precision: 0.0,
+            mqs_recall: 0.0,
+            mqs_noise_rejection: 100.0,
+            aus_step_success: 0.0,
+            aus_assertion_pass: 0.0,
+        };
+    }
+
+    let mut precisions = vec![];
+    let mut recalls = vec![];
+    let mut noises = vec![];
+    let mut passed_count = 0usize;
+    for (i, assertion) in scenario.assertions.iter().enumerate() {
+        let returned = exec
+            .assertion_results
+            .get(i)
+            .map(|r| r.returned_contents.as_slice())
+            .unwrap_or(&[]);
+        let (p, r, n, ok) = score_contents(assertion, returned);
+        precisions.push(p);
+        recalls.push(r);
+        noises.push(n);
+        if ok {
+            passed_count += 1;
+        }
+    }
+
+    let avg = |v: &[f64]| {
+        if v.is_empty() {
+            0.0
+        } else {
+            v.iter().sum::<f64>() / v.len() as f64
+        }
+    };
+    let mqs_p = avg(&precisions);
+    let mqs_r = avg(&recalls);
+    let mqs_n = avg(&noises);
+    let assertion_pass = if scenario.assertions.is_empty() {
+        0.0
+    } else {
+        100.0 * passed_count as f64 / scenario.assertions.len() as f64
+    };
+    let step_success = if exec.step_results.is_empty() {
+        100.0
+    } else {
+        100.0 * exec.step_results.iter().filter(|s| s.success).count() as f64
+            / exec.step_results.len() as f64
+    };
+
+    let mqs = (mqs_p + mqs_r + mqs_n) / 3.0;
+    let aus = (step_success + assertion_pass) / 2.0;
+    let total = 0.65 * mqs + 0.35 * aus;
+
+    ScenarioResult {
+        scenario_id: scenario.scenario_id.clone(),
+        title: scenario.title.clone(),
+        domain: scenario.domain.clone(),
+        difficulty: scenario.difficulty.clone(),
+        horizon: scenario.horizon.clone(),
+        tags: scenario.tags.clone(),
+        source_family,
+        question_type,
+        official_category: official.as_ref().map(|(key, _)| key.clone()),
+        official_category_label: official.as_ref().map(|(_, label)| label.clone()),
+        total_score: (total * 100.0).round() / 100.0,
+        grade: grade(total).into(),
+        mqs_precision: (mqs_p * 100.0).round() / 100.0,
+        mqs_recall: (mqs_r * 100.0).round() / 100.0,
+        mqs_noise_rejection: (mqs_n * 100.0).round() / 100.0,
+        aus_step_success: (step_success * 100.0).round() / 100.0,
+        aus_assertion_pass: (assertion_pass * 100.0).round() / 100.0,
+    }
+}
+
+pub fn score_dataset(
+    dataset: &ScenarioDataset,
+    executions: &HashMap<String, ScenarioExecution>,
+) -> BenchmarkReport {
+    let mut results = vec![];
+    let mut by_diff: HashMap<String, Vec<f64>> = HashMap::new();
+    let mut by_tag: HashMap<String, Vec<f64>> = HashMap::new();
+    let mut by_domain: HashMap<String, Vec<f64>> = HashMap::new();
+    let mut by_family: HashMap<String, Vec<f64>> = HashMap::new();
+    let mut by_lme_category: HashMap<String, Vec<f64>> = HashMap::new();
+    let mut lme_labels: HashMap<String, String> = HashMap::new();
+    let mut by_beam_ability: HashMap<String, Vec<f64>> = HashMap::new();
+    let mut beam_labels: HashMap<String, String> = HashMap::new();
+    let mut family_labels: HashMap<String, String> = HashMap::new();
+
+    for scenario in &dataset.scenarios {
+        let empty = ScenarioExecution {
+            _scenario_id: scenario.scenario_id.clone(),
+            step_results: vec![],
+            assertion_results: vec![],
+            error: Some("no execution".into()),
+        };
+        let exec = executions.get(&scenario.scenario_id).unwrap_or(&empty);
+        let result = score_scenario(scenario, exec);
+        by_diff
+            .entry(scenario.difficulty.clone())
+            .or_default()
+            .push(result.total_score);
+        if !scenario.domain.is_empty() {
+            by_domain
+                .entry(scenario.domain.clone())
+                .or_default()
+                .push(result.total_score);
+        }
+        for tag in &scenario.tags {
+            by_tag
+                .entry(tag.clone())
+                .or_default()
+                .push(result.total_score);
+        }
+        if let Some(family) = result.source_family.as_ref() {
+            by_family
+                .entry(family.clone())
+                .or_default()
+                .push(result.total_score);
+            family_labels.entry(family.clone()).or_insert_with(|| match family.as_str() {
+                "longmemeval" => "LongMemEval".into(),
+                "beam" => "BEAM".into(),
+                _ => family.clone(),
+            });
+        }
+        if let (Some(family), Some(category), Some(label)) = (
+            result.source_family.as_ref(),
+            result.official_category.as_ref(),
+            result.official_category_label.as_ref(),
+        ) {
+            if family == "longmemeval" {
+                by_lme_category
+                    .entry(category.clone())
+                    .or_default()
+                    .push(result.total_score);
+                lme_labels.entry(category.clone()).or_insert_with(|| label.clone());
+            } else if family == "beam" {
+                by_beam_ability
+                    .entry(category.clone())
+                    .or_default()
+                    .push(result.total_score);
+                beam_labels.entry(category.clone()).or_insert_with(|| label.clone());
+            }
+        }
+        results.push(result);
+    }
+
+    let avg = |v: &[f64]| {
+        if v.is_empty() {
+            0.0
+        } else {
+            v.iter().sum::<f64>() / v.len() as f64
+        }
+    };
+    let all: Vec<f64> = results.iter().map(|r| r.total_score).collect();
+    let overall = avg(&all);
+
+    BenchmarkReport {
+        dataset_id: dataset.dataset_id.clone(),
+        version: dataset.version.clone(),
+        scenario_count: results.len(),
+        overall_score: (overall * 100.0).round() / 100.0,
+        overall_grade: grade(overall).into(),
+        by_difficulty: by_diff
+            .iter()
+            .map(|(k, v)| (k.clone(), (avg(v) * 100.0).round() / 100.0))
+            .collect(),
+        by_tag: by_tag
+            .iter()
+            .map(|(k, v)| (k.clone(), (avg(v) * 100.0).round() / 100.0))
+            .collect(),
+        by_domain: by_domain
+            .iter()
+            .map(|(k, v)| (k.clone(), (avg(v) * 100.0).round() / 100.0))
+            .collect(),
+        by_source_family: category_breakdown(&by_family, &family_labels),
+        by_longmemeval_category: category_breakdown(&by_lme_category, &lme_labels),
+        by_beam_ability: category_breakdown(&by_beam_ability, &beam_labels),
+        results,
+    }
+}

--- a/memoria/crates/memoria-cli/src/benchmark_taxonomy.rs
+++ b/memoria/crates/memoria-cli/src/benchmark_taxonomy.rs
@@ -1,0 +1,174 @@
+use super::benchmark_schema::{CategoryBreakdown, Scenario};
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub fn grade(score: f64) -> &'static str {
+    if score >= 90.0 {
+        "S"
+    } else if score >= 80.0 {
+        "A"
+    } else if score >= 70.0 {
+        "B"
+    } else if score >= 60.0 {
+        "C"
+    } else {
+        "D"
+    }
+}
+
+fn normalize_key(value: &str) -> String {
+    value.trim()
+        .to_lowercase()
+        .replace([' ', '/', '-'], "_")
+        .replace("__", "_")
+}
+
+pub fn scenario_source_family(dataset_id: &str, scenario: &Scenario) -> Option<String> {
+    if let Some(value) = scenario.source_family.as_ref() {
+        let normalized = normalize_key(value);
+        if !normalized.is_empty() {
+            return Some(if normalized == "longmem" {
+                "longmemeval".into()
+            } else {
+                normalized
+            });
+        }
+    }
+    if let Some(Value::String(value)) = scenario.metadata.get("source_family") {
+        let normalized = normalize_key(value);
+        if !normalized.is_empty() {
+            return Some(if normalized == "longmem" {
+                "longmemeval".into()
+            } else {
+                normalized
+            });
+        }
+    }
+    let domain = normalize_key(&scenario.domain);
+    if domain == "beam" {
+        return Some("beam".into());
+    }
+    if domain == "longmem" || domain == "longmemeval" {
+        return Some("longmemeval".into());
+    }
+    let dataset_id = normalize_key(dataset_id);
+    if dataset_id.starts_with("beam") {
+        return Some("beam".into());
+    }
+    if dataset_id.starts_with("longmemeval") || dataset_id.contains("longmemeval") {
+        return Some("longmemeval".into());
+    }
+    None
+}
+
+pub fn scenario_question_type(scenario: &Scenario) -> Option<String> {
+    if let Some(value) = scenario.question_type.as_ref() {
+        let normalized = normalize_key(value);
+        if !normalized.is_empty() {
+            return Some(normalized);
+        }
+    }
+    if let Some(Value::String(value)) = scenario.metadata.get("question_type") {
+        let normalized = normalize_key(value);
+        if !normalized.is_empty() {
+            return Some(normalized);
+        }
+    }
+    if scenario.scenario_id.to_lowercase().ends_with("_abs") {
+        return Some("abstention".into());
+    }
+    None
+}
+
+fn longmemeval_category_label(category: &str) -> &'static str {
+    match category {
+        "single-session-user" => "Single-Session User",
+        "single-session-assistant" => "Single-Session Assistant",
+        "single-session-preference" => "Single-Session Preference",
+        "multi-session" => "Multi-Session",
+        "temporal-reasoning" => "Temporal Reasoning",
+        "knowledge-update" => "Knowledge Update",
+        "abstention" => "Abstention",
+        _ => "Unknown",
+    }
+}
+
+fn beam_ability_label(category: &str) -> &'static str {
+    match category {
+        "information_extraction" => "Information Extraction",
+        "preference_following" => "Preference Following",
+        "multi_session_reasoning" => "Multi-Session Reasoning",
+        "summarization" => "Summarization",
+        "temporal_reasoning" => "Temporal Reasoning",
+        "event_ordering" => "Event Ordering",
+        "knowledge_update" => "Knowledge Update",
+        "contradiction_resolution" => "Contradiction Resolution",
+        "abstention" => "Abstention",
+        "instruction_following" => "Instruction Following",
+        _ => "Unknown",
+    }
+}
+
+pub fn official_category(
+    source_family: Option<&str>,
+    question_type: Option<&str>,
+) -> Option<(String, String)> {
+    let family = source_family?;
+    let qtype = normalize_key(question_type?);
+    if family == "longmemeval" {
+        let canonical = match qtype.as_str() {
+            "single_session_user" => "single-session-user",
+            "single_session_assistant" => "single-session-assistant",
+            "single_session_preference" => "single-session-preference",
+            "multi_session" => "multi-session",
+            "temporal_reasoning" => "temporal-reasoning",
+            "knowledge_update" => "knowledge-update",
+            "abstention" => "abstention",
+            _ if qtype.ends_with("_abs") => "abstention",
+            _ => return None,
+        };
+        return Some((canonical.into(), longmemeval_category_label(canonical).into()));
+    }
+    if family == "beam" {
+        let canonical = match qtype.as_str() {
+            "information_extraction" => "information_extraction",
+            "preference_following" => "preference_following",
+            "multi_session_reasoning" => "multi_session_reasoning",
+            "summarization" => "summarization",
+            "temporal_reasoning" => "temporal_reasoning",
+            "event_ordering" => "event_ordering",
+            "knowledge_update" => "knowledge_update",
+            "contradiction_resolution" => "contradiction_resolution",
+            "abstention" => "abstention",
+            "instruction_following" => "instruction_following",
+            _ => return None,
+        };
+        return Some((canonical.into(), beam_ability_label(canonical).into()));
+    }
+    None
+}
+
+pub fn category_breakdown(
+    values: &HashMap<String, Vec<f64>>,
+    labels: &HashMap<String, String>,
+) -> HashMap<String, CategoryBreakdown> {
+    values
+        .iter()
+        .map(|(key, scores)| {
+            let avg = if scores.is_empty() {
+                0.0
+            } else {
+                scores.iter().sum::<f64>() / scores.len() as f64
+            };
+            (
+                key.clone(),
+                CategoryBreakdown {
+                    label: labels.get(key).cloned().unwrap_or_else(|| key.clone()),
+                    scenario_count: scores.len(),
+                    score: (avg * 100.0).round() / 100.0,
+                    grade: grade(avg).into(),
+                },
+            )
+        })
+        .collect()
+}

--- a/memoria/crates/memoria-cli/src/main.rs
+++ b/memoria/crates/memoria-cli/src/main.rs
@@ -1543,6 +1543,24 @@ fn cmd_benchmark(
     out: Option<&str>,
     validate_only: bool,
 ) {
+    fn print_category_breakdown(
+        heading: &str,
+        values: &std::collections::HashMap<String, benchmark::CategoryBreakdown>,
+    ) {
+        if values.is_empty() {
+            return;
+        }
+        let mut items: Vec<_> = values.iter().collect();
+        items.sort_by(|a, b| a.0.cmp(b.0));
+        println!("  {heading}:");
+        for (_key, item) in items {
+            println!(
+                "    {}: {:.1} ({}) [{}]",
+                item.label, item.score, item.grade, item.scenario_count
+            );
+        }
+    }
+
     let dataset_path = {
         let p = Path::new(dataset);
         if p.exists() {
@@ -1621,7 +1639,7 @@ fn cmd_benchmark(
     );
     if !report.by_difficulty.is_empty() {
         let mut items: Vec<_> = report.by_difficulty.iter().collect();
-        items.sort_by_key(|(k, _)| k.to_string());
+        items.sort_by(|a, b| a.0.cmp(b.0));
         print!("  By difficulty:");
         for (k, v) in &items {
             print!(" {k}={v:.1}");
@@ -1630,13 +1648,25 @@ fn cmd_benchmark(
     }
     if !report.by_tag.is_empty() {
         let mut items: Vec<_> = report.by_tag.iter().collect();
-        items.sort_by_key(|(k, _)| k.to_string());
+        items.sort_by(|a, b| a.0.cmp(b.0));
         print!("  By tag:");
         for (k, v) in &items {
             print!(" {k}={v:.1}");
         }
         println!();
     }
+    if !report.by_domain.is_empty() {
+        let mut items: Vec<_> = report.by_domain.iter().collect();
+        items.sort_by(|a, b| a.0.cmp(b.0));
+        print!("  By domain:");
+        for (k, v) in &items {
+            print!(" {k}={v:.1}");
+        }
+        println!();
+    }
+    print_category_breakdown("By source family", &report.by_source_family);
+    print_category_breakdown("LongMemEval official categories", &report.by_longmemeval_category);
+    print_category_breakdown("BEAM official abilities", &report.by_beam_ability);
 
     if let Some(path) = out {
         let json = serde_json::to_string_pretty(&report).unwrap();

--- a/scripts/rollup_benchmark_report.py
+++ b/scripts/rollup_benchmark_report.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Add a normalized 6-bucket memory-ability rollup to benchmark JSON reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+TAXONOMY_VERSION = "v1"
+
+BUCKETS: list[dict[str, str]] = [
+    {
+        "key": "single_session_grounding",
+        "label": "Single-Session Grounding",
+        "description": "Direct factual or contextual grounding within one session.",
+    },
+    {
+        "key": "preference_understanding",
+        "label": "Preference Understanding",
+        "description": "Capturing and applying user preferences beyond keyword matching.",
+    },
+    {
+        "key": "multi_session_synthesis",
+        "label": "Multi-Session Synthesis",
+        "description": "Combining information across multiple sessions into a coherent answer.",
+    },
+    {
+        "key": "temporal_state_tracking",
+        "label": "Temporal State Tracking",
+        "description": "Reasoning about time, chronology, order, and evolving state.",
+    },
+    {
+        "key": "knowledge_update_and_conflict_handling",
+        "label": "Knowledge Update And Conflict Handling",
+        "description": "Resolving stale-vs-current knowledge and handling contradictions.",
+    },
+    {
+        "key": "abstention_and_constraint_following",
+        "label": "Abstention And Constraint Following",
+        "description": "Refusing unsupported answers and following remembered instructions or constraints.",
+    },
+]
+
+BUCKET_BY_KEY = {bucket["key"]: bucket for bucket in BUCKETS}
+
+LONGMEMEVAL_BUCKET_MAP = {
+    "single_session_user": "single_session_grounding",
+    "single_session_assistant": "single_session_grounding",
+    "single_session_preference": "preference_understanding",
+    "multi_session": "multi_session_synthesis",
+    "temporal_reasoning": "temporal_state_tracking",
+    "knowledge_update": "knowledge_update_and_conflict_handling",
+    "abstention": "abstention_and_constraint_following",
+}
+
+BEAM_BUCKET_MAP = {
+    "information_extraction": "single_session_grounding",
+    "preference_following": "preference_understanding",
+    "multi_session_reasoning": "multi_session_synthesis",
+    "summarization": "multi_session_synthesis",
+    "temporal_reasoning": "temporal_state_tracking",
+    "event_ordering": "temporal_state_tracking",
+    "knowledge_update": "knowledge_update_and_conflict_handling",
+    "contradiction_resolution": "knowledge_update_and_conflict_handling",
+    "abstention": "abstention_and_constraint_following",
+    "instruction_following": "abstention_and_constraint_following",
+}
+
+
+def normalize_text(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    for ch in (" ", "-", "/", ":", "."):
+        text = text.replace(ch, "_")
+    while "__" in text:
+        text = text.replace("__", "_")
+    return text.strip("_")
+
+
+def grade_from_score(score: float) -> str:
+    if score >= 95:
+        return "S"
+    if score >= 85:
+        return "A"
+    if score >= 75:
+        return "B"
+    if score >= 60:
+        return "C"
+    return "D"
+
+
+def infer_source_family(payload: dict[str, Any], result: dict[str, Any]) -> str:
+    candidates = [
+        result.get("source_family"),
+        result.get("dataset_family"),
+        (result.get("metadata") or {}).get("source_family"),
+        (result.get("gold_reference") or {}).get("source_family"),
+        (result.get("scenario") or {}).get("domain"),
+        payload.get("source_family"),
+        payload.get("dataset_family"),
+    ]
+    dataset_id = str(payload.get("dataset_id") or "").lower()
+    for candidate in candidates:
+        normalized = normalize_text(candidate)
+        if normalized in {"longmemeval", "longmem"}:
+            return "longmemeval"
+        if normalized == "beam":
+            return "beam"
+    if dataset_id.startswith("beam"):
+        return "beam"
+    return "longmemeval"
+
+
+def infer_question_type(result: dict[str, Any]) -> str:
+    candidates = [
+        result.get("question_type"),
+        (result.get("metadata") or {}).get("question_type"),
+        (result.get("gold_reference") or {}).get("question_type"),
+        (result.get("scenario") or {}).get("question_type"),
+        ((result.get("scenario") or {}).get("metadata") or {}).get("question_type"),
+        result.get("title"),
+        (result.get("scenario") or {}).get("title"),
+    ]
+    for candidate in candidates:
+        if candidate:
+            return normalize_text(candidate)
+    scenario_id = normalize_text(result.get("scenario_id"))
+    if scenario_id.endswith("_abs"):
+        return "abstention"
+    return "unknown"
+
+
+def infer_bucket(source_family: str, question_type: str) -> str:
+    qtype = normalize_text(question_type)
+    if source_family == "beam":
+        if qtype in BEAM_BUCKET_MAP:
+            return BEAM_BUCKET_MAP[qtype]
+    else:
+        if qtype in LONGMEMEVAL_BUCKET_MAP:
+            return LONGMEMEVAL_BUCKET_MAP[qtype]
+        if qtype.endswith("_abs"):
+            return "abstention_and_constraint_following"
+
+    if "preference" in qtype:
+        return "preference_understanding"
+    if "summar" in qtype or ("multi" in qtype and "session" in qtype):
+        return "multi_session_synthesis"
+    if "temporal" in qtype or "ordering" in qtype or "timeline" in qtype:
+        return "temporal_state_tracking"
+    if (
+        "update" in qtype
+        or "contradiction" in qtype
+        or "conflict" in qtype
+        or "stale" in qtype
+    ):
+        return "knowledge_update_and_conflict_handling"
+    if "abstention" in qtype or "instruction" in qtype or "constraint" in qtype:
+        return "abstention_and_constraint_following"
+    return "single_session_grounding"
+
+
+def infer_score(result: dict[str, Any]) -> float | None:
+    for key in ("total_score", "score", "overall_score"):
+        value = result.get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+    return None
+
+
+def infer_passed(result: dict[str, Any], score: float | None) -> bool | None:
+    passed = result.get("passed")
+    if isinstance(passed, bool):
+        return passed
+    verdict = str(result.get("verdict") or "").strip().lower()
+    if verdict:
+        if verdict in {"passed", "pass", "correct"}:
+            return True
+        if verdict in {"failed", "fail", "incorrect", "runner_error"}:
+            return False
+    if score is not None:
+        return score >= 100.0
+    return None
+
+
+def summarize_bucket(results: list[dict[str, Any]]) -> dict[str, Any]:
+    scored = [result["_normalized_score"] for result in results if result["_normalized_score"] is not None]
+    pass_values = [result["_normalized_passed"] for result in results if result["_normalized_passed"] is not None]
+    question_type_counts = Counter(result["_normalized_question_type"] for result in results)
+    source_family_counts = Counter(result["_normalized_source_family"] for result in results)
+    score = round(sum(scored) / len(scored), 2) if scored else None
+    pass_rate = round(100.0 * sum(1 for value in pass_values if value) / len(pass_values), 2) if pass_values else None
+    return {
+        "scenario_count": len(results),
+        "score": score,
+        "grade": grade_from_score(score) if score is not None else None,
+        "pass_rate": pass_rate,
+        "pass_count": sum(1 for value in pass_values if value),
+        "scored_scenario_count": len(scored),
+        "sample_scenario_ids": [result.get("scenario_id") for result in results[:10] if result.get("scenario_id")],
+        "question_type_counts": dict(sorted(question_type_counts.items())),
+        "source_family_counts": dict(sorted(source_family_counts.items())),
+    }
+
+
+def augment_report(payload: dict[str, Any]) -> bool:
+    results = payload.get("results")
+    if not isinstance(results, list) or not results:
+        return False
+
+    bucket_results: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        source_family = infer_source_family(payload, result)
+        question_type = infer_question_type(result)
+        bucket_key = infer_bucket(source_family, question_type)
+        score = infer_score(result)
+        passed = infer_passed(result, score)
+
+        result["memory_ability_bucket"] = bucket_key
+        result["memory_ability_bucket_label"] = BUCKET_BY_KEY[bucket_key]["label"]
+        result["_normalized_source_family"] = source_family
+        result["_normalized_question_type"] = question_type
+        result["_normalized_score"] = score
+        result["_normalized_passed"] = passed
+        bucket_results[bucket_key].append(result)
+
+    payload["memory_ability_taxonomy"] = {
+        "version": TAXONOMY_VERSION,
+        "buckets": BUCKETS,
+        "notes": [
+            "This rollup normalizes LongMemEval and BEAM into shared memory-ability buckets.",
+            "Raw benchmark labels remain the source of truth and are preserved per result.",
+            "Use these buckets for cross-benchmark Memoria reporting, not as a replacement for official benchmark categories.",
+        ],
+    }
+    payload["by_memory_ability_bucket"] = {
+        bucket["key"]: {
+            "label": bucket["label"],
+            "description": bucket["description"],
+            **summarize_bucket(bucket_results[bucket["key"]]),
+        }
+        for bucket in BUCKETS
+        if bucket_results.get(bucket["key"])
+    }
+
+    for result in results:
+        result.pop("_normalized_source_family", None)
+        result.pop("_normalized_question_type", None)
+        result.pop("_normalized_score", None)
+        result.pop("_normalized_passed", None)
+    return True
+
+
+def iter_report_paths(paths: list[str]) -> list[Path]:
+    resolved: list[Path] = []
+    for raw in paths:
+        path = Path(raw)
+        if path.is_dir():
+            resolved.extend(sorted(path.rglob("*.report.json")))
+            resolved.extend(sorted(path.rglob("*.qa.report.json")))
+            continue
+        resolved.append(path)
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for path in resolved:
+        resolved_path = path.resolve()
+        if resolved_path not in seen:
+            seen.add(resolved_path)
+            unique.append(resolved_path)
+    return unique
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Normalize benchmark JSON reports into a shared 6-bucket memory taxonomy."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        help="Report files or directories containing *.report.json / *.qa.report.json files.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the paths that would be updated without rewriting them.",
+    )
+    args = parser.parse_args()
+
+    changed = 0
+    for path in iter_report_paths(args.paths):
+        if not path.exists():
+            print(f"skip missing: {path}")
+            continue
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not augment_report(payload):
+            print(f"skip unsupported: {path}")
+            continue
+        if args.dry_run:
+            print(f"would update: {path}")
+        else:
+            path.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            print(f"updated: {path}")
+        changed += 1
+    if changed == 0:
+        raise SystemExit("no benchmark reports updated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- separate Rust benchmark internals into schema / executor / taxonomy / scoring modules inside `memoria-cli`
- keep benchmark evolution isolated from `memoria-service`, `memoria-storage`, and `memoria-api`
- add official LongMemEval category reporting and official BEAM ability reporting to benchmark outputs
- keep the optional rollup taxonomy as a secondary helper, not the primary reporting path

## Verification
- `cargo check -p memoria-cli`
- `cargo test -p memoria-cli`
- live smoke benchmark against `http://127.0.0.1:18100`
  - LongMemEval smoke: verified `by_source_family`, `by_longmemeval_category`, and per-result official category fields
  - BEAM smoke: verified `by_source_family`, `by_beam_ability`, and per-result official category fields

## Notes
- benchmark changes are contained within `memoria-cli`
- no changes to core service / storage / API behavior
