### PR TITLE
build(ci): switch Linux release binaries to musl static linking

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -28,15 +28,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-          - target: aarch64-unknown-linux-gnu
+            strip_bin: strip
+          - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             cross: true
+            strip_bin: aarch64-linux-gnu-strip
           - target: x86_64-apple-darwin
             os: macos-latest
+            strip_bin: strip
           - target: aarch64-apple-darwin
             os: macos-latest
+            strip_bin: strip
 
     steps:
       - uses: actions/checkout@v4
@@ -52,11 +56,17 @@ jobs:
           workspaces: memoria
           shared-key: release-${{ matrix.target }}
 
-      - name: Install build deps (x86_64-linux)
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
+      - name: Install build deps (x86_64-linux-musl)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev
+          sudo apt-get install -y musl-tools
+
+      - name: Install strip tool (aarch64-linux-musl)
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y binutils-aarch64-linux-gnu
 
       - name: Install cross
         if: matrix.cross
@@ -80,6 +90,7 @@ jobs:
         run: |
           mkdir -p dist
           cp memoria/target/${{ matrix.target }}/release/memoria dist/ 2>/dev/null || true
+          ${{ matrix.strip_bin }} dist/memoria 2>/dev/null || true
           cd dist && tar czf ../memoria-${{ matrix.target }}.tar.gz *
 
       - uses: actions/upload-artifact@v4

--- a/memoria/Cross.toml
+++ b/memoria/Cross.toml
@@ -1,4 +1,4 @@
-[target.aarch64-unknown-linux-gnu]
+[target.aarch64-unknown-linux-musl]
 # No special setup needed — we use rustls (pure Rust TLS), no system OpenSSL required.
 
 [build.env]

--- a/memoria/Makefile
+++ b/memoria/Makefile
@@ -4,7 +4,8 @@ export
 DATABASE_URL ?= mysql://root:111@localhost:6001/memoria
 CARGO = SQLX_OFFLINE=true DATABASE_URL=$(DATABASE_URL) cargo
 
-.PHONY: check test test-unit test-integration build clean
+.PHONY: check test test-unit test-integration build clean \
+        build-musl build-aarch64-musl build-all-musl
 
 check:
 	$(CARGO) check
@@ -42,3 +43,34 @@ test:
 
 clean:
 	cargo clean
+
+# ── Cross-compilation (mirrors CI release-rust.yml) ─────────────────
+#
+# Requires:
+#   x86_64 musl : sudo apt-get install musl-tools
+#                 rustup target add x86_64-unknown-linux-musl
+#   aarch64 musl: cargo install cross  (uses Docker; uses separate target/cross/ dir
+#                 to avoid glibc cache conflicts with native builds)
+#                 sudo apt-get install binutils-aarch64-linux-gnu  (for strip)
+
+build-musl:
+	@echo "Building x86_64-unknown-linux-musl..."
+	SQLX_OFFLINE=true cargo build --release -p memoria-cli --target x86_64-unknown-linux-musl
+	@strip target/x86_64-unknown-linux-musl/release/memoria
+	@echo "Binary: target/x86_64-unknown-linux-musl/release/memoria ($(shell du -sh target/x86_64-unknown-linux-musl/release/memoria | cut -f1), statically linked)"
+	@ldd target/x86_64-unknown-linux-musl/release/memoria 2>&1 | grep -E 'statically|not a dynamic'
+
+build-aarch64-musl:
+	@command -v cross >/dev/null 2>&1 || { echo "❌ cross not installed. Run: cargo install cross"; exit 1; }
+	@command -v docker >/dev/null 2>&1 || { echo "❌ docker not running. cross requires Docker"; exit 1; }
+	@echo "Building aarch64-unknown-linux-musl (via cross)..."
+	SQLX_OFFLINE=true CARGO_TARGET_DIR=target/cross \
+		cross build --release -p memoria-cli --target aarch64-unknown-linux-musl
+	@aarch64-linux-gnu-strip target/cross/aarch64-unknown-linux-musl/release/memoria 2>/dev/null || \
+		echo "⚠️  strip skipped (install: sudo apt-get install binutils-aarch64-linux-gnu)"
+	@echo "Binary: target/cross/aarch64-unknown-linux-musl/release/memoria ($(shell du -sh target/cross/aarch64-unknown-linux-musl/release/memoria | cut -f1))"
+
+build-all-musl: build-musl build-aarch64-musl
+	@echo "✅ Both musl binaries ready"
+	@ls -lh target/x86_64-unknown-linux-musl/release/memoria \
+	         target/cross/aarch64-unknown-linux-musl/release/memoria

--- a/plugins/openclaw/scripts/install-openclaw-memoria.sh
+++ b/plugins/openclaw/scripts/install-openclaw-memoria.sh
@@ -213,8 +213,8 @@ resolve_memoria_target() {
   esac
   case "${os}" in
     linux)
-      [[ "${arch}" == "x86_64" ]] && printf 'x86_64-unknown-linux-gnu' && return 0
-      [[ "${arch}" == "aarch64" ]] && printf 'aarch64-unknown-linux-gnu' && return 0
+      [[ "${arch}" == "x86_64" ]] && printf 'x86_64-unknown-linux-musl' && return 0
+      [[ "${arch}" == "aarch64" ]] && printf 'aarch64-unknown-linux-musl' && return 0
       ;;
     darwin)
       [[ "${arch}" == "x86_64" ]] && printf 'x86_64-apple-darwin' && return 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -72,8 +72,8 @@ detect_target() {
   esac
   case "$os" in
     linux)
-      [ "$arch" = "x86_64" ] && printf "x86_64-unknown-linux-gnu" && return
-      [ "$arch" = "aarch64" ] && printf "aarch64-unknown-linux-gnu" && return
+      [ "$arch" = "x86_64" ] && printf "x86_64-unknown-linux-musl" && return
+      [ "$arch" = "aarch64" ] && printf "aarch64-unknown-linux-musl" && return
       ;;
     darwin)
       [ "$arch" = "x86_64" ] && printf "x86_64-apple-darwin" && return

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -42,8 +42,8 @@ Ask: "Do you have an OpenAI-compatible embedding endpoint?"
 
 ```bash
 # Linux x86_64
-curl -LO https://github.com/matrixorigin/Memoria/releases/latest/download/memoria-x86_64-unknown-linux-gnu.tar.gz
-tar xzf memoria-x86_64-unknown-linux-gnu.tar.gz && sudo mv memoria /usr/local/bin/
+curl -LO https://github.com/matrixorigin/Memoria/releases/latest/download/memoria-x86_64-unknown-linux-musl.tar.gz
+tar xzf memoria-x86_64-unknown-linux-musl.tar.gz && sudo mv memoria /usr/local/bin/
 
 # macOS Apple Silicon
 curl -LO https://github.com/matrixorigin/Memoria/releases/latest/download/memoria-aarch64-apple-darwin.tar.gz


### PR DESCRIPTION
## What type of PR is this?

- [x] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes #

## What this PR does / why we need it

Switch Linux release binaries from dynamically-linked glibc (`-gnu`) to
fully static musl (`-musl`), eliminating glibc version compatibility issues.

### Problem

The `x86_64-unknown-linux-gnu` binary compiled on `ubuntu-latest` (glibc 2.39)
cannot run on older systems (e.g. CentOS 7 / glibc 2.17, Ubuntu 20.04 / glibc 2.31).
Verified locally:

```
# gnu binary on CentOS 7 (glibc 2.17):
GLIBC_2.27 not found, GLIBC_2.29 not found, ... GLIBC_2.39 not found → crash

# musl binary on same system:
memoria 0.2.0 → works
```

No OpenSSL changes needed — project already uses `rustls` + `reqwest/rustls-tls`.

### Changes

- **CI** (`release-rust.yml`): change Linux targets to `x86_64-unknown-linux-musl`
  and `aarch64-unknown-linux-musl`; add `strip` step (binary: ~27 MB → ~22 MB);
  install `binutils-aarch64-linux-gnu` for aarch64 strip support
- **Cross.toml**: update target section to `aarch64-unknown-linux-musl`
- **Makefile** (`memoria/Makefile`): add `build-musl`, `build-aarch64-musl`,
  `build-all-musl` targets for local cross-compilation mirroring CI;
  aarch64 uses `CARGO_TARGET_DIR=target/cross` to avoid glibc cache conflicts
  between native and `cross` builds
- **Install scripts**: update `resolve_target` in `scripts/install.sh` and
  `plugins/openclaw/scripts/install-openclaw-memoria.sh` to use musl triple
- **Docs**: update `README.md` and `skills/setup/SKILL.md` download examples
