### PR TITLE
fix(openclaw): make verify fail on unhealthy backend

### DIFF
--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -332,6 +332,7 @@ openclaw ltm list --limit 10
 Notes:
 
 - `openclaw memoria capabilities` is a config/plugin check and does not require a live Memoria backend
+- `openclaw memoria verify` now includes `openclaw memoria health`, so it fails if the configured backend is unreachable even when plugin/config wiring looks correct
 - `openclaw memoria stats` and `openclaw ltm list` require the configured backend to be reachable; in embedded mode that means MatrixOne must be up and the embedding config must be valid
 - OpenClaw reserves `openclaw memory` for its built-in file memory, so this plugin uses `openclaw memoria` and the compatibility alias `openclaw ltm`
 - `openclaw memoria setup` is the recommended onboarding command for cloud/local setup

--- a/plugins/openclaw/scripts/verify_plugin_install.mjs
+++ b/plugins/openclaw/scripts/verify_plugin_install.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
@@ -23,6 +23,27 @@ function run(command, args) {
   }).trim();
 }
 
+function runResult(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  return {
+    status: typeof result.status === "number" ? result.status : null,
+    signal: result.signal ?? null,
+    stdout: typeof result.stdout === "string" ? result.stdout.trim() : "",
+    stderr: typeof result.stderr === "string" ? result.stderr.trim() : "",
+    error: result.error ? String(result.error) : null,
+  };
+}
+
+function stripAnsi(value) {
+  return typeof value === "string"
+    ? value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "")
+    : "";
+}
+
 function tryParseJson(raw) {
   try {
     return JSON.parse(raw);
@@ -32,16 +53,17 @@ function tryParseJson(raw) {
 }
 
 function parseCommandJson(raw) {
-  const direct = tryParseJson(raw);
+  const cleaned = stripAnsi(raw).trim();
+  const direct = tryParseJson(cleaned);
   if (direct) {
     return direct;
   }
-  const start = raw.indexOf("{");
-  const end = raw.lastIndexOf("}");
+  const start = cleaned.indexOf("{");
+  const end = cleaned.lastIndexOf("}");
   if (start >= 0 && end > start) {
-    return tryParseJson(raw.slice(start, end + 1)) ?? raw;
+    return tryParseJson(cleaned.slice(start, end + 1)) ?? cleaned;
   }
-  return raw;
+  return cleaned;
 }
 
 function parsePort(rawProtocol, rawPort) {
@@ -89,6 +111,11 @@ if (pluginConfig.memoriaExecutable == null) {
 }
 
 const resolvedMemoriaBin = pluginConfig.memoriaExecutable || memoriaBin;
+const backend = pluginConfig.backend ?? "embedded";
+const userId =
+  typeof pluginConfig.defaultUserId === "string" && pluginConfig.defaultUserId.trim()
+    ? pluginConfig.defaultUserId.trim()
+    : "openclaw-user";
 const openclawVersion = run(openclawBin, ["--version"]);
 const configValidation = tryParseJson(run(openclawBin, ["config", "validate", "--json"]));
 const memoriaVersion = run(resolvedMemoriaBin, ["--version"]);
@@ -105,14 +132,51 @@ const result = {
   memoriaVersion,
   memoriaExecutable: pluginConfig.memoriaExecutable,
   configValidation,
+  healthCheck: {
+    performed: true,
+    ok: false,
+    backend,
+    userId,
+  },
   deepChecks: {
-    backend: pluginConfig.backend ?? "embedded",
+    backend,
     performed: false,
     skipped: null,
   },
 };
 
-if ((pluginConfig.backend ?? "embedded") === "embedded" && typeof pluginConfig.dbUrl === "string") {
+const healthResult = runResult(openclawBin, ["memoria", "health", "--user-id", userId]);
+result.healthCheck.exitStatus = healthResult.status;
+result.healthCheck.stdout = parseCommandJson(healthResult.stdout);
+if (healthResult.stderr) {
+  result.healthCheck.stderr = healthResult.stderr;
+}
+if (healthResult.error) {
+  result.healthCheck.error = healthResult.error;
+}
+if (healthResult.status === 0) {
+  result.healthCheck.ok = true;
+} else {
+  const hints = [];
+  if (backend === "embedded" && typeof pluginConfig.dbUrl === "string") {
+    hints.push(`Verify MatrixOne is reachable at ${pluginConfig.dbUrl}.`);
+  }
+  if (backend === "embedded" && pluginConfig.embeddingProvider === "local") {
+    hints.push(
+      "embeddingProvider=local requires a memoria binary built with local-embedding support; otherwise setup may validate but health/search will fail at runtime.",
+    );
+  }
+  if (backend === "http" && typeof pluginConfig.apiUrl === "string") {
+    hints.push(`Verify the remote Memoria API is healthy and reachable at ${pluginConfig.apiUrl}.`);
+  }
+
+  result.ok = false;
+  result.healthCheck.hints = hints;
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(1);
+}
+
+if (backend === "embedded" && typeof pluginConfig.dbUrl === "string") {
   const dbUrl = new URL(pluginConfig.dbUrl);
   const dbReachable = await checkTcp(
     dbUrl.hostname || "127.0.0.1",
@@ -123,10 +187,6 @@ if ((pluginConfig.backend ?? "embedded") === "embedded" && typeof pluginConfig.d
   result.deepChecks.dbReachable = dbReachable;
 
   if (dbReachable) {
-    const userId =
-      typeof pluginConfig.defaultUserId === "string" && pluginConfig.defaultUserId.trim()
-        ? pluginConfig.defaultUserId.trim()
-        : "openclaw-user";
     const statsRaw = run(openclawBin, ["memoria", "stats", "--user-id", userId]);
     const listRaw = run(openclawBin, ["ltm", "list", "--limit", "1", "--user-id", userId]);
     result.deepChecks.performed = true;
@@ -134,16 +194,17 @@ if ((pluginConfig.backend ?? "embedded") === "embedded" && typeof pluginConfig.d
     result.deepChecks.stats = parseCommandJson(statsRaw);
     result.deepChecks.list = parseCommandJson(listRaw);
   } else {
+    result.ok = false;
     result.deepChecks.skipped = "Embedded database is not reachable; skipped stats/list verification.";
   }
 } else {
-  result.deepChecks.skipped = "Deep verification is only automatic for embedded mode.";
+  const listRaw = run(openclawBin, ["ltm", "list", "--limit", "1", "--user-id", userId]);
+  result.deepChecks.performed = true;
+  result.deepChecks.userId = userId;
+  result.deepChecks.list = parseCommandJson(listRaw);
 }
 
-console.log(
-  JSON.stringify(
-    result,
-    null,
-    2,
-  ),
-);
+console.log(JSON.stringify(result, null, 2));
+if (!result.ok) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- make `openclaw memoria verify` run a real `openclaw memoria health` check before reporting success
- fail verification when the configured backend is unreachable, even if plugin/config wiring looks valid
- include backend-specific hints in the verification output and document the stricter verify behavior in the README

## Why
I hit a local false-positive case where `verify` returned `ok: true` even though the configured Memoria backend was not healthy and normal memory operations were already failing at runtime.

That made `verify` good at checking install wiring, but not good enough at answering the practical question users care about: "is this setup actually usable right now?"

This change makes `verify` a better post-install / post-setup diagnostic by requiring a successful health check before it reports success.

## What changed
- add a non-throwing command runner in `verify_plugin_install.mjs`
- run `openclaw memoria health --user-id ...` as part of verification
- return a non-zero exit when health fails
- keep backend-specific hints in the output:
  - embedded: check MatrixOne reachability
  - embedded + `embeddingProvider=local`: remind users that the binary must be built with `local-embedding`
  - http: check remote API reachability
- keep deeper follow-up checks after health succeeds
- update README verification notes

## Local testing
Passed locally:
- `node --check plugins/openclaw/scripts/connect_openclaw_memoria.mjs`
- `node --check plugins/openclaw/scripts/verify_plugin_install.mjs`
- connector smoke test with a temp config path (`connect_openclaw_memoria.mjs` writes the expected cloud config)
- reproduced the original false-positive scenario and confirmed `verify_plugin_install.mjs` now exits non-zero with health details and hints instead of returning `ok: true`
