### PR TITLE
chore(plugin): bump to v0.4.1 for npm republish

### DIFF
--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "thememoria",
   "name": "Memoria",
   "description": "Memoria-backed long-term memory plugin for OpenClaw powered by the Rust memoria CLI and API.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "kind": "memory",
   "uiHints": {
     "backend": {

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matrixorigin/thememoria",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "OpenClaw memory plugin that uses the Rust Memoria CLI/API for embedded and remote backends.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

Published `@matrixorigin/thememoria` v0.4.0 tarball was built from stale pre-rename code:

- `openclaw.plugin.json` had `id: "memory-memoria"` instead of `"thememoria"`
- `index.ts` lacked the cloud mode HTTP health check fix (required memoria binary for all modes)

This caused OpenClaw to:
1. Install the plugin as `memory-memoria` (wrong id)
2. Require the memoria binary even for `--mode cloud` / `backend: api`

## Fix

Version bump to 0.4.1 in `package.json` and `openclaw.plugin.json`. No code changes — the correct code was already merged in PR #101, just never made it into the v0.4.0 npm tarball.

## Verification

- 100/100 tests pass
- `npm pack --dry-run` confirms correct manifest (`id: thememoria`, `version: 0.4.1`)
- After merge, republish with `npm publish --access public`