### PR TITLE
ci: add GitHub Actions workflow for npm publishing + update npm package version to 0.4.2

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,62 @@
+name: Release OpenClaw npm Package
+
+# Trigger: push a tag like openclaw-v*.*.* or run manually.
+on:
+  push:
+    tags:
+      - 'openclaw-v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.4.3). Leave empty to publish current package.json version.'
+        required: false
+        type: string
+
+jobs:
+  test:
+    name: Test OpenClaw Plugin
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/openclaw
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: plugins/openclaw/package-lock.json
+      - run: npm ci
+      - run: npm test
+
+  publish:
+    name: Publish to npm
+    needs: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/openclaw
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Set version (if provided)
+        if: inputs.version != ''
+        run: npm version ${{ inputs.version }} --no-git-tag-version
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Get published version
+        id: pkg
+        run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        run: echo "### Published @matrixorigin/thememoria@${{ steps.pkg.outputs.version }} ✅" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ scripts/migrate_embedding_dim.sh
 
 # Plugin dev keys
 dev-signing-key.b64
+.npmrc

--- a/plugins/openclaw/package-lock.json
+++ b/plugins/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@matrixorigin/thememoria",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@matrixorigin/thememoria",
-      "version": "0.4.0",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matrixorigin/thememoria",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "OpenClaw memory plugin that uses the Rust Memoria CLI/API for embedded and remote backends.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What

Adds automated npm publishing for the OpenClaw plugin (`@matrixorigin/thememoria`).

## Changes

- **`.github/workflows/release-npm.yml`**: New workflow that:
  - Triggers on `openclaw-v*.*.*` tags or manual `workflow_dispatch`
  - Runs vitest tests before publishing
  - Publishes to npm using `NPM_TOKEN` secret
  - Supports optional version override via manual dispatch input
- **`.gitignore`**: Added `.npmrc` to prevent accidental token commits
- **`plugins/openclaw/package.json`**: Version bump to 0.4.2 (already published)

## Setup Required

After merging, add the npm token as a repo secret:
1. Go to Settings → Secrets and variables → Actions
2. Add `NPM_TOKEN` with the npm publish token

## Usage

```bash
# Tag-based release
git tag openclaw-v0.4.3
git push origin openclaw-v0.4.3

# Or manual dispatch from Actions tab
```