### PR TITLE
docs: propose role-scoped memory with internal scope model

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ openclaw plugins enable memory-memoria
 openclaw memoria install
 ```
 
+Design note:
+- [Role-Scoped Memory Spaces with Inheritance](docs/role-scoped-memory-spaces.md)
+
 ### 🦞 OpenClaw Plugin (Already Using OpenClaw?)
 
 Use the native OpenClaw plugin guide: [OpenClaw Plugin Setup](plugins/openclaw/README.md).

--- a/docs/role-scoped-memory-spaces.md
+++ b/docs/role-scoped-memory-spaces.md
@@ -4,6 +4,10 @@
 
 This document proposes **role-scoped memory spaces** as a first-class collaboration primitive in Memoria.
 
+User-facing surfaces should prefer the term **role** because it matches how people think about collaborators such as `writer`, `reviewer`, or `github-ops`.
+
+Internally, Memoria can still model this as a more general **scope** abstraction so the system can later support other inherited overlays beyond roles.
+
 Example:
 
 ```text
@@ -88,16 +92,16 @@ where:
 
 ## Desired capabilities
 
-### Scope lifecycle
+### Role lifecycle (user-facing)
 
-- create role based on a parent scope
-- list available role scopes
-- inspect role parent
-- delete role scope
+- create role based on a parent role/scope
+- list available roles
+- inspect role parent / lineage
+- delete role
 
 ### Memory operations
 
-- store memory into a specific scope
+- store memory into a specific role/scope
 - recall from `main` only
 - recall from `main + role`
 - optionally recall from role-only or parent-only
@@ -133,6 +137,8 @@ POST /v1/roles
   "based_on": "main"
 }
 ```
+
+The API may still map this internally onto a generic scope record.
 
 ### List roles
 
@@ -170,6 +176,19 @@ Server-side semantics:
 ## Data model direction
 
 A generic scope abstraction is likely more future-proof than a hard-coded `role` field.
+
+That leads to a two-layer model:
+
+- **user-facing CLI / product language**: `role`
+- **internal storage / execution model**: `scope`
+
+For example, a user may run:
+
+```bash
+memoria role create writer --based-on main
+```
+
+while the backend stores this as a named inherited scope.
 
 ### Option A: scope fields
 

--- a/docs/role-scoped-memory-spaces.md
+++ b/docs/role-scoped-memory-spaces.md
@@ -1,0 +1,242 @@
+# Role-Scoped Memory Spaces with Inheritance
+
+## Summary
+
+This document proposes **role-scoped memory spaces** as a first-class collaboration primitive in Memoria.
+
+Example:
+
+```text
+create role "writer" based on main
+```
+
+The goal is to let clients share a common base memory space while keeping role-specific procedural rules, heuristics, and working preferences separate.
+
+## Motivation
+
+Multi-agent systems often need two things at the same time:
+
+1. **Shared user/base memory**
+   - preferences
+   - stable facts
+   - global boundaries
+   - long-term operating context
+
+2. **Role-specific overlays**
+   - writer rules
+   - reviewer rules
+   - github-ops rules
+   - planner/executor differences
+
+Today, clients can approximate this by:
+
+- encoding role labels in raw content
+- splitting into separate user IDs
+- overloading branch/snapshot semantics
+
+All three are awkward.
+
+## Why role scope is not the same as branch/snapshot
+
+Memoria already has strong Git-like ideas such as snapshots, rollback, branch, merge, and diff.
+
+Those are best suited for:
+
+- experimentation
+- recovery from mistakes
+- version control
+- rollback
+- comparing alternate evolution paths
+
+By contrast, **role scope** is better suited for:
+
+- collaboration
+- stable inherited overlays
+- role separation without cloning the full user memory base
+- retrieving a shared base plus role-specific deltas
+
+A useful distinction is:
+
+- **branch/snapshot answers**: _which version?_
+- **role answers**: _which collaborator / viewpoint?_
+
+## Proposed model
+
+### Base scope
+
+Every user has a shared base scope:
+
+- `main`
+
+### Role scopes
+
+Clients can create named role scopes that inherit from `main`:
+
+- `writer`
+- `reviewer`
+- `github-ops`
+- `tech-analyst`
+
+A recall against `writer` would effectively resolve as:
+
+- `main` + `writer`
+
+where:
+
+- `main` provides shared/global memory
+- `writer` provides role-local delta memory
+
+## Desired capabilities
+
+### Scope lifecycle
+
+- create role based on a parent scope
+- list available role scopes
+- inspect role parent
+- delete role scope
+
+### Memory operations
+
+- store memory into a specific scope
+- recall from `main` only
+- recall from `main + role`
+- optionally recall from role-only or parent-only
+
+### Introspection
+
+- stats per scope
+- diff role vs parent
+- snapshot / rollback an individual role scope
+
+## Example CLI ideas
+
+```bash
+memoria role create writer --based-on main
+memoria role list
+memoria role show writer
+memoria role delete writer
+
+memoria store --scope writer --type procedural "Prefer investor-ready writing"
+memoria search "deck narrative" --scope writer
+memoria stats --scope writer
+memoria diff --scope writer --against main
+```
+
+## Example API ideas
+
+### Create role
+
+```http
+POST /v1/roles
+{
+  "name": "writer",
+  "based_on": "main"
+}
+```
+
+### List roles
+
+```http
+GET /v1/roles
+```
+
+### Scoped store
+
+```http
+POST /v1/memories
+{
+  "scope": "writer",
+  "memory_type": "procedural",
+  "content": "Prefer investor-ready writing"
+}
+```
+
+### Scoped recall
+
+```http
+POST /v1/memories/search
+{
+  "query": "deck narrative",
+  "scope": "writer"
+}
+```
+
+Server-side semantics:
+
+- include `main`
+- include `writer`
+- rank across both
+
+## Data model direction
+
+A generic scope abstraction is likely more future-proof than a hard-coded `role` field.
+
+### Option A: scope fields
+
+Possible fields:
+
+- `scope_kind`
+- `scope_value`
+- `parent_scope_id`
+
+This can support more than roles later:
+
+- role
+- project
+- session
+- workspace overlays
+
+### Option B: named memory spaces
+
+Alternatively, Memoria could expose a more direct abstraction:
+
+- memory spaces
+- inherited spaces
+- role is a special case of a named inherited space
+
+## Suggested retrieval semantics
+
+For a scoped recall against `writer`:
+
+1. load base scope `main`
+2. load child scope `writer`
+3. combine both result sets
+4. rank with a preference for role-local memories when scores are close
+
+This keeps role-local guidance strong without losing the shared base.
+
+## Suggested governance semantics
+
+Role scopes should remain compatible with existing Memoria governance ideas:
+
+- snapshots
+- rollback
+- diff
+- merge
+
+That means a role can be both:
+
+- collaboration-oriented (through inheritance)
+- versioned (through branch/snapshot)
+
+## Non-goals
+
+This proposal does **not** replace:
+
+- snapshots
+- rollback
+- branches
+- diff/merge
+
+Those remain the right abstraction for version control and recovery.
+
+The goal here is to introduce an additional abstraction for collaboration-oriented inherited memory.
+
+## Why this matters
+
+This would make Memoria more useful for real multi-agent coordination where:
+
+- a shared memory base is needed
+- specialized roles need their own stable local rules
+- clients should not have to encode scope in raw text
+- role separation should not require duplicating the whole user memory graph


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [x] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Related to #126

## What this PR does / why we need it

This PR adds a design note for **role-scoped memory spaces with inheritance**.

The main idea is to separate:

- **branch/snapshot** for rollback, experimentation, and version control
- **role scope** for collaboration, inherited shared memory, and role-local overlays

The document proposes a model where clients can create a role like:

```text
create role "writer" based on main
```

so recalls can use:

- shared base memory from `main`
- role-specific delta memory from `writer`

without encoding role semantics in raw content or fragmenting memory into separate user IDs.

It also sketches a minimum API / CLI surface for future implementation.

## Local validation

```bash
cargo test -p memoria-api --test api_e2e test_remote_store_retrieve -- --nocapture
```
