### PR TITLE
feat: add ops metrics

### DIFF
--- a/memoria/crates/memoria-api/src/lib.rs
+++ b/memoria/crates/memoria-api/src/lib.rs
@@ -77,6 +77,23 @@ async fn call_log_mw(
                     latency_ms,
                 );
             }
+            // Push-based ops metrics (non-blocking, best-effort).
+            // Dashboard-originated calls are excluded to avoid inflating agent stats.
+            // MCP calls are skipped here: mcp_handler reports ApiCallLogged with the
+            // accurate track_path (e.g. /mcp/remember) and RPC-level success flag,
+            // which is necessary because JSON-RPC errors return HTTP 200.
+            if !is_dashboard && !path.starts_with("/v1/mcp") {
+                if let Some(reporter) = &state.stats_reporter {
+                    reporter.report(
+                        memoria_service::stats_reporter::StatsEvent::ApiCallLogged {
+                            user_id: uid.clone(),
+                            path: path.clone(),
+                            is_mcp: false,
+                            is_success: status_code < 400,
+                        },
+                    );
+                }
+            }
             if let Some(mask) = should_mark_metrics_dirty(&method, &path, status_code) {
                 let state = state.clone();
                 let user_id = uid.clone();

--- a/memoria/crates/memoria-api/src/routes/mcp.rs
+++ b/memoria/crates/memoria-api/src/routes/mcp.rs
@@ -132,6 +132,16 @@ pub async fn mcp_handler(
                 t.elapsed().as_millis() as u32,
                 RpcMeta::err($code),
             );
+            if let Some(reporter) = &state.stats_reporter {
+                reporter.report(
+                    memoria_service::stats_reporter::StatsEvent::ApiCallLogged {
+                        user_id: auth.user_id.clone(),
+                        path: $path.to_string(),
+                        is_mcp: true,
+                        is_success: false,
+                    },
+                );
+            }
             return Json($body).into_response();
         }};
     }
@@ -200,6 +210,23 @@ pub async fn mcp_handler(
         state.tool_usage_batcher.mark_used(user_id.clone(), tool);
     }
 
+    // Single reporting point for MCP call stats, shared by both the
+    // notification path and the regular-request path below.
+    let report_stats = {
+        let reporter = state.stats_reporter.clone();
+        let uid = user_id.clone();
+        move |path: &str, is_success: bool| {
+            if let Some(r) = &reporter {
+                r.report(memoria_service::stats_reporter::StatsEvent::ApiCallLogged {
+                    user_id: uid.clone(),
+                    path: path.to_string(),
+                    is_mcp: true,
+                    is_success,
+                });
+            }
+        }
+    };
+
     // JSON-RPC 2.0: a Notification is a *valid* Request without an "id" member.
     // The server MUST NOT reply to Notifications.
     if req.get("id").is_none() {
@@ -220,6 +247,9 @@ pub async fn mcp_handler(
                 spawn_metrics_dirty_mark(state.clone(), user_id.clone(), mask);
             }
         }
+        // Report accurate ops metrics using the real RPC path and success flag
+        // (JSON-RPC errors still return HTTP 200, so is_success must come from rpc.success).
+        report_stats(&track_path, rpc.success);
         state.call_log_batcher.record_rpc(
             user_id,
             "POST".to_string(),
@@ -268,6 +298,9 @@ pub async fn mcp_handler(
         }
     }
 
+    // Report accurate ops metrics using the real RPC path and success flag
+    // (JSON-RPC errors still return HTTP 200, so is_success must come from rpc.success).
+    report_stats(&track_path, rpc.success);
     state.call_log_batcher.record_rpc(
         user_id,
         "POST".to_string(),

--- a/memoria/crates/memoria-api/src/state.rs
+++ b/memoria/crates/memoria-api/src/state.rs
@@ -6,7 +6,7 @@ use crate::metrics_summary::MetricsSummaryManager;
 use crate::rate_limit::RateLimiter;
 use memoria_core::MemoriaError;
 use memoria_git::GitForDataService;
-use memoria_service::{AsyncTaskStore, MemoryService};
+use memoria_service::{AsyncTaskStore, MemoryService, StatsReporter};
 use memoria_storage::store::spawn_pool_monitor;
 use memoria_storage::PoolHealthSnapshot;
 use std::collections::HashMap;
@@ -103,6 +103,8 @@ pub struct AppState {
     pub metrics_summary: Option<Arc<MetricsSummaryManager>>,
     /// Batched API call log writer (flushed every 5 s to mem_api_call_log).
     pub call_log_batcher: Arc<CallLogBatcher>,
+    /// Push-based operational metrics reporter for admin dashboard.
+    pub stats_reporter: Option<Arc<StatsReporter>>,
     /// Shutdown signal + task handles for background flushers.
     /// Wrapped together so drain_flushers() can take ownership of the sender.
     flusher_state: Arc<std::sync::Mutex<FlusherState>>,
@@ -153,6 +155,7 @@ impl AppState {
             last_used_batcher: Arc::new(LastUsedBatcher::new()),
             tool_usage_batcher: Arc::new(ToolUsageBatcher::new()),
             call_log_batcher: Arc::new(CallLogBatcher::new()),
+            stats_reporter: None,
             rate_limiter: crate::rate_limit::from_env(),
             metrics_cache: Arc::new(RwLock::new(None)),
             metrics_cache_ttl,
@@ -169,7 +172,11 @@ impl AppState {
     ///
     /// This is strict on purpose: if the auth pool cannot be created, startup fails
     /// rather than letting auth traffic spill into the main business pool.
-    pub async fn init_auth_pool(mut self, database_url: &str) -> Result<Self, MemoriaError> {
+    pub async fn init_auth_pool(
+        mut self,
+        database_url: &str,
+        ops_metrics_enabled: bool,
+    ) -> Result<Self, MemoriaError> {
         let auth_max_connections = {
             let raw: u32 = std::env::var("MEMORIA_AUTH_POOL_MAX_CONNECTIONS")
                 .ok()
@@ -239,6 +246,16 @@ impl AppState {
             .as_ref()
             .and_then(|sql| sql.db_router())
             .is_some();
+
+        // Initialise push-based operational metrics reporter when enabled.
+        // Uses the same auth pool (shared DB) to write aggregate counters.
+        if ops_metrics_enabled {
+            let reporter = Arc::new(StatsReporter::new(pool.clone()));
+            // Inject into MemoryService so write-path hooks can report events.
+            self.service.init_stats(reporter.clone());
+            info!("Ops metrics reporter initialized");
+            self.stats_reporter = Some(reporter);
+        }
 
         // In multi-db mode, eager rebuild would fan out across every user DB and can
         // block startup for large tenants. Load per-user tool usage lazily instead.

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -867,7 +867,7 @@ async fn spawn_server_with_master_key(master_key: &str) -> (String, reqwest::Cli
     let git = Arc::new(GitForDataService::new(pool, &cfg.db_name));
     let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
     let state = memoria_api::AppState::new(service, git, master_key.to_string())
-        .init_auth_pool(&db)
+        .init_auth_pool(&db, false)
         .await
         .expect("init auth pool");
     let app = memoria_api::build_router(state);
@@ -5819,7 +5819,7 @@ async fn test_api_key_auth_uses_batcher_not_fire_and_forget() {
     let git = Arc::new(GitForDataService::new(pool, &cfg.db_name));
     let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
     let state = memoria_api::AppState::new(service, git, mk.to_string())
-        .init_auth_pool(&db)
+        .init_auth_pool(&db, false)
         .await
         .expect("auth pool");
 

--- a/memoria/crates/memoria-cli/src/main.rs
+++ b/memoria/crates/memoria-cli/src/main.rs
@@ -574,7 +574,7 @@ async fn cmd_serve(db_url: Option<String>, port: u16, master_key: String) -> Res
         .start();
     let state = AppState::new(service.clone(), git, master_key)
         .with_instance_id(cfg.instance_id.clone())
-        .init_auth_pool(cfg.effective_sql_url())
+        .init_auth_pool(cfg.effective_sql_url(), cfg.ops_metrics_enabled)
         .await?;
 
     let app = build_router(state.clone()).layer(TraceLayer::new_for_http());
@@ -3537,6 +3537,7 @@ mod tests {
             governance_plugin_dir: None,
             instance_id: "test-instance".to_string(),
             lock_ttl_secs: 120,
+            ops_metrics_enabled: false,
         }
     }
 

--- a/memoria/crates/memoria-service/src/config.rs
+++ b/memoria/crates/memoria-service/src/config.rs
@@ -68,6 +68,11 @@ pub struct Config {
     pub instance_id: String,
     /// Lock TTL in seconds for distributed leader election. Default: 120.
     pub lock_ttl_secs: u64,
+
+    /// Enable writing operational metrics to the shared DB for admin dashboard.
+    /// Only aggregate counters are written — no user memory content is stored.
+    /// Env: MEMORIA_OPS_METRICS (default: true).
+    pub ops_metrics_enabled: bool,
 }
 
 impl Config {
@@ -151,6 +156,7 @@ impl Config {
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(120),
+            ops_metrics_enabled: env_bool_default("MEMORIA_OPS_METRICS", true),
         }
     }
 
@@ -211,6 +217,20 @@ fn env_bool(name: &str) -> bool {
             .as_deref(),
         Some("1" | "true" | "yes" | "on")
     )
+}
+
+fn env_bool_default(name: &str, default: bool) -> bool {
+    match std::env::var(name)
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("1" | "true" | "yes" | "on") => true,
+        Some("0" | "false" | "no" | "off") => false,
+        _ => default,
+    }
 }
 
 fn replace_db_name(database_url: &str, db_name: &str) -> Option<String> {
@@ -477,5 +497,52 @@ mod tests {
                 assert!(cfg.embedding_endpoints.is_empty());
             },
         );
+    }
+
+    // ── env_bool_default / ops_metrics_enabled tests ─────────────────────────
+
+    #[test]
+    fn ops_metrics_defaults_to_true_when_unset() {
+        with_env(&[("MEMORIA_OPS_METRICS", None)], || {
+            let cfg = Config::from_env();
+            assert!(cfg.ops_metrics_enabled, "should be enabled by default");
+        });
+    }
+
+    #[test]
+    fn ops_metrics_recognised_truthy_values() {
+        for val in &["1", "true", "True", "TRUE", "yes", "YES", "on", "ON"] {
+            with_env(&[("MEMORIA_OPS_METRICS", Some(val))], || {
+                let cfg = Config::from_env();
+                assert!(
+                    cfg.ops_metrics_enabled,
+                    "MEMORIA_OPS_METRICS={val:?} should be truthy"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn ops_metrics_recognised_falsy_values() {
+        for val in &["0", "false", "False", "FALSE", "no", "NO", "off", "OFF"] {
+            with_env(&[("MEMORIA_OPS_METRICS", Some(val))], || {
+                let cfg = Config::from_env();
+                assert!(
+                    !cfg.ops_metrics_enabled,
+                    "MEMORIA_OPS_METRICS={val:?} should be falsy"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn ops_metrics_unknown_value_falls_back_to_default() {
+        with_env(&[("MEMORIA_OPS_METRICS", Some("maybe"))], || {
+            let cfg = Config::from_env();
+            assert!(
+                cfg.ops_metrics_enabled,
+                "unrecognised value should fall back to the default (true)"
+            );
+        });
     }
 }

--- a/memoria/crates/memoria-service/src/lib.rs
+++ b/memoria/crates/memoria-service/src/lib.rs
@@ -9,11 +9,13 @@ pub mod rebuild_worker;
 pub mod scheduler;
 pub mod scoring;
 pub mod service;
+pub mod stats_reporter;
 pub mod strategy;
 pub mod strategy_domain;
 pub mod vector_index_monitor;
 pub use config::Config;
 pub use distributed::{AsyncTask, AsyncTaskStore, DistributedLock, NoopDistributedLock};
+pub use stats_reporter::StatsReporter;
 pub use governance::{
     DefaultGovernanceStrategy, GovernanceExecution, GovernancePlan, GovernanceRunSummary,
     GovernanceStore, GovernanceStrategy, GovernanceTask,

--- a/memoria/crates/memoria-service/src/scheduler.rs
+++ b/memoria/crates/memoria-service/src/scheduler.rs
@@ -1400,6 +1400,7 @@ mod tests {
             governance_plugin_dir: None,
             instance_id: "test-instance".into(),
             lock_ttl_secs: 120,
+            ops_metrics_enabled: false,
         };
         let scheduler = tokio::runtime::Runtime::new()
             .unwrap()

--- a/memoria/crates/memoria-service/src/service.rs
+++ b/memoria/crates/memoria-service/src/service.rs
@@ -9,10 +9,12 @@ use memoria_embedding::LlmClient;
 use memoria_storage::{DbRouter, OwnedEditLogEntry, SqlMemoryStore};
 use moka::sync::Cache;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tracing::{error, info, warn};
 use uuid::Uuid;
+
+use crate::stats_reporter::{StatsEvent, StatsReporter};
 
 /// Incremented when entity extraction jobs are dropped (queue full or channel closed).
 pub static ENTITY_EXTRACTION_DROPS: AtomicU64 = AtomicU64::new(0);
@@ -390,6 +392,10 @@ pub struct MemoryService {
     /// Isolated pool for graph retrieval (spreading activation, entity recall)
     /// to avoid starving the main pool during heavy retrieve queries.
     graph_pool: Option<Arc<SqlMemoryStore>>,
+    /// Shared operational metrics reporter (None = disabled, zero overhead).
+    /// Wrapped in OnceLock so the entity background worker can also access it
+    /// after construction via `with_stats()`.
+    stats: Arc<OnceLock<Arc<StatsReporter>>>,
 }
 
 /// A pending entity-extraction job pushed from the write path.
@@ -428,6 +434,10 @@ impl MemoryService {
         // Create edit-log buffer early so background stores inherit the sender
         let edit_log = EditLogBuffer::new(store.clone());
         store.set_edit_log_tx(edit_log.entry_sender());
+
+        // Stats cell shared between MemoryService and background entity workers.
+        // Populated later via with_stats(); workers check it on each batch.
+        let stats_cell: Arc<OnceLock<Arc<StatsReporter>>> = Arc::new(OnceLock::new());
 
         let entity_queue_size: usize = std::env::var("ENTITY_QUEUE_SIZE")
             .ok()
@@ -479,7 +489,7 @@ impl MemoryService {
                     info!("Entity extraction uses routed user stores in multi-db mode");
                 }
                 let (entity_tx, entity_rx) = tokio::sync::mpsc::channel(entity_queue_size);
-                Self::spawn_entity_worker(entity_rx, store.clone(), llm.clone());
+                Self::spawn_entity_worker(entity_rx, store.clone(), llm.clone(), stats_cell.clone());
                 tracing::info!(entity_queue_size, "entity extraction enabled");
                 Some(entity_tx)
             }
@@ -493,7 +503,7 @@ impl MemoryService {
                 match store.spawn_background_store(entity_pool_size).await {
                     Ok(entity_store) => {
                         let (entity_tx, entity_rx) = tokio::sync::mpsc::channel(entity_queue_size);
-                        Self::spawn_entity_worker(entity_rx, entity_store, llm.clone());
+                        Self::spawn_entity_worker(entity_rx, entity_store, llm.clone(), stats_cell.clone());
                         tracing::info!(
                             entity_queue_size,
                             entity_pool_size,
@@ -572,6 +582,7 @@ impl MemoryService {
                 .build(),
             vector_monitor,
             graph_pool,
+            stats: stats_cell,
         }
     }
 
@@ -609,6 +620,7 @@ impl MemoryService {
                 .build(),
             vector_monitor: None,
             graph_pool: None,
+            stats: Arc::new(OnceLock::new()),
         }
     }
 
@@ -638,9 +650,31 @@ impl MemoryService {
                     .build(),
                 vector_monitor: None,
                 graph_pool: None,
+                stats: Arc::new(OnceLock::new()),
             },
             entries,
         )
+    }
+
+    /// Attach a `StatsReporter` after construction.
+    /// Must be called before the service receives any requests.
+    /// No-op if called more than once (OnceLock semantics).
+    pub fn with_stats(self, reporter: Arc<StatsReporter>) -> Self {
+        let _ = self.stats.set(reporter);
+        self
+    }
+
+    /// Initialize the stats reporter from an external caller (e.g., AppState::init_auth_pool).
+    /// Safe to call concurrently; OnceLock guarantees only the first call wins.
+    pub fn init_stats(&self, reporter: Arc<StatsReporter>) {
+        let _ = self.stats.set(reporter);
+    }
+
+    #[inline]
+    fn report(&self, event: StatsEvent) {
+        if let Some(r) = self.stats.get() {
+            r.report(event);
+        }
     }
 
     /// Force-flush all buffered edit-log entries to the store.
@@ -694,6 +728,10 @@ impl MemoryService {
                 snapshot_before,
             );
         }
+        self.report(StatsEvent::EditLogged {
+            user_id: user_id.to_string(),
+            operation: operation.to_string(),
+        });
     }
 
     /// Best-effort cleanup of graph node + entity links for a deactivated memory.
@@ -760,6 +798,7 @@ impl MemoryService {
         rx: tokio::sync::mpsc::Receiver<EntityJob>,
         store: Arc<SqlMemoryStore>,
         llm: Option<Arc<LlmClient>>,
+        stats_cell: Arc<OnceLock<Arc<StatsReporter>>>,
     ) {
         let worker_count: usize = std::env::var("ENTITY_WORKER_COUNT")
             .ok()
@@ -797,9 +836,10 @@ impl MemoryService {
                     };
                     let store = Arc::clone(&store);
                     let llm = llm.clone();
+                    let stats = stats_cell.get().cloned();
                     tokio::spawn(async move {
                         let _permit = permit;
-                        Self::process_entity_batch(store, llm, user_id, jobs).await;
+                        Self::process_entity_batch(store, llm, stats, user_id, jobs).await;
                     });
                 }
 
@@ -817,6 +857,7 @@ impl MemoryService {
     async fn process_entity_batch(
         store: Arc<SqlMemoryStore>,
         llm: Option<Arc<LlmClient>>,
+        stats: Option<Arc<StatsReporter>>,
         user_id: String,
         jobs: Vec<EntityJob>,
     ) {
@@ -884,7 +925,18 @@ impl MemoryService {
                 .filter(|e| seen.insert(e.name.as_str()))
                 .map(|e| (e.name.as_str(), e.display.as_str(), e.entity_type.as_str()))
                 .collect();
+            let refs_len = refs.len() as u64;
             if let Ok(resolved) = graph.batch_upsert_entities(&user_id, &refs).await {
+                // Report approximate new-entity count (best-effort; refs_len may overcount
+                // if some entities already existed, which is acceptable for monitoring).
+                if refs_len > 0 {
+                    if let Some(r) = &stats {
+                        r.report(StatsEvent::EntitiesUpserted {
+                            user_id: user_id.clone(),
+                            count: refs_len,
+                        });
+                    }
+                }
                 // Build name→entity_id map
                 let id_map: std::collections::HashMap<&str, &str> = resolved
                     .iter()
@@ -1086,6 +1138,14 @@ impl MemoryService {
                             "store_memory:supersede",
                             None,
                         );
+                        self.report(StatsEvent::MemoryStored {
+                            user_id: user_id.to_string(),
+                            memory_type: memory.memory_type.to_string(),
+                            trust_tier: memory.trust_tier.to_string(),
+                        });
+                        self.report(StatsEvent::MemoryDeactivated {
+                            user_id: user_id.to_string(),
+                        });
                         self.enqueue_entity_extraction(user_id, &memory.memory_id, &memory.content)
                             .await;
                         if t0.elapsed().as_secs() >= 1 {
@@ -1123,6 +1183,11 @@ impl MemoryService {
                     "store_memory",
                     None,
                 );
+                self.report(StatsEvent::MemoryStored {
+                    user_id: user_id.to_string(),
+                    memory_type: memory.memory_type.to_string(),
+                    trust_tier: memory.trust_tier.to_string(),
+                });
                 self.enqueue_entity_extraction(user_id, &memory.memory_id, &memory.content)
                     .await;
                 if t0.elapsed().as_secs() >= 1 {
@@ -1145,6 +1210,11 @@ impl MemoryService {
                     "store_memory",
                     None,
                 );
+                self.report(StatsEvent::MemoryStored {
+                    user_id: user_id.to_string(),
+                    memory_type: memory.memory_type.to_string(),
+                    trust_tier: memory.trust_tier.to_string(),
+                });
                 self.enqueue_entity_extraction(user_id, &memory.memory_id, &memory.content)
                     .await;
                 if t0.elapsed().as_secs() >= 1 {
@@ -1633,6 +1703,15 @@ impl MemoryService {
             );
             sup_res?;
 
+            self.report(StatsEvent::MemoryStored {
+                user_id: user_id.to_string(),
+                memory_type: new_mem.memory_type.to_string(),
+                trust_tier: new_mem.trust_tier.to_string(),
+            });
+            self.report(StatsEvent::MemoryDeactivated {
+                user_id: user_id.to_string(),
+            });
+
             let payload = serde_json::json!({
                 "new_content": new_content,
                 "new_memory_id": &new_mem.memory_id,
@@ -1695,7 +1774,12 @@ impl MemoryService {
             let (snap, warning) = sql.create_safety_snapshot("purge").await;
             self.send_edit_log(user_id, "purge", Some(memory_id), None, "", snap.as_deref());
             let table = sql.active_table(user_id).await?;
-            sql.soft_delete_from(&table, memory_id).await?;
+            let deactivated = sql.soft_delete_from(&table, memory_id).await?;
+            if deactivated > 0 {
+                self.report(StatsEvent::MemoryDeactivated {
+                    user_id: user_id.to_string(),
+                });
+            }
             // Graph + entity link cleanup (best-effort, governance fallback covers crash)
             Self::cleanup_entity_data_for_memory(sql.as_ref(), memory_id, "purge").await;
             Ok(PurgeResult {
@@ -1724,8 +1808,13 @@ impl MemoryService {
             let (snap, warning) = sql.create_safety_snapshot("purge").await;
             let table = sql.active_table(user_id).await?;
             for id in ids {
-                sql.soft_delete_from(&table, id).await?;
+                let deactivated = sql.soft_delete_from(&table, id).await?;
                 self.send_edit_log(user_id, "purge", Some(id), None, "", snap.as_deref());
+                if deactivated > 0 {
+                    self.report(StatsEvent::MemoryDeactivated {
+                        user_id: user_id.to_string(),
+                    });
+                }
                 Self::cleanup_entity_data_for_memory(sql.as_ref(), id, "purge_batch").await;
             }
             Ok(PurgeResult {

--- a/memoria/crates/memoria-service/src/stats_reporter.rs
+++ b/memoria/crates/memoria-service/src/stats_reporter.rs
@@ -1,0 +1,318 @@
+//! Push-based operational metrics reporter.
+//!
+//! Collects aggregate counters (memories, edits, API calls) and writes them
+//! into the shared `memoria_srv` database for the admin dashboard.
+//!
+//! Design constraints:
+//! - **Best-effort**: channel is bounded; events are silently dropped when full.
+//! - **Non-blocking**: `report()` is synchronous and never waits for a DB write.
+//! - **No user content**: only aggregate counters and category labels are stored.
+
+use sqlx::MySqlPool;
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+use tracing::warn;
+
+const CHANNEL_CAP: usize = 1_000;
+const FLUSH_INTERVAL_MS: u64 = 2_000;
+const BATCH_FLUSH_SIZE: usize = 200;
+
+/// Every write-path event that should be reflected in the shared stats tables.
+#[derive(Debug)]
+pub enum StatsEvent {
+    /// A new memory was stored (active).
+    MemoryStored {
+        user_id: String,
+        memory_type: String,
+        trust_tier: String,
+    },
+    /// An existing memory was deactivated (soft-deleted / superseded).
+    MemoryDeactivated { user_id: String },
+    /// A previously deactivated memory was re-activated.
+    MemoryActivated { user_id: String },
+    /// An edit-log entry was written (any operation).
+    EditLogged {
+        user_id: String,
+        operation: String,
+    },
+    /// One or more new entities were upserted for a user.
+    EntitiesUpserted { user_id: String, count: u64 },
+    /// An API or MCP call completed (used for devops/MCP tab).
+    ApiCallLogged {
+        user_id: String,
+        path: String,
+        is_mcp: bool,
+        is_success: bool,
+    },
+}
+
+/// Lightweight handle that enqueues stats events into a background writer.
+#[derive(Clone)]
+pub struct StatsReporter {
+    tx: mpsc::Sender<StatsEvent>,
+}
+
+impl StatsReporter {
+    /// Construct a new reporter that writes to `shared_pool`.
+    /// Spawns a background tokio task; call from an async context.
+    pub fn new(shared_pool: MySqlPool) -> Self {
+        let (tx, rx) = mpsc::channel(CHANNEL_CAP);
+        tokio::spawn(run_writer(rx, shared_pool));
+        Self { tx }
+    }
+
+    /// Enqueue an event. Never blocks; silently drops when the channel is full.
+    pub fn report(&self, event: StatsEvent) {
+        let _ = self.tx.try_send(event);
+    }
+}
+
+// ── Background writer ─────────────────────────────────────────────────────────
+
+async fn run_writer(mut rx: mpsc::Receiver<StatsEvent>, pool: MySqlPool) {
+    let mut buf: Vec<StatsEvent> = Vec::with_capacity(BATCH_FLUSH_SIZE);
+    loop {
+        // Collect up to BATCH_FLUSH_SIZE events or wait up to FLUSH_INTERVAL_MS.
+        let deadline = tokio::time::sleep(tokio::time::Duration::from_millis(FLUSH_INTERVAL_MS));
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                event = rx.recv() => {
+                    match event {
+                        Some(e) => {
+                            buf.push(e);
+                            if buf.len() >= BATCH_FLUSH_SIZE { break; }
+                        }
+                        None => {
+                            // Channel closed (shutdown) — do a final flush.
+                            if !buf.is_empty() {
+                                flush_batch(&buf, &pool).await;
+                                buf.clear();
+                            }
+                            return;
+                        }
+                    }
+                }
+                _ = &mut deadline => break,
+            }
+        }
+        if !buf.is_empty() {
+            flush_batch(&buf, &pool).await;
+            buf.clear();
+        }
+    }
+}
+
+// ── Batch aggregation & SQL flush ─────────────────────────────────────────────
+
+#[derive(Default)]
+struct UserStatsDelta {
+    total_memories: i64,
+    active_memories: i64,
+    inactive_memories: i64,
+    total_entities: i64,
+    total_edits: i64,
+}
+
+#[derive(Default)]
+struct ApiStatsDelta {
+    total_calls: i64,
+    mcp_calls: i64,
+    mcp_errors: i64,
+    first_mcp_call: Option<chrono::NaiveDateTime>,
+}
+
+async fn flush_batch(events: &[StatsEvent], pool: &MySqlPool) {
+    // Aggregate all events in-memory before touching the DB.
+    let mut user_stats: HashMap<String, UserStatsDelta> = HashMap::new();
+    let mut api_stats: HashMap<String, ApiStatsDelta> = HashMap::new();
+    // (user_id, metric, dim_key) → delta_count
+    let mut metric_detail: HashMap<(String, String, String), i64> = HashMap::new();
+    // (date, metric) → delta_count
+    let mut daily: HashMap<(chrono::NaiveDate, String), i64> = HashMap::new();
+    // path → delta_count (MCP paths)
+    let mut mcp_paths: HashMap<String, i64> = HashMap::new();
+
+    let today = chrono::Utc::now().naive_utc().date();
+
+    for event in events {
+        match event {
+            StatsEvent::MemoryStored {
+                user_id,
+                memory_type,
+                trust_tier,
+            } => {
+                let u = user_stats.entry(user_id.clone()).or_default();
+                u.total_memories += 1;
+                u.active_memories += 1;
+                *metric_detail
+                    .entry((user_id.clone(), "memory_type".into(), memory_type.clone()))
+                    .or_default() += 1;
+                *metric_detail
+                    .entry((user_id.clone(), "trust_tier".into(), trust_tier.clone()))
+                    .or_default() += 1;
+                *daily
+                    .entry((today, "memory_stored".into()))
+                    .or_default() += 1;
+            }
+            StatsEvent::MemoryDeactivated { user_id } => {
+                let u = user_stats.entry(user_id.clone()).or_default();
+                u.active_memories -= 1;
+                u.inactive_memories += 1;
+            }
+            StatsEvent::MemoryActivated { user_id } => {
+                let u = user_stats.entry(user_id.clone()).or_default();
+                u.active_memories += 1;
+                u.inactive_memories -= 1;
+            }
+            StatsEvent::EditLogged { user_id, operation } => {
+                let u = user_stats.entry(user_id.clone()).or_default();
+                u.total_edits += 1;
+                *metric_detail
+                    .entry((user_id.clone(), "edit_op".into(), operation.clone()))
+                    .or_default() += 1;
+            }
+            StatsEvent::EntitiesUpserted { user_id, count } => {
+                let u = user_stats.entry(user_id.clone()).or_default();
+                u.total_entities += *count as i64;
+            }
+            StatsEvent::ApiCallLogged {
+                user_id,
+                path,
+                is_mcp,
+                is_success,
+            } => {
+                let a = api_stats.entry(user_id.clone()).or_default();
+                a.total_calls += 1;
+                if *is_mcp {
+                    a.mcp_calls += 1;
+                    if !is_success {
+                        a.mcp_errors += 1;
+                    }
+                    if a.first_mcp_call.is_none() {
+                        a.first_mcp_call = Some(chrono::Utc::now().naive_utc());
+                    }
+                    *mcp_paths.entry(path.clone()).or_default() += 1;
+                    *daily
+                        .entry((today, "mcp_calls".into()))
+                        .or_default() += 1;
+                }
+                *daily
+                    .entry((today, "api_calls".into()))
+                    .or_default() += 1;
+            }
+        }
+    }
+
+    // Capture a single timestamp for all updated_at columns in this flush.
+    let now = chrono::Utc::now().naive_utc();
+
+    // ── Write srv_user_stats (one multi-row INSERT per flush) ────────────────
+    if !user_stats.is_empty() {
+        let mut qb: sqlx::QueryBuilder<sqlx::MySql> = sqlx::QueryBuilder::new(
+            "INSERT INTO srv_user_stats \
+             (user_id, total_memories, active_memories, inactive_memories, \
+              total_entities, total_edits, updated_at) ",
+        );
+        qb.push_values(user_stats.iter(), |mut b, (user_id, delta)| {
+            b.push_bind(user_id)
+                .push_bind(delta.total_memories)
+                .push_bind(delta.active_memories.max(0))
+                .push_bind(delta.inactive_memories.max(0))
+                .push_bind(delta.total_entities)
+                .push_bind(delta.total_edits)
+                .push_bind(now);
+        });
+        qb.push(
+            " ON DUPLICATE KEY UPDATE \
+               total_memories    = total_memories    + VALUES(total_memories), \
+               active_memories   = GREATEST(0, active_memories   + VALUES(active_memories)), \
+               inactive_memories = GREATEST(0, inactive_memories + VALUES(inactive_memories)), \
+               total_entities    = total_entities    + VALUES(total_entities), \
+               total_edits       = total_edits       + VALUES(total_edits), \
+               updated_at        = VALUES(updated_at)",
+        );
+        if let Err(e) = qb.build().execute(pool).await {
+            warn!(rows = user_stats.len(), error = %e, "stats_reporter: srv_user_stats write failed");
+        }
+    }
+
+    // ── Write srv_user_metric_detail (one multi-row INSERT per flush) ────────
+    if !metric_detail.is_empty() {
+        let mut qb: sqlx::QueryBuilder<sqlx::MySql> = sqlx::QueryBuilder::new(
+            "INSERT INTO srv_user_metric_detail (user_id, metric, dim_key, cnt) ",
+        );
+        qb.push_values(
+            metric_detail.iter(),
+            |mut b, ((user_id, metric, dim_key), cnt)| {
+                b.push_bind(user_id)
+                    .push_bind(metric)
+                    .push_bind(dim_key)
+                    .push_bind(*cnt);
+            },
+        );
+        qb.push(" ON DUPLICATE KEY UPDATE cnt = cnt + VALUES(cnt)");
+        if let Err(e) = qb.build().execute(pool).await {
+            warn!(rows = metric_detail.len(), error = %e, "stats_reporter: srv_user_metric_detail write failed");
+        }
+    }
+
+    // ── Write srv_daily_stats (one multi-row INSERT per flush) ───────────────
+    if !daily.is_empty() {
+        let mut qb: sqlx::QueryBuilder<sqlx::MySql> =
+            sqlx::QueryBuilder::new("INSERT INTO srv_daily_stats (dt, metric, cnt) ");
+        qb.push_values(daily.iter(), |mut b, ((dt, metric), cnt)| {
+            b.push_bind(dt).push_bind(metric).push_bind(*cnt);
+        });
+        qb.push(" ON DUPLICATE KEY UPDATE cnt = cnt + VALUES(cnt)");
+        if let Err(e) = qb.build().execute(pool).await {
+            warn!(rows = daily.len(), error = %e, "stats_reporter: srv_daily_stats write failed");
+        }
+    }
+
+    // ── Write srv_user_api_stats (one multi-row INSERT per flush) ────────────
+    if !api_stats.is_empty() {
+        let mut qb: sqlx::QueryBuilder<sqlx::MySql> = sqlx::QueryBuilder::new(
+            "INSERT INTO srv_user_api_stats \
+             (user_id, total_calls, mcp_calls, mcp_errors, first_mcp_call, updated_at) ",
+        );
+        qb.push_values(api_stats.iter(), |mut b, (user_id, delta)| {
+            b.push_bind(user_id)
+                .push_bind(delta.total_calls)
+                .push_bind(delta.mcp_calls)
+                .push_bind(delta.mcp_errors)
+                .push_bind(delta.first_mcp_call)
+                .push_bind(now);
+        });
+        qb.push(
+            " ON DUPLICATE KEY UPDATE \
+               total_calls    = total_calls  + VALUES(total_calls), \
+               mcp_calls      = mcp_calls    + VALUES(mcp_calls), \
+               mcp_errors     = mcp_errors   + VALUES(mcp_errors), \
+               first_mcp_call = COALESCE(first_mcp_call, VALUES(first_mcp_call)), \
+               updated_at     = VALUES(updated_at)",
+        );
+        if let Err(e) = qb.build().execute(pool).await {
+            warn!(rows = api_stats.len(), error = %e, "stats_reporter: srv_user_api_stats write failed");
+        }
+    }
+
+    // ── Write srv_mcp_path_stats (one multi-row INSERT per flush) ────────────
+    if !mcp_paths.is_empty() {
+        let mut qb: sqlx::QueryBuilder<sqlx::MySql> =
+            sqlx::QueryBuilder::new("INSERT INTO srv_mcp_path_stats (path, cnt) ");
+        qb.push_values(mcp_paths.iter(), |mut b, (path, cnt)| {
+            b.push_bind(path).push_bind(*cnt);
+        });
+        qb.push(" ON DUPLICATE KEY UPDATE cnt = cnt + VALUES(cnt)");
+        if let Err(e) = qb.build().execute(pool).await {
+            warn!(rows = mcp_paths.len(), error = %e, "stats_reporter: srv_mcp_path_stats write failed");
+        }
+    }
+
+    tracing::debug!(
+        events = events.len(),
+        users = user_stats.len(),
+        "stats_reporter: batch flushed"
+    );
+}

--- a/memoria/crates/memoria-service/tests/plugin_repository.rs
+++ b/memoria/crates/memoria-service/tests/plugin_repository.rs
@@ -449,6 +449,7 @@ async fn repository_requires_review_before_activation_and_startup_load() {
         governance_plugin_dir: None,
         instance_id: "test-instance".into(),
         lock_ttl_secs: 120,
+        ops_metrics_enabled: false,
     };
     let scheduler = GovernanceScheduler::from_config(service, &config)
         .await

--- a/memoria/crates/memoria-storage/src/router.rs
+++ b/memoria/crates/memoria-storage/src/router.rs
@@ -411,6 +411,74 @@ impl DbRouter {
         .execute(&self.shared_pool)
         .await
         .map_err(db_err)?;
+
+        // ── Operational metrics tables (push-based aggregation for admin dashboard) ──
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS srv_user_stats (
+                user_id           VARCHAR(64) NOT NULL PRIMARY KEY,
+                total_memories    BIGINT      NOT NULL DEFAULT 0,
+                active_memories   BIGINT      NOT NULL DEFAULT 0,
+                inactive_memories BIGINT      NOT NULL DEFAULT 0,
+                total_entities    BIGINT      NOT NULL DEFAULT 0,
+                total_edits       BIGINT      NOT NULL DEFAULT 0,
+                updated_at        DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                  ON UPDATE CURRENT_TIMESTAMP
+            )"#,
+        )
+        .execute(&self.shared_pool)
+        .await
+        .map_err(db_err)?;
+
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS srv_user_metric_detail (
+                user_id   VARCHAR(64)  NOT NULL,
+                metric    VARCHAR(64)  NOT NULL,
+                dim_key   VARCHAR(128) NOT NULL,
+                cnt       BIGINT       NOT NULL DEFAULT 0,
+                PRIMARY KEY (user_id, metric, dim_key)
+            )"#,
+        )
+        .execute(&self.shared_pool)
+        .await
+        .map_err(db_err)?;
+
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS srv_daily_stats (
+                dt      DATE        NOT NULL,
+                metric  VARCHAR(64) NOT NULL,
+                cnt     BIGINT      NOT NULL DEFAULT 0,
+                PRIMARY KEY (dt, metric)
+            )"#,
+        )
+        .execute(&self.shared_pool)
+        .await
+        .map_err(db_err)?;
+
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS srv_user_api_stats (
+                user_id        VARCHAR(64) NOT NULL PRIMARY KEY,
+                total_calls    BIGINT      NOT NULL DEFAULT 0,
+                mcp_calls      BIGINT      NOT NULL DEFAULT 0,
+                mcp_errors     BIGINT      NOT NULL DEFAULT 0,
+                first_mcp_call DATETIME    DEFAULT NULL,
+                updated_at     DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP
+                               ON UPDATE CURRENT_TIMESTAMP
+            )"#,
+        )
+        .execute(&self.shared_pool)
+        .await
+        .map_err(db_err)?;
+
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS srv_mcp_path_stats (
+                path  VARCHAR(128) NOT NULL PRIMARY KEY,
+                cnt   BIGINT       NOT NULL DEFAULT 0
+            )"#,
+        )
+        .execute(&self.shared_pool)
+        .await
+        .map_err(db_err)?;
+
         Ok(())
     }
 }

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -1752,6 +1752,76 @@ impl SqlMemoryStore {
         .execute(&mut *conn)
         .await;
 
+        // ── Ops-metrics aggregate tables (push-based stats written by Memoria) ──
+        // Created here so they exist in both single-db and multi-db deployments.
+        // DbRouter::ensure_user_registry_table also creates these for multi-db
+        // startup — CREATE TABLE IF NOT EXISTS makes all paths idempotent.
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS srv_user_stats (
+                user_id          VARCHAR(64)  NOT NULL PRIMARY KEY,
+                total_memories   BIGINT       NOT NULL DEFAULT 0,
+                active_memories  BIGINT       NOT NULL DEFAULT 0,
+                inactive_memories BIGINT      NOT NULL DEFAULT 0,
+                total_entities   BIGINT       NOT NULL DEFAULT 0,
+                total_edits      BIGINT       NOT NULL DEFAULT 0,
+                updated_at       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                 ON UPDATE CURRENT_TIMESTAMP
+            )"#,
+        )
+        .execute(&mut *conn)
+        .await
+        .map_err(db_err)?;
+
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS srv_user_metric_detail (
+                user_id  VARCHAR(64)  NOT NULL,
+                metric   VARCHAR(64)  NOT NULL,
+                dim_key  VARCHAR(128) NOT NULL,
+                cnt      BIGINT       NOT NULL DEFAULT 0,
+                PRIMARY KEY (user_id, metric, dim_key)
+            )"#,
+        )
+        .execute(&mut *conn)
+        .await
+        .map_err(db_err)?;
+
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS srv_daily_stats (
+                dt      DATE         NOT NULL,
+                metric  VARCHAR(64)  NOT NULL,
+                cnt     BIGINT       NOT NULL DEFAULT 0,
+                PRIMARY KEY (dt, metric)
+            )"#,
+        )
+        .execute(&mut *conn)
+        .await
+        .map_err(db_err)?;
+
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS srv_user_api_stats (
+                user_id        VARCHAR(64) NOT NULL PRIMARY KEY,
+                total_calls    BIGINT      NOT NULL DEFAULT 0,
+                mcp_calls      BIGINT      NOT NULL DEFAULT 0,
+                mcp_errors     BIGINT      NOT NULL DEFAULT 0,
+                first_mcp_call DATETIME    DEFAULT NULL,
+                updated_at     DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP
+                               ON UPDATE CURRENT_TIMESTAMP
+            )"#,
+        )
+        .execute(&mut *conn)
+        .await
+        .map_err(db_err)?;
+
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS srv_mcp_path_stats (
+                path  VARCHAR(128) NOT NULL PRIMARY KEY,
+                cnt   BIGINT       NOT NULL DEFAULT 0
+            )"#,
+        )
+        .execute(&mut *conn)
+        .await
+        .map_err(db_err)?;
+
         Ok(())
     }
 
@@ -4095,18 +4165,20 @@ impl SqlMemoryStore {
 
     /// Mark a memory as superseded by another.
     /// Branch-aware soft-delete: deactivate a memory in the given table.
-    pub async fn soft_delete_from(&self, table: &str, memory_id: &str) -> Result<(), MemoriaError> {
+    /// Returns the number of rows actually deactivated (0 means the memory
+    /// was already inactive or not found — idempotent, not an error).
+    pub async fn soft_delete_from(&self, table: &str, memory_id: &str) -> Result<u64, MemoriaError> {
         let mut conn = self.conn().await?;
         let now = Utc::now().naive_utc();
-        sqlx::query(&format!(
-            "UPDATE {table} SET is_active = 0, updated_at = ? WHERE memory_id = ?"
+        let res = sqlx::query(&format!(
+            "UPDATE {table} SET is_active = 0, updated_at = ? WHERE memory_id = ? AND is_active = 1"
         ))
         .bind(now)
         .bind(memory_id)
         .execute(&mut *conn)
         .await
         .map_err(db_err)?;
-        Ok(())
+        Ok(res.rows_affected())
     }
 
     /// Batch soft-delete: deactivate multiple memories in one round trip per chunk.


### PR DESCRIPTION
## What type of PR is this?

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes # https://github.com/matrixorigin/memoria-website/issues/76

## What this PR does / why we need it

**Add push-based operational metrics reporter for admin dashboard**

Introduces a lightweight, non-blocking stats pipeline that aggregates write-path events and persists them to shared DB tables, enabling an admin dashboard to display per-user and system-wide operational metrics.

**What's new**

- `memoria-service/src/stats_reporter.rs` — new `StatsReporter` with a bounded async channel and a background batch writer. Events are silently dropped when the channel is full; the write path is never blocked.
- Five new `srv_*` tables auto-created on startup (`srv_user_stats`, `srv_user_metric_detail`, `srv_daily_stats`, `srv_user_api_stats`, `srv_mcp_path_stats`). All writes use `INSERT ... ON DUPLICATE KEY UPDATE` for idempotency.
- `StatsEvent` variants cover: memory stored/deactivated/activated, edit logged, entities upserted, API/MCP call completed.
- `MemoryService` gains `init_stats()` / `with_stats()` to attach the reporter after construction via `OnceLock`, with zero overhead when disabled.
- `AppState` wires up the reporter when `MEMORIA_OPS_METRICS=true` (default).
- `mcp_handler` reports accurate success/failure using `rpc.success` rather than HTTP status (JSON-RPC errors always return HTTP 200).
- `soft_delete_from` now returns `rows_affected` and adds `AND is_active = 1` to the `UPDATE` predicate, making it idempotent and allowing callers to skip reporting deactivation events for already-inactive memories.

**Design constraints**

- Best-effort only: no retries, no blocking, no impact on request latency.
- No user memory content is stored — only aggregate counters and category labels.
- Opt-out via `MEMORIA_OPS_METRICS=0` env var.
- `CREATE TABLE IF NOT EXISTS` in both `store.rs` and `router.rs` ensures tables exist in single-db and multi-db deployments without migration tooling.

**Test changes**

Added `ops_metrics_enabled: false` to test `Config` structs in `main.rs`, `scheduler.rs`, and `plugin_repository.rs` to keep existing tests compiling without a DB.