### PR TITLE
feat: auto-migrate legacy local startup

### DIFF
--- a/memoria/crates/memoria-cli/src/main.rs
+++ b/memoria/crates/memoria-cli/src/main.rs
@@ -415,6 +415,60 @@ async fn connect_git_pool(database_url: &str, multi_db: bool) -> Result<sqlx::My
 }
 
 #[cfg(feature = "server-runtime")]
+async fn bootstrap_runtime_topology(cfg: &mut memoria_service::Config) -> Result<()> {
+    use memoria_storage::{
+        detect_runtime_topology, execute_legacy_single_db_to_multi_db,
+        LegacyToMultiDbMigrationOptions, RuntimeTopology,
+    };
+
+    if cfg.multi_db {
+        return Ok(());
+    }
+
+    match detect_runtime_topology(&cfg.db_url, &cfg.shared_db_url).await? {
+        RuntimeTopology::FreshSingleDb => Ok(()),
+        RuntimeTopology::MultiDbReady => {
+            tracing::info!(
+                shared_db_url = %redact_url(&cfg.shared_db_url),
+                "Detected completed shared registry behind legacy config; continuing in multi-db mode"
+            );
+            enable_runtime_multi_db(cfg);
+            Ok(())
+        }
+        RuntimeTopology::PendingLegacyMigration(pending) => {
+            tracing::info!(
+                legacy_db_name = %pending.legacy_db_name,
+                shared_db_name = %pending.shared_db_name,
+                users = pending.legacy_users.len(),
+                missing_users = pending.missing_users.len(),
+                "Auto-migrating legacy single-db deployment before startup"
+            );
+            execute_legacy_single_db_to_multi_db(
+                &cfg.db_url,
+                &cfg.shared_db_url,
+                cfg.embedding_dim,
+                LegacyToMultiDbMigrationOptions::default(),
+            )
+            .await?;
+            enable_runtime_multi_db(cfg);
+            tracing::info!(
+                shared_db_url = %redact_url(&cfg.shared_db_url),
+                "Legacy migration completed; continuing startup in multi-db mode"
+            );
+            Ok(())
+        }
+    }
+}
+
+#[cfg(feature = "server-runtime")]
+fn enable_runtime_multi_db(cfg: &mut memoria_service::Config) {
+    cfg.multi_db = true;
+    if let Some(db_name) = parse_db_name(&cfg.shared_db_url) {
+        cfg.db_name = db_name;
+    }
+}
+
+#[cfg(feature = "server-runtime")]
 async fn cmd_serve(db_url: Option<String>, port: u16, master_key: String) -> Result<()> {
     use memoria_api::{build_router, AppState};
     use memoria_git::GitForDataService;
@@ -430,6 +484,7 @@ async fn cmd_serve(db_url: Option<String>, port: u16, master_key: String) -> Res
     }
 
     validate_embedding_config(&cfg)?;
+    bootstrap_runtime_topology(&mut cfg).await?;
     let redacted_db_url = redact_url(&cfg.db_url);
     let redacted_shared_db_url = redact_url(&cfg.shared_db_url);
 
@@ -602,6 +657,8 @@ async fn cmd_mcp(
     if let Some(v) = db_name {
         cfg.db_name = v;
     }
+    validate_embedding_config(&cfg)?;
+    bootstrap_runtime_topology(&mut cfg).await?;
     let redacted_db_url = redact_url(&cfg.db_url);
     let redacted_shared_db_url = redact_url(&cfg.shared_db_url);
 
@@ -3355,8 +3412,8 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        redact_url, run_with_edit_log_drain, validate_embedding_config, Cli, Commands,
-        MigrationCommands,
+        enable_runtime_multi_db, redact_url, run_with_edit_log_drain, validate_embedding_config,
+        Cli, Commands, MigrationCommands,
     };
     use async_trait::async_trait;
     use clap::Parser;
@@ -3572,6 +3629,17 @@ mod tests {
     }
 
     #[test]
+    fn enable_runtime_multi_db_switches_to_shared_db_name() {
+        let mut cfg = test_config();
+
+        enable_runtime_multi_db(&mut cfg);
+
+        assert!(cfg.multi_db);
+        assert_eq!(cfg.db_name, "memoria_shared");
+        assert_eq!(cfg.db_url, "mysql://root:111@localhost:6001/memoria");
+    }
+
+    #[test]
     fn mcp_entry_includes_auto_approve() {
         use super::mcp_entry;
 
@@ -3597,7 +3665,12 @@ mod tests {
             "autoApprove must contain at least one tool"
         );
         // Core tools that the issue specifically calls out
-        for tool in &["memory_store", "memory_retrieve", "memory_search", "memory_purge"] {
+        for tool in &[
+            "memory_store",
+            "memory_retrieve",
+            "memory_search",
+            "memory_purge",
+        ] {
             assert!(
                 approved.iter().any(|v| v.as_str() == Some(tool)),
                 "autoApprove is missing tool: {tool}"

--- a/memoria/crates/memoria-storage/src/lib.rs
+++ b/memoria/crates/memoria-storage/src/lib.rs
@@ -9,9 +9,10 @@ pub use graph::{
     GraphStore,
 };
 pub use migration::{
-    execute_legacy_single_db_to_multi_db, plan_legacy_single_db_to_multi_db,
-    LegacyToMultiDbMigrationOptions, LegacyToMultiDbMigrationReport, TableMigrationReport,
-    UserMigrationReport,
+    detect_runtime_topology, execute_legacy_single_db_to_multi_db,
+    plan_legacy_single_db_to_multi_db, LegacyToMultiDbMigrationOptions,
+    LegacyToMultiDbMigrationReport, PendingLegacyMultiDbMigration, RuntimeTopology,
+    TableMigrationReport, UserMigrationReport,
 };
 pub use router::{DbRouter, UserDatabaseRecord};
 pub use store::{

--- a/memoria/crates/memoria-storage/src/migration.rs
+++ b/memoria/crates/memoria-storage/src/migration.rs
@@ -70,6 +70,21 @@ pub struct TableMigrationReport {
     pub note: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingLegacyMultiDbMigration {
+    pub legacy_db_name: String,
+    pub shared_db_name: String,
+    pub legacy_users: Vec<String>,
+    pub missing_users: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeTopology {
+    FreshSingleDb,
+    PendingLegacyMigration(PendingLegacyMultiDbMigration),
+    MultiDbReady,
+}
+
 #[derive(Debug, Clone)]
 struct ColumnSpec {
     name: String,
@@ -102,6 +117,37 @@ pub async fn execute_legacy_single_db_to_multi_db(
 ) -> Result<LegacyToMultiDbMigrationReport, MemoriaError> {
     run_legacy_single_db_to_multi_db(legacy_db_url, shared_db_url, embedding_dim, options, false)
         .await
+}
+
+pub async fn detect_runtime_topology(
+    legacy_db_url: &str,
+    shared_db_url: &str,
+) -> Result<RuntimeTopology, MemoriaError> {
+    let legacy_db_name = parse_db_name(legacy_db_url)?;
+    let shared_db_name = parse_db_name(shared_db_url)?;
+    if legacy_db_name == shared_db_name {
+        return Ok(RuntimeTopology::FreshSingleDb);
+    }
+
+    let legacy_pool = match connect_pool(legacy_db_url).await {
+        Ok(pool) => pool,
+        Err(MemoriaError::Database(msg))
+            if is_unknown_database_error_message(&msg, &legacy_db_name) =>
+        {
+            return Ok(RuntimeTopology::FreshSingleDb);
+        }
+        Err(err) => return Err(err),
+    };
+    let legacy_users = discover_users(&legacy_pool, &legacy_db_name).await?;
+    let shared_users =
+        load_active_shared_registry_users_or_empty(shared_db_url, &shared_db_name).await?;
+
+    Ok(classify_runtime_topology(
+        legacy_db_name,
+        shared_db_name,
+        legacy_users,
+        shared_users,
+    ))
 }
 
 async fn run_legacy_single_db_to_multi_db(
@@ -244,8 +290,7 @@ async fn run_legacy_single_db_to_multi_db(
                         if execute {
                             println!("Migrating user {user_id}");
                         }
-                        let res =
-                            migrate_user(pool, db_name, router_ref, user_id, execute).await;
+                        let res = migrate_user(pool, db_name, router_ref, user_id, execute).await;
                         (user_id.as_str(), res)
                     }
                 })
@@ -568,6 +613,35 @@ fn split_database_url(database_url: &str) -> Option<(&str, &str, &str)> {
     Some((base, db_name, suffix))
 }
 
+fn classify_runtime_topology(
+    legacy_db_name: String,
+    shared_db_name: String,
+    mut legacy_users: Vec<String>,
+    shared_users: BTreeSet<String>,
+) -> RuntimeTopology {
+    legacy_users.sort();
+    legacy_users.dedup();
+    if legacy_users.is_empty() {
+        return RuntimeTopology::FreshSingleDb;
+    }
+
+    let missing_users = legacy_users
+        .iter()
+        .filter(|user_id| !shared_users.contains(*user_id))
+        .cloned()
+        .collect::<Vec<_>>();
+    if missing_users.is_empty() {
+        RuntimeTopology::MultiDbReady
+    } else {
+        RuntimeTopology::PendingLegacyMigration(PendingLegacyMultiDbMigration {
+            legacy_db_name,
+            shared_db_name,
+            legacy_users,
+            missing_users,
+        })
+    }
+}
+
 async fn discover_users(pool: &MySqlPool, db_name: &str) -> Result<Vec<String>, MemoriaError> {
     let rows = sqlx::query(
         "SELECT DISTINCT table_name FROM information_schema.columns \
@@ -597,6 +671,33 @@ async fn discover_users(pool: &MySqlPool, db_name: &str) -> Result<Vec<String>, 
         }
     }
     Ok(users.into_iter().collect())
+}
+
+async fn load_active_shared_registry_users_or_empty(
+    shared_db_url: &str,
+    shared_db_name: &str,
+) -> Result<BTreeSet<String>, MemoriaError> {
+    let shared_pool = match connect_pool(shared_db_url).await {
+        Ok(pool) => pool,
+        Err(MemoriaError::Database(msg))
+            if is_unknown_database_error_message(&msg, shared_db_name) =>
+        {
+            return Ok(BTreeSet::new());
+        }
+        Err(err) => return Err(err),
+    };
+
+    if !table_exists(&shared_pool, shared_db_name, "mem_user_registry").await? {
+        return Ok(BTreeSet::new());
+    }
+
+    let rows = sqlx::query("SELECT user_id FROM mem_user_registry WHERE status = 'active'")
+        .fetch_all(&shared_pool)
+        .await
+        .map_err(db_err)?;
+    rows.into_iter()
+        .map(|row| row.try_get("user_id").map_err(db_err))
+        .collect::<Result<BTreeSet<String>, MemoriaError>>()
 }
 
 async fn collect_active_snapshot_violations(
@@ -1150,13 +1251,23 @@ fn db_err(e: sqlx::Error) -> MemoriaError {
     MemoriaError::Database(e.to_string())
 }
 
+fn is_unknown_database_error_message(message: &str, db_name: &str) -> bool {
+    message.contains("1049")
+        && message.contains("Unknown database")
+        && (message.contains(db_name)
+            || message.contains(&format!("'{db_name}'"))
+            || message.contains(&format!("`{db_name}`")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        copyable_columns, pre_execute_account_snapshot_name, quote_ident,
-        sanitize_identifier_fragment, ColumnSpec, MAX_IDENTIFIER_LEN,
-        PRE_EXECUTE_ACCOUNT_SNAPSHOT_PREFIX, PRE_EXECUTE_ACCOUNT_SNAPSHOT_SUFFIX_LEN,
+        classify_runtime_topology, copyable_columns, pre_execute_account_snapshot_name,
+        quote_ident, sanitize_identifier_fragment, ColumnSpec, PendingLegacyMultiDbMigration,
+        RuntimeTopology, MAX_IDENTIFIER_LEN, PRE_EXECUTE_ACCOUNT_SNAPSHOT_PREFIX,
+        PRE_EXECUTE_ACCOUNT_SNAPSHOT_SUFFIX_LEN,
     };
+    use std::collections::BTreeSet;
 
     fn col(name: &str, nullable: bool, has_default: bool, auto_increment: bool) -> ColumnSpec {
         ColumnSpec {
@@ -1198,6 +1309,50 @@ mod tests {
     #[test]
     fn quote_ident_escapes_backticks() {
         assert_eq!(quote_ident("a`b"), "`a``b`");
+    }
+
+    #[test]
+    fn classify_runtime_topology_detects_fresh_single_db() {
+        let topology = classify_runtime_topology(
+            "memoria".to_string(),
+            "memoria_shared".to_string(),
+            vec![],
+            BTreeSet::new(),
+        );
+
+        assert_eq!(topology, RuntimeTopology::FreshSingleDb);
+    }
+
+    #[test]
+    fn classify_runtime_topology_detects_pending_migration() {
+        let topology = classify_runtime_topology(
+            "memoria".to_string(),
+            "memoria_shared".to_string(),
+            vec!["bob".to_string(), "alice".to_string()],
+            BTreeSet::from(["alice".to_string()]),
+        );
+
+        assert_eq!(
+            topology,
+            RuntimeTopology::PendingLegacyMigration(PendingLegacyMultiDbMigration {
+                legacy_db_name: "memoria".to_string(),
+                shared_db_name: "memoria_shared".to_string(),
+                legacy_users: vec!["alice".to_string(), "bob".to_string()],
+                missing_users: vec!["bob".to_string()],
+            })
+        );
+    }
+
+    #[test]
+    fn classify_runtime_topology_detects_multi_db_ready() {
+        let topology = classify_runtime_topology(
+            "memoria".to_string(),
+            "memoria_shared".to_string(),
+            vec!["bob".to_string(), "alice".to_string()],
+            BTreeSet::from(["alice".to_string(), "bob".to_string()]),
+        );
+
+        assert_eq!(topology, RuntimeTopology::MultiDbReady);
     }
 
     #[test]

--- a/memoria/crates/memoria-storage/src/migration.rs
+++ b/memoria/crates/memoria-storage/src/migration.rs
@@ -207,14 +207,14 @@ async fn run_legacy_single_db_to_multi_db(
         None
     } else {
         let snapshot_name = create_required_account_snapshot(&legacy_pool, &legacy_db_name).await?;
-        println!("Created pre-execute account snapshot {snapshot_name}");
+        eprintln!("Created pre-execute account snapshot {snapshot_name}");
         Some(snapshot_name)
     };
 
     let shared_store = if dry_run {
         None
     } else {
-        println!("Resetting target shared database {shared_db_name}");
+        eprintln!("Resetting target shared database {shared_db_name}");
         reset_database(shared_db_url).await?;
         let shared_store =
             SqlMemoryStore::connect(shared_db_url, embedding_dim, MIGRATION_INSTANCE_ID.into())
@@ -238,7 +238,7 @@ async fn run_legacy_single_db_to_multi_db(
     let mut shared_tables = Vec::new();
     for table in SHARED_DURABLE_TABLES {
         if !dry_run {
-            println!("Copying shared table {table}");
+            eprintln!("Copying shared table {table}");
         }
         shared_tables.push(
             copy_shared_table(
@@ -261,7 +261,7 @@ async fn run_legacy_single_db_to_multi_db(
         // Serial path (original behavior)
         for user_id in &selected_users {
             if !dry_run {
-                println!("Migrating user {user_id}");
+                eprintln!("Migrating user {user_id}");
             }
             users.push(
                 migrate_user(
@@ -288,7 +288,7 @@ async fn run_legacy_single_db_to_multi_db(
                     let execute = !dry_run;
                     async move {
                         if execute {
-                            println!("Migrating user {user_id}");
+                            eprintln!("Migrating user {user_id}");
                         }
                         let res = migrate_user(pool, db_name, router_ref, user_id, execute).await;
                         (user_id.as_str(), res)
@@ -338,7 +338,7 @@ async fn migrate_user(
             .ok_or_else(|| MemoriaError::Internal("missing router for execute mode".into()))?;
         let target_db = DbRouter::user_db_name_for_id(user_id);
         let target_url = router.user_db_url(&target_db)?;
-        println!("  Resetting target user database {target_db}");
+        eprintln!("  Resetting target user database {target_db}");
         reset_database(&target_url).await?;
         router.invalidate_user(user_id).await;
         // Register user in shared DB so runtime can discover it later
@@ -375,7 +375,7 @@ async fn migrate_user(
             .filter(|table| !is_physical_branch_table(table))
             .collect::<Vec<_>>();
         for table in target_tables {
-            println!("  Copying user table {table}");
+            eprintln!("  Copying user table {table}");
             tables.push(
                 copy_user_scoped_table(
                     legacy_pool,
@@ -391,7 +391,7 @@ async fn migrate_user(
         }
 
         tables.push({
-            println!("  Copying user table mem_memories_stats");
+            eprintln!("  Copying user table mem_memories_stats");
             copy_memories_stats_table(
                 legacy_pool,
                 legacy_db_name,
@@ -405,7 +405,7 @@ async fn migrate_user(
 
         let branches = load_branch_records(legacy_pool, legacy_db_name, user_id).await?;
         for branch in branches {
-            println!("  Copying branch table {}", branch.table_name);
+            eprintln!("  Copying branch table {}", branch.table_name);
             let mut report = copy_branch_table(
                 legacy_pool,
                 legacy_db_name,

--- a/memoria/crates/memoria-storage/src/migration.rs
+++ b/memoria/crates/memoria-storage/src/migration.rs
@@ -134,7 +134,14 @@ pub async fn detect_runtime_topology(
         Err(MemoriaError::Database(msg))
             if is_unknown_database_error_message(&msg, &legacy_db_name) =>
         {
-            return Ok(RuntimeTopology::FreshSingleDb);
+            let shared_users =
+                load_active_shared_registry_users_or_empty(shared_db_url, &shared_db_name).await?;
+            return Ok(classify_runtime_topology(
+                legacy_db_name,
+                shared_db_name,
+                vec![],
+                shared_users,
+            ));
         }
         Err(err) => return Err(err),
     };
@@ -622,7 +629,11 @@ fn classify_runtime_topology(
     legacy_users.sort();
     legacy_users.dedup();
     if legacy_users.is_empty() {
-        return RuntimeTopology::FreshSingleDb;
+        return if shared_users.is_empty() {
+            RuntimeTopology::FreshSingleDb
+        } else {
+            RuntimeTopology::MultiDbReady
+        };
     }
 
     let missing_users = legacy_users
@@ -1350,6 +1361,18 @@ mod tests {
             "memoria_shared".to_string(),
             vec!["bob".to_string(), "alice".to_string()],
             BTreeSet::from(["alice".to_string(), "bob".to_string()]),
+        );
+
+        assert_eq!(topology, RuntimeTopology::MultiDbReady);
+    }
+
+    #[test]
+    fn classify_runtime_topology_detects_multi_db_ready_without_legacy_users() {
+        let topology = classify_runtime_topology(
+            "memoria".to_string(),
+            "memoria_shared".to_string(),
+            vec![],
+            BTreeSet::from(["alice".to_string()]),
         );
 
         assert_eq!(topology, RuntimeTopology::MultiDbReady);


### PR DESCRIPTION
## Summary
- detect startup topology and auto-run legacy single-db to multi-db migration when old local data is present
- switch already-migrated deployments to multi-db in memory even when users still launch with legacy config
- keep MCP stdio JSON clean during first-run migration by sending migration progress to stderr instead of stdout

## Tested
- 89e8281 -> ghs/auto-migrate-startup: seeded 10 legacy users with 50 memories each, verified auto-migration on startup, then verified API and stdio MCP read/write for existing users and new users
- upstream/main (already-migrated data, legacy config) -> ghs/auto-migrate-startup: seeded 10 users with 50 memories each, verified startup detects completed shared registry and runs normally in multi-db mode, then verified API and stdio MCP read/write for existing users and new users
- make check in upstream-main-auto-migrate/memoria