### PR TITLE
fix(memory): enforce strict session retrieval semantics

### DIFF
--- a/memoria/crates/memoria-api/src/models.rs
+++ b/memoria/crates/memoria-api/src/models.rs
@@ -33,6 +33,9 @@ pub struct RetrieveRequest {
     #[serde(default = "default_top_k")]
     pub top_k: i64,
     pub session_id: Option<String>,
+    /// Explicit strict session filter. Overrides include_cross_session when provided.
+    #[serde(default)]
+    pub filter_session: Option<bool>,
     /// When false and session_id is set, only return memories from that session.
     #[serde(default = "default_true")]
     pub include_cross_session: bool,
@@ -45,6 +48,16 @@ fn default_top_k() -> i64 {
 }
 fn default_true() -> bool {
     true
+}
+
+impl RetrieveRequest {
+    pub fn retrieve_options(&self) -> memoria_service::RetrieveOptions {
+        memoria_service::RetrieveOptions::from_session_scope(
+            self.session_id.as_deref(),
+            self.filter_session,
+            Some(self.include_cross_session),
+        )
+    }
 }
 
 fn deserialize_explain<'de, D: serde::Deserializer<'de>>(d: D) -> Result<String, D::Error> {

--- a/memoria/crates/memoria-api/src/routes/memory.rs
+++ b/memoria/crates/memoria-api/src/routes/memory.rs
@@ -211,6 +211,13 @@ pub async fn retrieve(
     AuthUser { user_id, .. }: AuthUser,
     Json(req): Json<RetrieveRequest>,
 ) -> ApiResult<serde_json::Value> {
+    if req.session_id.is_none() && (req.filter_session == Some(true) || !req.include_cross_session)
+    {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "session_id is required for strict session retrieval".to_string(),
+        ));
+    }
     let top_k = req.top_k.clamp(1, 100);
     let level = memoria_service::ExplainLevel::from_str_or_bool(&req.explain);
     let retrieve_options = req.retrieve_options();

--- a/memoria/crates/memoria-api/src/routes/memory.rs
+++ b/memoria/crates/memoria-api/src/routes/memory.rs
@@ -213,37 +213,31 @@ pub async fn retrieve(
 ) -> ApiResult<serde_json::Value> {
     let top_k = req.top_k.clamp(1, 100);
     let level = memoria_service::ExplainLevel::from_str_or_bool(&req.explain);
-    let filter_session = req
-        .session_id
-        .as_deref()
-        .filter(|_| !req.include_cross_session);
-
-    let apply_filter = |mut mems: Vec<memoria_core::Memory>| -> Vec<memoria_core::Memory> {
-        if let Some(sid) = filter_session {
-            mems.retain(|m| m.session_id.as_deref() == Some(sid));
-        }
-        mems
-    };
+    let retrieve_options = req.retrieve_options();
 
     if level != memoria_service::ExplainLevel::None {
         let (results, explain) = state
             .service
-            .retrieve_explain_level(&user_id, &req.query, top_k, level)
+            .retrieve_explain_level_with_options(
+                &user_id,
+                &req.query,
+                top_k,
+                level,
+                &retrieve_options,
+            )
             .await
             .map_err(api_err)?;
-        let items: Vec<MemoryResponse> =
-            apply_filter(results).into_iter().map(Into::into).collect();
+        let items: Vec<MemoryResponse> = results.into_iter().map(Into::into).collect();
         Ok(Json(
             serde_json::json!({"results": items, "explain": explain}),
         ))
     } else {
         let results = state
             .service
-            .retrieve(&user_id, &req.query, top_k)
+            .retrieve_with_options(&user_id, &req.query, top_k, &retrieve_options)
             .await
             .map_err(api_err)?;
-        let items: Vec<MemoryResponse> =
-            apply_filter(results).into_iter().map(Into::into).collect();
+        let items: Vec<MemoryResponse> = results.into_iter().map(Into::into).collect();
         Ok(Json(serde_json::json!(items)))
     }
 }

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -3360,39 +3360,6 @@ async fn test_retrieve_filter_session_preserves_top_k_with_session_candidates() 
         store_memory_for_session(&client, &base, &uid, "global-candidate-b", "sess-other").await;
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
-    let relaxed = client
-        .post(format!("{base}/v1/memories/retrieve"))
-        .header("X-User-Id", &uid)
-        .json(&json!({
-                "query": "scoped topk query",
-                "session_id": "sess-target",
-                "top_k": 2
-        }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(relaxed.status(), 200);
-    let relaxed_body: Value = relaxed.json().await.unwrap();
-    let relaxed_results = relaxed_body
-        .as_array()
-        .expect("retrieve should return array");
-    assert_eq!(relaxed_results.len(), 2);
-    assert!(
-        relaxed_results
-            .iter()
-            .any(|item| item["session_id"].as_str() == Some("sess-other")),
-        "relaxed retrieval should still be free to return cross-session candidates",
-    );
-    let relaxed_target_ids: std::collections::HashSet<&str> = relaxed_results
-        .iter()
-        .filter(|item| item["session_id"].as_str() == Some("sess-target"))
-        .filter_map(|item| item["memory_id"].as_str())
-        .collect();
-    assert!(
-        relaxed_target_ids.len() < 2,
-        "without strict session pre-filter, a global top_k should not reliably preserve all target-session candidates",
-    );
-
     let strict = client
         .post(format!("{base}/v1/memories/retrieve"))
         .header("X-User-Id", &uid)

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -2555,7 +2555,7 @@ async fn spawn_server_with_custom_embedder_and_pool(
         .await
         .expect("connect");
     store.migrate().await.expect("migrate");
-    let pool = sqlx::MySqlPool::connect(&db).await.expect("pool");
+    let pool = store.pool().clone();
     let git = Arc::new(GitForDataService::new(pool.clone(), &cfg.db_name));
     let service =
         Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), Some(embedder), None).await);
@@ -3309,6 +3309,38 @@ async fn test_retrieve_filter_session_prefilters_and_skips_graph() {
         Some(target_mid.as_str()),
         "legacy include_cross_session=false should keep strict session semantics",
     );
+}
+
+#[tokio::test]
+async fn test_retrieve_filter_session_requires_session_id() {
+    let (base, client) = spawn_server().await;
+    let user = uid();
+
+    let r = client
+        .post(format!("{base}/v1/memories/retrieve"))
+        .header("X-User-Id", &user)
+        .json(&json!({
+            "query": "strict session query",
+            "filter_session": true,
+            "top_k": 1
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 422);
+
+    let r = client
+        .post(format!("{base}/v1/memories/retrieve"))
+        .header("X-User-Id", &user)
+        .json(&json!({
+            "query": "strict session query",
+            "include_cross_session": false,
+            "top_k": 1
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 422);
 }
 
 #[tokio::test]

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -48,6 +48,52 @@ async fn spawn_fake_llm() -> (
     memoria_test_utils::spawn_fake_llm(episodic_rules()).await
 }
 
+struct SessionScopeTestEmbedder;
+
+impl SessionScopeTestEmbedder {
+    fn vector_for(text: &str) -> Vec<f32> {
+        let mut v = vec![0.0; test_dim()];
+        match text {
+            "strict session query" | "other-session top" => v[0] = 1.0,
+            "scoped topk query" | "global-candidate-a" => v[0] = 1.0,
+            "other-session second" => {
+                v[0] = 0.98;
+                v[1] = 0.02;
+            }
+            "global-candidate-b" => {
+                v[0] = 0.97;
+                v[1] = 0.03;
+            }
+            "target-session memory" => v[1] = 1.0,
+            "scoped-candidate-a" => {
+                v[0] = 0.6;
+                v[1] = 0.4;
+            }
+            "target-session backup" => {
+                v[1] = 0.97;
+                v[2] = 0.03;
+            }
+            "scoped-candidate-b" => {
+                v[0] = 0.3;
+                v[1] = 0.7;
+            }
+            _ => v[2] = 1.0,
+        }
+        v
+    }
+}
+
+#[async_trait::async_trait]
+impl memoria_core::interfaces::EmbeddingProvider for SessionScopeTestEmbedder {
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, memoria_core::MemoriaError> {
+        Ok(Self::vector_for(text))
+    }
+
+    fn dimension(&self) -> usize {
+        test_dim()
+    }
+}
+
 /// Returns (key, base_url, model) if EMBEDDING_API_KEY is set, else None.
 fn try_embedding() -> Option<(String, String, String)> {
     let key = std::env::var("EMBEDDING_API_KEY")
@@ -2495,6 +2541,55 @@ async fn spawn_server_with_embedding(
     (format!("http://127.0.0.1:{port}"), client)
 }
 
+async fn spawn_server_with_custom_embedder_and_pool(
+    embedder: Arc<dyn memoria_core::interfaces::EmbeddingProvider>,
+    dim: usize,
+) -> (String, reqwest::Client, sqlx::MySqlPool) {
+    use memoria_git::GitForDataService;
+    use memoria_service::{Config, MemoryService};
+    use memoria_storage::SqlMemoryStore;
+
+    let cfg = Config::from_env();
+    let db = db_url();
+    let store = SqlMemoryStore::connect(&db, dim, uuid::Uuid::new_v4().to_string())
+        .await
+        .expect("connect");
+    store.migrate().await.expect("migrate");
+    let pool = sqlx::MySqlPool::connect(&db).await.expect("pool");
+    let git = Arc::new(GitForDataService::new(pool.clone(), &cfg.db_name));
+    let service =
+        Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), Some(embedder), None).await);
+    let state = memoria_api::AppState::new(service, git, String::new());
+    let app = memoria_api::build_router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+    let client = reqwest::Client::builder().no_proxy().build().unwrap();
+    (format!("http://127.0.0.1:{port}"), client, pool)
+}
+
+async fn store_memory_for_session(
+    client: &reqwest::Client,
+    base: &str,
+    user_id: &str,
+    content: &str,
+    session_id: &str,
+) -> String {
+    let r = client
+        .post(format!("{base}/v1/memories"))
+        .header("X-User-Id", user_id)
+        .json(&json!({"content": content, "session_id": session_id}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 201);
+    r.json::<Value>().await.unwrap()["memory_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
 #[tokio::test]
 async fn test_episodic_no_memories_returns_error() {
     let (llm, _shutdown) = spawn_fake_llm().await;
@@ -3090,6 +3185,223 @@ async fn test_explain_verbose_candidate_scores() {
     } else {
         println!("⚠️  no results returned (embedding may not have indexed yet)");
     }
+}
+
+#[tokio::test]
+async fn test_retrieve_filter_session_prefilters_and_skips_graph() {
+    use memoria_storage::{GraphEdge, GraphNode, GraphStore, NodeType};
+
+    let (base, client, pool) =
+        spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
+            .await;
+    let uid = uid();
+
+    let target_mid =
+        store_memory_for_session(&client, &base, &uid, "target-session memory", "sess-target")
+            .await;
+    let other_mid =
+        store_memory_for_session(&client, &base, &uid, "other-session top", "sess-other").await;
+    let other_second_mid =
+        store_memory_for_session(&client, &base, &uid, "other-session second", "sess-other").await;
+
+    let graph = GraphStore::new(pool, test_dim());
+    graph.migrate().await.expect("graph migrate");
+
+    let make_node = |memory_id: &str, session_id: &str, content: &str| GraphNode {
+        node_id: uuid::Uuid::new_v4().simple().to_string()[..32].to_string(),
+        user_id: uid.clone(),
+        node_type: NodeType::Semantic,
+        content: content.to_string(),
+        entity_type: None,
+        embedding: Some(SessionScopeTestEmbedder::vector_for(content)),
+        memory_id: Some(memory_id.to_string()),
+        session_id: Some(session_id.to_string()),
+        confidence: 0.95,
+        trust_tier: "T1".to_string(),
+        importance: 0.5,
+        source_nodes: vec![],
+        conflicts_with: None,
+        conflict_resolution: None,
+        access_count: 0,
+        cross_session_count: 0,
+        is_active: true,
+        superseded_by: None,
+        created_at: Some(chrono::Utc::now().naive_utc()),
+    };
+
+    let target_node = make_node(&target_mid, "sess-target", "target-session memory");
+    let other_node = make_node(&other_mid, "sess-other", "other-session top");
+    let other_second_node = make_node(&other_second_mid, "sess-other", "other-session second");
+    graph.create_node(&target_node).await.unwrap();
+    graph.create_node(&other_node).await.unwrap();
+    graph.create_node(&other_second_node).await.unwrap();
+    graph
+        .add_edge(&GraphEdge {
+            source_id: other_node.node_id.clone(),
+            target_id: other_second_node.node_id.clone(),
+            edge_type: "association".to_string(),
+            weight: 1.0,
+            user_id: uid.clone(),
+        })
+        .await
+        .unwrap();
+
+    let relaxed = client
+        .post(format!("{base}/v1/memories/retrieve"))
+        .header("X-User-Id", &uid)
+        .json(&json!({
+            "query": "strict session query",
+            "session_id": "sess-target",
+            "top_k": 1,
+            "explain": true
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(relaxed.status(), 200);
+    let relaxed_body: Value = relaxed.json().await.unwrap();
+    assert_eq!(relaxed_body["explain"]["graph_attempted"], true);
+    assert_eq!(
+        relaxed_body["results"][0]["session_id"].as_str(),
+        Some("sess-other"),
+        "cross-session retrieval should still be free to return another session",
+    );
+
+    let strict = client
+        .post(format!("{base}/v1/memories/retrieve"))
+        .header("X-User-Id", &uid)
+        .json(&json!({
+            "query": "strict session query",
+            "session_id": "sess-target",
+            "filter_session": true,
+            "top_k": 1,
+            "explain": true
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(strict.status(), 200);
+    let strict_body: Value = strict.json().await.unwrap();
+    assert_eq!(strict_body["explain"]["graph_attempted"], false);
+    assert_ne!(strict_body["explain"]["path"], "graph");
+    assert_eq!(
+        strict_body["results"][0]["memory_id"].as_str(),
+        Some(target_mid.as_str()),
+        "strict session retrieval should pre-filter tabular candidates before ranking",
+    );
+
+    let legacy = client
+        .post(format!("{base}/v1/memories/retrieve"))
+        .header("X-User-Id", &uid)
+        .json(&json!({
+            "query": "strict session query",
+            "session_id": "sess-target",
+            "include_cross_session": false,
+            "top_k": 1
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(legacy.status(), 200);
+    let legacy_body: Value = legacy.json().await.unwrap();
+    assert_eq!(
+        legacy_body[0]["memory_id"].as_str(),
+        Some(target_mid.as_str()),
+        "legacy include_cross_session=false should keep strict session semantics",
+    );
+}
+
+#[tokio::test]
+async fn test_retrieve_filter_session_preserves_top_k_with_session_candidates() {
+    let (base, client, _pool) =
+        spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
+            .await;
+    let uid = uid();
+
+    let target_first =
+        store_memory_for_session(&client, &base, &uid, "scoped-candidate-a", "sess-target").await;
+    let target_second =
+        store_memory_for_session(&client, &base, &uid, "scoped-candidate-b", "sess-target").await;
+    let _other_first =
+        store_memory_for_session(&client, &base, &uid, "global-candidate-a", "sess-other").await;
+    let _other_second =
+        store_memory_for_session(&client, &base, &uid, "global-candidate-b", "sess-other").await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    let relaxed = client
+        .post(format!("{base}/v1/memories/retrieve"))
+        .header("X-User-Id", &uid)
+        .json(&json!({
+                "query": "scoped topk query",
+                "session_id": "sess-target",
+                "top_k": 2
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(relaxed.status(), 200);
+    let relaxed_body: Value = relaxed.json().await.unwrap();
+    let relaxed_results = relaxed_body
+        .as_array()
+        .expect("retrieve should return array");
+    assert_eq!(relaxed_results.len(), 2);
+    assert!(
+        relaxed_results
+            .iter()
+            .any(|item| item["session_id"].as_str() == Some("sess-other")),
+        "relaxed retrieval should still be free to return cross-session candidates",
+    );
+    let relaxed_target_ids: std::collections::HashSet<&str> = relaxed_results
+        .iter()
+        .filter(|item| item["session_id"].as_str() == Some("sess-target"))
+        .filter_map(|item| item["memory_id"].as_str())
+        .collect();
+    assert!(
+        relaxed_target_ids.len() < 2,
+        "without strict session pre-filter, a global top_k should not reliably preserve all target-session candidates",
+    );
+
+    let strict = client
+        .post(format!("{base}/v1/memories/retrieve"))
+        .header("X-User-Id", &uid)
+        .json(&json!({
+            "query": "scoped topk query",
+            "session_id": "sess-target",
+            "filter_session": true,
+            "top_k": 2
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(strict.status(), 200);
+    let strict_body: Value = strict.json().await.unwrap();
+    let strict_results = strict_body
+        .as_array()
+        .expect("retrieve should return array");
+    assert_eq!(
+        strict_results.len(),
+        2,
+        "strict session retrieval should still fill top_k from session-local candidates",
+    );
+    assert_eq!(
+        strict_results[0]["session_id"].as_str(),
+        Some("sess-target"),
+        "strict session retrieval must only return target-session memories",
+    );
+    assert_eq!(
+        strict_results[1]["session_id"].as_str(),
+        Some("sess-target"),
+        "strict session retrieval must only return target-session memories",
+    );
+    let strict_ids: std::collections::HashSet<&str> = strict_results
+        .iter()
+        .filter_map(|item| item["memory_id"].as_str())
+        .collect();
+    assert_eq!(
+        strict_ids,
+        std::collections::HashSet::from([target_first.as_str(), target_second.as_str()]),
+        "strict retrieval should pre-filter before ranking instead of post-filtering a global top_k",
+    );
 }
 
 #[tokio::test]
@@ -6362,6 +6674,10 @@ async fn mcp_post_with_headers(
         .expect("parse json")
 }
 
+fn mcp_result_text(resp: &Value) -> &str {
+    resp["result"]["content"][0]["text"].as_str().unwrap_or("")
+}
+
 #[tokio::test]
 async fn test_mcp_initialize() {
     let (base, client) = spawn_server().await;
@@ -6447,6 +6763,142 @@ async fn test_mcp_tools_call_memory_store() {
     let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
     assert!(text.contains("Stored"), "expected 'Stored' in: {text}");
     println!("✅ POST /mcp tools/call memory_store: {text}");
+}
+
+#[tokio::test]
+async fn test_mcp_memory_retrieve_filter_session_end_to_end() {
+    let (base, client, _pool) =
+        spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
+            .await;
+    let uid = uid();
+    let headers = [("X-User-Id", uid.as_str())];
+
+    for (id, content, session_id) in [
+        (11, "target-session memory", "sess-target"),
+        (12, "other-session top", "sess-other"),
+        (13, "other-session second", "sess-other"),
+    ] {
+        let resp = mcp_post_with_headers(
+            &client,
+            &base,
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "tools/call",
+                "params": {
+                    "name": "memory_store",
+                    "arguments": {
+                        "content": content,
+                        "memory_type": "semantic",
+                        "session_id": session_id
+                    }
+                }
+            }),
+            &headers,
+        )
+        .await;
+        assert!(
+            resp["error"].is_null(),
+            "unexpected store error: {}",
+            resp["error"]
+        );
+    }
+
+    let relaxed = mcp_post_with_headers(
+        &client,
+        &base,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 14,
+            "method": "tools/call",
+            "params": {
+                "name": "memory_retrieve",
+                "arguments": {
+                    "query": "strict session query",
+                    "session_id": "sess-target",
+                    "top_k": 1
+                }
+            }
+        }),
+        &headers,
+    )
+    .await;
+    assert!(
+        relaxed["error"].is_null(),
+        "unexpected relaxed error: {}",
+        relaxed["error"]
+    );
+    let relaxed_text = mcp_result_text(&relaxed);
+    assert!(
+        relaxed_text.contains("other-session"),
+        "relaxed MCP retrieve should still be free to return cross-session memory: {relaxed_text}"
+    );
+
+    let strict = mcp_post_with_headers(
+        &client,
+        &base,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 15,
+            "method": "tools/call",
+            "params": {
+                "name": "memory_retrieve",
+                "arguments": {
+                    "query": "strict session query",
+                    "session_id": "sess-target",
+                    "filter_session": true,
+                    "top_k": 1
+                }
+            }
+        }),
+        &headers,
+    )
+    .await;
+    assert!(
+        strict["error"].is_null(),
+        "unexpected strict error: {}",
+        strict["error"]
+    );
+    let strict_text = mcp_result_text(&strict);
+    assert!(
+        strict_text.contains("target-session memory"),
+        "strict MCP retrieve should return the target-session memory: {strict_text}"
+    );
+    assert!(
+        !strict_text.contains("other-session top"),
+        "strict MCP retrieve should not leak cross-session memory: {strict_text}"
+    );
+
+    let legacy = mcp_post_with_headers(
+        &client,
+        &base,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 16,
+            "method": "tools/call",
+            "params": {
+                "name": "memory_retrieve",
+                "arguments": {
+                    "query": "strict session query",
+                    "session_id": "sess-target",
+                    "include_cross_session": false,
+                    "top_k": 1
+                }
+            }
+        }),
+        &headers,
+    )
+    .await;
+    assert!(
+        legacy["error"].is_null(),
+        "unexpected legacy error: {}",
+        legacy["error"]
+    );
+    let legacy_text = mcp_result_text(&legacy);
+    assert!(
+        legacy_text.contains("target-session memory"),
+        "legacy MCP retrieve flag should still enforce session scope: {legacy_text}"
+    );
 }
 
 #[tokio::test]

--- a/memoria/crates/memoria-mcp/src/remote.rs
+++ b/memoria/crates/memoria-mcp/src/remote.rs
@@ -108,11 +108,17 @@ impl RemoteClient {
                     "session_id": args["session_id"],
                 });
                 if name == "memory_retrieve" {
-                    if let Some(filter_session) = args.get("filter_session") {
-                        payload["filter_session"] = filter_session.clone();
+                    if let Some(filter_session) = args
+                        .get("filter_session")
+                        .and_then(serde_json::Value::as_bool)
+                    {
+                        payload["filter_session"] = json!(filter_session);
                     }
-                    if let Some(include_cross_session) = args.get("include_cross_session") {
-                        payload["include_cross_session"] = include_cross_session.clone();
+                    if let Some(include_cross_session) = args
+                        .get("include_cross_session")
+                        .and_then(serde_json::Value::as_bool)
+                    {
+                        payload["include_cross_session"] = json!(include_cross_session);
                     }
                 }
                 let r = self

--- a/memoria/crates/memoria-mcp/src/remote.rs
+++ b/memoria/crates/memoria-mcp/src/remote.rs
@@ -102,14 +102,23 @@ impl RemoteClient {
                 } else {
                     "/v1/memories/retrieve"
                 };
+                let mut payload = json!({
+                    "query": args["query"],
+                    "top_k": args["top_k"].as_i64().unwrap_or(5),
+                    "session_id": args["session_id"],
+                });
+                if name == "memory_retrieve" {
+                    if let Some(filter_session) = args.get("filter_session") {
+                        payload["filter_session"] = filter_session.clone();
+                    }
+                    if let Some(include_cross_session) = args.get("include_cross_session") {
+                        payload["include_cross_session"] = include_cross_session.clone();
+                    }
+                }
                 let r = self
                     .client
                     .post(self.url(path))
-                    .json(&json!({
-                        "query": args["query"],
-                        "top_k": args["top_k"].as_i64().unwrap_or(5),
-                        "session_id": args["session_id"],
-                    }))
+                    .json(&payload)
                     .send()
                     .await?;
                 let body = Self::parse_response(r).await?;

--- a/memoria/crates/memoria-mcp/src/tools.rs
+++ b/memoria/crates/memoria-mcp/src/tools.rs
@@ -109,6 +109,8 @@ pub fn list() -> Value {
                     "query": {"type": "string"},
                     "top_k": {"type": "integer", "default": 5},
                     "session_id": {"type": "string"},
+                    "filter_session": {"type": "boolean", "description": "When true, restrict retrieval to the given session_id and bypass cross-session graph retrieval"},
+                    "include_cross_session": {"type": "boolean", "default": true, "description": "Legacy flag. false is equivalent to filter_session=true when session_id is set"},
                     "explain": {"type": ["boolean", "string"], "default": false, "description": "Explain level: false/\"none\"=off, true/\"basic\"=timing+path, \"verbose\"=+per-candidate scores, \"analyze\"=full"}
                 },
                 "required": ["query"]
@@ -248,6 +250,7 @@ pub async fn call(
         "memory_observe" => ToolCallName::MemoryObserve,
         _ => ToolCallName::Unknown(name.to_string()),
     };
+    let is_memory_retrieve = matches!(tool, ToolCallName::MemoryRetrieve);
     match tool {
         ToolCallName::MemoryStore => {
             let content = args["content"].as_str().unwrap_or("").to_string();
@@ -333,6 +336,15 @@ pub async fn call(
         ToolCallName::MemoryRetrieve | ToolCallName::MemorySearch => {
             let query = args["query"].as_str().unwrap_or("").to_string();
             let top_k = args["top_k"].as_i64().unwrap_or(5);
+            let retrieve_options = if is_memory_retrieve {
+                memoria_service::RetrieveOptions::from_session_scope(
+                    args["session_id"].as_str(),
+                    args.get("filter_session").and_then(|v| v.as_bool()),
+                    args.get("include_cross_session").and_then(|v| v.as_bool()),
+                )
+            } else {
+                memoria_service::RetrieveOptions::default()
+            };
             // explain accepts bool or string: true/"basic"/"verbose"/"analyze"
             let explain_str = match &args["explain"] {
                 serde_json::Value::Bool(true) => "basic",
@@ -343,7 +355,13 @@ pub async fn call(
 
             if level != memoria_service::ExplainLevel::None {
                 let (results, stats) = service
-                    .retrieve_explain_level(user_id, &query, top_k, level)
+                    .retrieve_explain_level_with_options(
+                        user_id,
+                        &query,
+                        top_k,
+                        level,
+                        &retrieve_options,
+                    )
                     .await?;
                 if results.is_empty() {
                     let explain_json = serde_json::to_string_pretty(&stats).unwrap_or_default();
@@ -361,7 +379,9 @@ pub async fn call(
                     "{text}\n\n--- explain ---\n{explain_json}"
                 )))
             } else {
-                let results = service.retrieve(user_id, &query, top_k).await?;
+                let results = service
+                    .retrieve_with_options(user_id, &query, top_k, &retrieve_options)
+                    .await?;
                 if results.is_empty() {
                     return Ok(mcp_text("No relevant memories found."));
                 }

--- a/memoria/crates/memoria-service/src/lib.rs
+++ b/memoria/crates/memoria-service/src/lib.rs
@@ -15,7 +15,6 @@ pub mod strategy_domain;
 pub mod vector_index_monitor;
 pub use config::Config;
 pub use distributed::{AsyncTask, AsyncTaskStore, DistributedLock, NoopDistributedLock};
-pub use stats_reporter::StatsReporter;
 pub use governance::{
     DefaultGovernanceStrategy, GovernanceExecution, GovernancePlan, GovernanceRunSummary,
     GovernanceStore, GovernanceStrategy, GovernanceTask,
@@ -47,8 +46,9 @@ pub use scoring::{
 };
 pub use service::{
     CandidateScore, ExplainLevel, InMemoryFlusher, MemoryService, PurgeResult, RetrievalExplain,
-    ENTITY_EXTRACTION_DROPS,
+    RetrieveOptions, ENTITY_EXTRACTION_DROPS,
 };
+pub use stats_reporter::StatsReporter;
 
 /// Wait for SIGTERM or Ctrl-C. Shared across CLI, MCP, and API servers.
 pub async fn shutdown_signal() {

--- a/memoria/crates/memoria-service/src/service.rs
+++ b/memoria/crates/memoria-service/src/service.rs
@@ -63,11 +63,7 @@ impl RetrieveOptions {
         filter_session: Option<bool>,
         include_cross_session: Option<bool>,
     ) -> Self {
-        let strict_session = filter_session.unwrap_or_else(|| {
-            include_cross_session
-                .map(|include| !include)
-                .unwrap_or(false)
-        });
+        let strict_session = filter_session == Some(true) || include_cross_session == Some(false);
         Self {
             strict_session_id: session_id.filter(|_| strict_session).map(str::to_string),
         }

--- a/memoria/crates/memoria-service/src/service.rs
+++ b/memoria/crates/memoria-service/src/service.rs
@@ -49,6 +49,39 @@ impl ExplainLevel {
     }
 }
 
+/// Extra retrieval controls that must be threaded through the full retrieval pipeline.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RetrieveOptions {
+    strict_session_id: Option<String>,
+}
+
+impl RetrieveOptions {
+    /// `filter_session=true` takes precedence over `include_cross_session`.
+    /// When neither is provided, retrieval remains cross-session.
+    pub fn from_session_scope(
+        session_id: Option<&str>,
+        filter_session: Option<bool>,
+        include_cross_session: Option<bool>,
+    ) -> Self {
+        let strict_session = filter_session.unwrap_or_else(|| {
+            include_cross_session
+                .map(|include| !include)
+                .unwrap_or(false)
+        });
+        Self {
+            strict_session_id: session_id.filter(|_| strict_session).map(str::to_string),
+        }
+    }
+
+    pub fn strict_session_id(&self) -> Option<&str> {
+        self.strict_session_id.as_deref()
+    }
+
+    pub fn is_strict_session(&self) -> bool {
+        self.strict_session_id.is_some()
+    }
+}
+
 /// Per-candidate scoring breakdown — answers "why is this memory ranked here?"
 /// Only populated at Verbose/Analyze level.
 #[derive(Debug, serde::Serialize)]
@@ -489,7 +522,12 @@ impl MemoryService {
                     info!("Entity extraction uses routed user stores in multi-db mode");
                 }
                 let (entity_tx, entity_rx) = tokio::sync::mpsc::channel(entity_queue_size);
-                Self::spawn_entity_worker(entity_rx, store.clone(), llm.clone(), stats_cell.clone());
+                Self::spawn_entity_worker(
+                    entity_rx,
+                    store.clone(),
+                    llm.clone(),
+                    stats_cell.clone(),
+                );
                 tracing::info!(entity_queue_size, "entity extraction enabled");
                 Some(entity_tx)
             }
@@ -503,7 +541,12 @@ impl MemoryService {
                 match store.spawn_background_store(entity_pool_size).await {
                     Ok(entity_store) => {
                         let (entity_tx, entity_rx) = tokio::sync::mpsc::channel(entity_queue_size);
-                        Self::spawn_entity_worker(entity_rx, entity_store, llm.clone(), stats_cell.clone());
+                        Self::spawn_entity_worker(
+                            entity_rx,
+                            entity_store,
+                            llm.clone(),
+                            stats_cell.clone(),
+                        );
                         tracing::info!(
                             entity_queue_size,
                             entity_pool_size,
@@ -1296,8 +1339,19 @@ impl MemoryService {
         query: &str,
         top_k: i64,
     ) -> Result<Vec<Memory>, MemoriaError> {
+        self.retrieve_with_options(user_id, query, top_k, &RetrieveOptions::default())
+            .await
+    }
+
+    pub async fn retrieve_with_options(
+        &self,
+        user_id: &str,
+        query: &str,
+        top_k: i64,
+        options: &RetrieveOptions,
+    ) -> Result<Vec<Memory>, MemoriaError> {
         let (mems, _) = self
-            .retrieve_inner(user_id, query, top_k, ExplainLevel::None)
+            .retrieve_inner(user_id, query, top_k, ExplainLevel::None, options)
             .await?;
         self.bump_access_counts(&mems);
         Ok(mems)
@@ -1311,7 +1365,13 @@ impl MemoryService {
         top_k: i64,
     ) -> Result<(Vec<Memory>, RetrievalExplain), MemoriaError> {
         let (mems, explain) = self
-            .retrieve_inner(user_id, query, top_k, ExplainLevel::Basic)
+            .retrieve_inner(
+                user_id,
+                query,
+                top_k,
+                ExplainLevel::Basic,
+                &RetrieveOptions::default(),
+            )
             .await?;
         self.bump_access_counts(&mems);
         Ok((mems, explain))
@@ -1325,8 +1385,28 @@ impl MemoryService {
         top_k: i64,
         level: ExplainLevel,
     ) -> Result<(Vec<Memory>, RetrievalExplain), MemoriaError> {
+        self.retrieve_explain_level_with_options(
+            user_id,
+            query,
+            top_k,
+            level,
+            &RetrieveOptions::default(),
+        )
+        .await
+    }
+
+    pub async fn retrieve_explain_level_with_options(
+        &self,
+        user_id: &str,
+        query: &str,
+        top_k: i64,
+        level: ExplainLevel,
+        options: &RetrieveOptions,
+    ) -> Result<(Vec<Memory>, RetrievalExplain), MemoriaError> {
         let start = std::time::Instant::now();
-        let (mems, explain) = self.retrieve_inner(user_id, query, top_k, level).await?;
+        let (mems, explain) = self
+            .retrieve_inner(user_id, query, top_k, level, options)
+            .await?;
         self.bump_access_counts(&mems);
 
         // 记录查询到 vector monitor（轻量级，无阻塞）
@@ -1356,6 +1436,7 @@ impl MemoryService {
         query: &str,
         top_k: i64,
         level: ExplainLevel,
+        options: &RetrieveOptions,
     ) -> Result<(Vec<Memory>, RetrievalExplain), MemoriaError> {
         let total_start = std::time::Instant::now();
         let mut explain = RetrievalExplain {
@@ -1366,6 +1447,7 @@ impl MemoryService {
         if self.sql_store.is_some() {
             let sql = self.user_sql_store(user_id).await?;
             let table = sql.active_table(user_id).await?;
+            let strict_session_id = options.strict_session_id();
             // Load per-user feedback_weight lazily — only when needed for scoring
             // (avoids extra DB query when fulltext fallback has no feedback to apply)
 
@@ -1375,120 +1457,125 @@ impl MemoryService {
             explain.embedding_ms = p0_start.elapsed().as_secs_f64() * 1000.0;
 
             // Phase 1: graph retrieval (activation-based)
-            if let Some(ref embedding) = emb {
-                explain.graph_attempted = true;
-                let g_start = std::time::Instant::now();
-                // Use isolated graph pool to avoid starving main pool
-                let graph_sql = if self.db_router.is_some() {
-                    sql.as_ref()
-                } else {
-                    self.graph_pool.as_deref().unwrap_or(sql.as_ref())
-                };
-                let graph_store = graph_sql.graph_store();
-                let retriever = memoria_storage::graph::ActivationRetriever::new(&graph_store);
-                match retriever
-                    .retrieve(user_id, query, embedding, top_k, None)
-                    .await
-                {
-                    Ok(scored_nodes) if !scored_nodes.is_empty() => {
-                        explain.graph_ms = g_start.elapsed().as_secs_f64() * 1000.0;
-                        explain.graph_hit = true;
-                        explain.graph_candidates = scored_nodes.len();
+            if strict_session_id.is_none() {
+                if let Some(ref embedding) = emb {
+                    explain.graph_attempted = true;
+                    let g_start = std::time::Instant::now();
+                    // Use isolated graph pool to avoid starving main pool
+                    let graph_sql = if self.db_router.is_some() {
+                        sql.as_ref()
+                    } else {
+                        self.graph_pool.as_deref().unwrap_or(sql.as_ref())
+                    };
+                    let graph_store = graph_sql.graph_store();
+                    let retriever = memoria_storage::graph::ActivationRetriever::new(&graph_store);
+                    match retriever
+                        .retrieve(user_id, query, embedding, top_k, None)
+                        .await
+                    {
+                        Ok(scored_nodes) if !scored_nodes.is_empty() => {
+                            explain.graph_ms = g_start.elapsed().as_secs_f64() * 1000.0;
+                            explain.graph_hit = true;
+                            explain.graph_candidates = scored_nodes.len();
 
-                        // Convert graph nodes to Memory objects via batch fetch
-                        let memory_ids: Vec<String> = scored_nodes
-                            .iter()
-                            .filter_map(|(n, _)| n.memory_id.clone())
-                            .collect();
-                        let tabular = if !memory_ids.is_empty() {
-                            sql.get_by_ids(&memory_ids).await.unwrap_or_default()
-                        } else {
-                            Default::default()
-                        };
+                            // Convert graph nodes to Memory objects via batch fetch
+                            let memory_ids: Vec<String> = scored_nodes
+                                .iter()
+                                .filter_map(|(n, _)| n.memory_id.clone())
+                                .collect();
+                            let tabular = if !memory_ids.is_empty() {
+                                sql.get_by_ids(&memory_ids).await.unwrap_or_default()
+                            } else {
+                                Default::default()
+                            };
 
-                        let mut graph_memories: Vec<Memory> = Vec::new();
-                        let mut seen = std::collections::HashSet::new();
-                        for (node, score) in &scored_nodes {
-                            if let Some(ref mid) = node.memory_id {
-                                if seen.insert(mid.clone()) {
-                                    if let Some(mut mem) = tabular.get(mid).cloned() {
-                                        mem.retrieval_score = Some(*score as f64);
-                                        graph_memories.push(mem);
+                            let mut graph_memories: Vec<Memory> = Vec::new();
+                            let mut seen = std::collections::HashSet::new();
+                            for (node, score) in &scored_nodes {
+                                if let Some(ref mid) = node.memory_id {
+                                    if seen.insert(mid.clone()) {
+                                        if let Some(mut mem) = tabular.get(mid).cloned() {
+                                            mem.retrieval_score = Some(*score as f64);
+                                            graph_memories.push(mem);
+                                        }
                                     }
                                 }
                             }
-                        }
 
-                        if graph_memories.len() as i64 >= top_k {
+                            if graph_memories.len() as i64 >= top_k {
+                                graph_memories.truncate(top_k as usize);
+                                explain.path = "graph";
+                                explain.result_count = graph_memories.len();
+                                explain.total_ms = total_start.elapsed().as_secs_f64() * 1000.0;
+                                return Ok((graph_memories, explain));
+                            }
+
+                            // Graph insufficient — supplement with hybrid
+                            explain.vector_attempted = true;
+                            let vs_start = std::time::Instant::now();
+                            // Always use _scored directly with cached feedback_weight
+                            // to avoid redundant get_user_retrieval_params query
+                            let fw = self.get_feedback_weight(user_id).await?;
+                            let (vec_results, scores) = sql
+                                .search_hybrid_from_scored(
+                                    &table, user_id, embedding, query, top_k, fw,
+                                )
+                                .await?;
+                            explain.vector_ms = vs_start.elapsed().as_secs_f64() * 1000.0;
+                            explain.vector_hit = !vec_results.is_empty();
+
+                            // Merge: dedup (keep higher score), sort by score
+                            for m in vec_results {
+                                if seen.insert(m.memory_id.clone()) {
+                                    graph_memories.push(m);
+                                } else {
+                                    // Memory exists from graph — use higher score
+                                    if let Some(existing) = graph_memories
+                                        .iter_mut()
+                                        .find(|g| g.memory_id == m.memory_id)
+                                    {
+                                        if m.retrieval_score > existing.retrieval_score {
+                                            existing.retrieval_score = m.retrieval_score;
+                                        }
+                                    }
+                                }
+                            }
+
+                            graph_memories.sort_by(|a, b| {
+                                b.retrieval_score
+                                    .partial_cmp(&a.retrieval_score)
+                                    .unwrap_or(std::cmp::Ordering::Equal)
+                            });
                             graph_memories.truncate(top_k as usize);
-                            explain.path = "graph";
+
+                            if level.at_least(ExplainLevel::Verbose) {
+                                explain.candidate_scores = scores
+                                    .into_iter()
+                                    .enumerate()
+                                    .map(|(i, (id, vs, ks, ts, cs, fs))| CandidateScore {
+                                        memory_id: id,
+                                        rank: i + 1,
+                                        final_score: round4(fs),
+                                        vector_score: round4(vs),
+                                        keyword_score: round4(ks),
+                                        temporal_score: round4(ts),
+                                        confidence_score: round4(cs),
+                                    })
+                                    .collect();
+                            }
+                            explain.path = "graph+vector";
                             explain.result_count = graph_memories.len();
                             explain.total_ms = total_start.elapsed().as_secs_f64() * 1000.0;
                             return Ok((graph_memories, explain));
                         }
-
-                        // Graph insufficient — supplement with hybrid
-                        explain.vector_attempted = true;
-                        let vs_start = std::time::Instant::now();
-                        // Always use _scored directly with cached feedback_weight
-                        // to avoid redundant get_user_retrieval_params query
-                        let fw = self.get_feedback_weight(user_id).await?;
-                        let (vec_results, scores) = sql
-                            .search_hybrid_from_scored(&table, user_id, embedding, query, top_k, fw)
-                            .await?;
-                        explain.vector_ms = vs_start.elapsed().as_secs_f64() * 1000.0;
-                        explain.vector_hit = !vec_results.is_empty();
-
-                        // Merge: dedup (keep higher score), sort by score
-                        for m in vec_results {
-                            if seen.insert(m.memory_id.clone()) {
-                                graph_memories.push(m);
-                            } else {
-                                // Memory exists from graph — use higher score
-                                if let Some(existing) = graph_memories
-                                    .iter_mut()
-                                    .find(|g| g.memory_id == m.memory_id)
-                                {
-                                    if m.retrieval_score > existing.retrieval_score {
-                                        existing.retrieval_score = m.retrieval_score;
-                                    }
-                                }
-                            }
+                        Ok(_) => {
+                            explain.graph_ms = g_start.elapsed().as_secs_f64() * 1000.0;
+                            // Graph returned nothing — fall through to vector
                         }
-                        graph_memories.sort_by(|a, b| {
-                            b.retrieval_score
-                                .partial_cmp(&a.retrieval_score)
-                                .unwrap_or(std::cmp::Ordering::Equal)
-                        });
-                        graph_memories.truncate(top_k as usize);
-
-                        if level.at_least(ExplainLevel::Verbose) {
-                            explain.candidate_scores = scores
-                                .into_iter()
-                                .enumerate()
-                                .map(|(i, (id, vs, ks, ts, cs, fs))| CandidateScore {
-                                    memory_id: id,
-                                    rank: i + 1,
-                                    final_score: round4(fs),
-                                    vector_score: round4(vs),
-                                    keyword_score: round4(ks),
-                                    temporal_score: round4(ts),
-                                    confidence_score: round4(cs),
-                                })
-                                .collect();
+                        Err(_) => {
+                            explain.graph_ms = g_start.elapsed().as_secs_f64() * 1000.0;
+                            // Graph failed — fall through to vector
                         }
-                        explain.path = "graph+vector";
-                        explain.result_count = graph_memories.len();
-                        explain.total_ms = total_start.elapsed().as_secs_f64() * 1000.0;
-                        return Ok((graph_memories, explain));
-                    }
-                    Ok(_) => {
-                        explain.graph_ms = g_start.elapsed().as_secs_f64() * 1000.0;
-                        // Graph returned nothing — fall through to vector
-                    }
-                    Err(_) => {
-                        explain.graph_ms = g_start.elapsed().as_secs_f64() * 1000.0;
-                        // Graph failed — fall through to vector
                     }
                 }
             }
@@ -1499,7 +1586,15 @@ impl MemoryService {
                 let vs_start = std::time::Instant::now();
                 let fw = self.get_feedback_weight(user_id).await?;
                 let (results, scores) = sql
-                    .search_hybrid_from_scored(&table, user_id, embedding, query, top_k, fw)
+                    .search_hybrid_from_scored_scoped(
+                        &table,
+                        user_id,
+                        embedding,
+                        query,
+                        top_k,
+                        fw,
+                        strict_session_id,
+                    )
                     .await?;
                 explain.vector_ms = vs_start.elapsed().as_secs_f64() * 1000.0;
                 if !results.is_empty() {
@@ -1530,7 +1625,7 @@ impl MemoryService {
             explain.fulltext_attempted = true;
             let ft_start = std::time::Instant::now();
             let mut results = sql
-                .search_fulltext_from(&table, user_id, query, top_k)
+                .search_fulltext_from_scoped(&table, user_id, query, top_k, strict_session_id)
                 .await?;
             explain.fulltext_ms = ft_start.elapsed().as_secs_f64() * 1000.0;
             explain.fulltext_hit = !results.is_empty();
@@ -1630,8 +1725,14 @@ impl MemoryService {
         query: &str,
         top_k: i64,
     ) -> Result<(Vec<Memory>, RetrievalExplain), MemoriaError> {
-        self.retrieve_inner(user_id, query, top_k, ExplainLevel::Basic)
-            .await
+        self.retrieve_inner(
+            user_id,
+            query,
+            top_k,
+            ExplainLevel::Basic,
+            &RetrieveOptions::default(),
+        )
+        .await
     }
 
     pub async fn search_explain_level(
@@ -1641,7 +1742,8 @@ impl MemoryService {
         top_k: i64,
         level: ExplainLevel,
     ) -> Result<(Vec<Memory>, RetrievalExplain), MemoriaError> {
-        self.retrieve_inner(user_id, query, top_k, level).await
+        self.retrieve_inner(user_id, query, top_k, level, &RetrieveOptions::default())
+            .await
     }
 
     // TODO(concurrency): concurrent correct on same memory_id can create duplicate

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -4167,7 +4167,11 @@ impl SqlMemoryStore {
     /// Branch-aware soft-delete: deactivate a memory in the given table.
     /// Returns the number of rows actually deactivated (0 means the memory
     /// was already inactive or not found — idempotent, not an error).
-    pub async fn soft_delete_from(&self, table: &str, memory_id: &str) -> Result<u64, MemoriaError> {
+    pub async fn soft_delete_from(
+        &self,
+        table: &str,
+        memory_id: &str,
+    ) -> Result<u64, MemoriaError> {
         let mut conn = self.conn().await?;
         let now = Utc::now().naive_utc();
         let res = sqlx::query(&format!(
@@ -4534,10 +4538,27 @@ impl SqlMemoryStore {
         query: &str,
         limit: i64,
     ) -> Result<Vec<Memory>, MemoriaError> {
+        self.search_fulltext_from_scoped(table, user_id, query, limit, None)
+            .await
+    }
+
+    pub async fn search_fulltext_from_scoped(
+        &self,
+        table: &str,
+        user_id: &str,
+        query: &str,
+        limit: i64,
+        session_id: Option<&str>,
+    ) -> Result<Vec<Memory>, MemoriaError> {
         let safe = sanitize_fulltext_query(query);
         if safe.is_empty() {
             return Ok(vec![]);
         }
+        let session_clause = if session_id.is_some() {
+            " AND session_id = ?"
+        } else {
+            ""
+        };
         // Use OR semantics (no + prefix) — AND is too strict for natural language queries
         // because stopwords are removed from the index but +stopword still requires a match.
         let sql = format!(
@@ -4549,16 +4570,15 @@ impl SqlMemoryStore {
              observed_at, created_at, updated_at, \
              MATCH(content) AGAINST('{safe}' IN BOOLEAN MODE) AS ft_score \
              FROM {table} \
-             WHERE user_id = ? AND is_active = 1 \
+             WHERE user_id = ? AND is_active = 1{session_clause} \
                AND MATCH(content) AGAINST('{safe}' IN BOOLEAN MODE) \
              ORDER BY ft_score DESC LIMIT ?"
         );
-        let rows = match sqlx::query(&sql)
-            .bind(user_id)
-            .bind(limit)
-            .fetch_all(&self.pool)
-            .await
-        {
+        let mut query = sqlx::query(&sql).bind(user_id);
+        if let Some(session_id) = session_id {
+            query = query.bind(session_id);
+        }
+        let rows = match query.bind(limit).fetch_all(&self.pool).await {
             Ok(rows) => rows,
             Err(e) => {
                 // MatrixOne returns 20101 when the search string tokenizes to an empty pattern
@@ -4590,7 +4610,19 @@ impl SqlMemoryStore {
         embedding: &[f32],
         limit: i64,
     ) -> Result<Vec<Memory>, MemoriaError> {
-        self.search_vector_from_filtered(table, user_id, embedding, limit, None)
+        self.search_vector_from_scoped(table, user_id, embedding, limit, None)
+            .await
+    }
+
+    pub async fn search_vector_from_scoped(
+        &self,
+        table: &str,
+        user_id: &str,
+        embedding: &[f32],
+        limit: i64,
+        session_id: Option<&str>,
+    ) -> Result<Vec<Memory>, MemoriaError> {
+        self.search_vector_from_filtered_scoped(table, user_id, embedding, limit, None, session_id)
             .await
     }
 
@@ -4603,33 +4635,64 @@ impl SqlMemoryStore {
         limit: i64,
         memory_type: Option<&str>,
     ) -> Result<Vec<Memory>, MemoriaError> {
+        self.search_vector_from_filtered_scoped(table, user_id, embedding, limit, memory_type, None)
+            .await
+    }
+
+    /// Vector search with optional memory_type and strict session pre-filter.
+    pub async fn search_vector_from_filtered_scoped(
+        &self,
+        table: &str,
+        user_id: &str,
+        embedding: &[f32],
+        limit: i64,
+        memory_type: Option<&str>,
+        session_id: Option<&str>,
+    ) -> Result<Vec<Memory>, MemoriaError> {
         let vec_literal = vec_to_mo(embedding);
         let type_clause = match memory_type {
             Some(mt) => format!(" AND memory_type = '{}'", sanitize_sql_literal(mt)),
             None => String::new(),
         };
+        let session_clause = match session_id {
+            Some(session_id) => format!(" AND session_id = '{}'", sanitize_sql_literal(session_id)),
+            None => String::new(),
+        };
+        let rank_mode = if session_id.is_some() { "pre" } else { "post" };
+        let build_sql = |rank_mode: Option<&str>| {
+            let limit_clause = match rank_mode {
+                Some(mode) => format!("LIMIT {limit} by rank with option 'mode={mode}'"),
+                None => format!("LIMIT {limit}"),
+            };
+            format!(
+                "SELECT memory_id, user_id, memory_type, content, \
+                 session_id, \
+                 CAST(source_event_ids AS CHAR) AS src_ids, \
+                 CAST(extra_metadata AS CHAR) AS extra_meta, \
+                 is_active, superseded_by, trust_tier, initial_confidence, \
+                 observed_at, created_at, updated_at, \
+                 l2_distance(embedding, '{vec_literal}') AS l2_dist \
+                 FROM {table} \
+                 WHERE user_id = '{}' AND is_active = 1 AND embedding IS NOT NULL{type_clause}{session_clause} \
+                 ORDER BY l2_distance(embedding, '{vec_literal}') ASC \
+                 {limit_clause}",
+                sanitize_sql_literal(user_id),
+            )
+        };
         // MatrixOne bug workaround: prepared statement with l2_distance in ORDER BY returns 0 rows
         // Solution: inline all parameters instead of using bind()
-        let sql = format!(
-            "SELECT memory_id, user_id, memory_type, content, \
-             session_id, \
-             CAST(source_event_ids AS CHAR) AS src_ids, \
-             CAST(extra_metadata AS CHAR) AS extra_meta, \
-             is_active, superseded_by, trust_tier, initial_confidence, \
-             observed_at, created_at, updated_at, \
-             l2_distance(embedding, '{vec_literal}') AS l2_dist \
-             FROM {table} \
-             WHERE user_id = '{}' AND is_active = 1 AND embedding IS NOT NULL{type_clause} \
-             ORDER BY l2_distance(embedding, '{vec_literal}') ASC \
-             LIMIT {} by rank with option 'mode=post'",
-            sanitize_sql_literal(user_id),
-            limit
-        );
-
-        let rows = sqlx::query(&sql)
+        let mut rows = sqlx::query(&build_sql(Some(rank_mode)))
             .fetch_all(&self.pool)
             .await
             .map_err(db_err)?;
+        // Strict session retrieval must preserve session-scoped semantics even if
+        // MatrixOne's IVF pre-filter path under-fills top_k on a tiny candidate set.
+        if session_id.is_some() && rows.len() < limit as usize {
+            rows = sqlx::query(&build_sql(None))
+                .fetch_all(&self.pool)
+                .await
+                .map_err(db_err)?;
+        }
 
         rows.iter()
             .map(|r| {
@@ -4656,18 +4719,32 @@ impl SqlMemoryStore {
         query: &str,
         limit: i64,
     ) -> Result<Vec<Memory>, MemoriaError> {
+        self.search_hybrid_from_scoped(table, user_id, embedding, query, limit, None)
+            .await
+    }
+
+    pub async fn search_hybrid_from_scoped(
+        &self,
+        table: &str,
+        user_id: &str,
+        embedding: &[f32],
+        query: &str,
+        limit: i64,
+        session_id: Option<&str>,
+    ) -> Result<Vec<Memory>, MemoriaError> {
         let params = self
             .get_user_retrieval_params(user_id)
             .await
             .unwrap_or_default();
         let (mems, _) = self
-            .search_hybrid_from_scored(
+            .search_hybrid_from_scored_scoped(
                 table,
                 user_id,
                 embedding,
                 query,
                 limit,
                 params.feedback_weight,
+                session_id,
             )
             .await?;
         Ok(mems)
@@ -4684,10 +4761,32 @@ impl SqlMemoryStore {
         limit: i64,
         feedback_weight: f64,
     ) -> Result<(Vec<Memory>, Vec<(String, f64, f64, f64, f64, f64)>), MemoriaError> {
+        self.search_hybrid_from_scored_scoped(
+            table,
+            user_id,
+            embedding,
+            query,
+            limit,
+            feedback_weight,
+            None,
+        )
+        .await
+    }
+
+    pub async fn search_hybrid_from_scored_scoped(
+        &self,
+        table: &str,
+        user_id: &str,
+        embedding: &[f32],
+        query: &str,
+        limit: i64,
+        feedback_weight: f64,
+        session_id: Option<&str>,
+    ) -> Result<(Vec<Memory>, Vec<(String, f64, f64, f64, f64, f64)>), MemoriaError> {
         let fetch_k = (limit * 3).max(20);
         let (vec_results, ft_results) = tokio::join!(
-            self.search_vector_from(table, user_id, embedding, fetch_k),
-            self.search_fulltext_from(table, user_id, query, fetch_k)
+            self.search_vector_from_scoped(table, user_id, embedding, fetch_k, session_id),
+            self.search_fulltext_from_scoped(table, user_id, query, fetch_k, session_id)
         );
         let vec_results = vec_results?;
         let ft_results = ft_results.unwrap_or_default();

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -583,12 +583,14 @@ fn uuid7_id() -> String {
 fn sanitize_sql_literal(s: &str) -> String {
     s.chars()
         .filter(|c| *c != '\0')
-        .map(|c| match c {
-            '\'' => ' ',
-            '\\' => ' ',
-            _ => c,
+        .fold(String::with_capacity(s.len()), |mut out, c| {
+            match c {
+                '\'' => out.push_str("''"),
+                '\\' => out.push_str("\\\\"),
+                _ => out.push(c),
+            }
+            out
         })
-        .collect()
 }
 
 /// Sanitize a string for use inside MATCH ... AGAINST('...' IN BOOLEAN MODE).
@@ -4574,11 +4576,11 @@ impl SqlMemoryStore {
                AND MATCH(content) AGAINST('{safe}' IN BOOLEAN MODE) \
              ORDER BY ft_score DESC LIMIT ?"
         );
-        let mut query = sqlx::query(&sql).bind(user_id);
+        let mut stmt = sqlx::query(&sql).bind(user_id);
         if let Some(session_id) = session_id {
-            query = query.bind(session_id);
+            stmt = stmt.bind(session_id);
         }
-        let rows = match query.bind(limit).fetch_all(&self.pool).await {
+        let rows = match stmt.bind(limit).fetch_all(&self.pool).await {
             Ok(rows) => rows,
             Err(e) => {
                 // MatrixOne returns 20101 when the search string tokenizes to an empty pattern
@@ -4640,6 +4642,7 @@ impl SqlMemoryStore {
     }
 
     /// Vector search with optional memory_type and strict session pre-filter.
+    #[allow(clippy::too_many_arguments)]
     pub async fn search_vector_from_filtered_scoped(
         &self,
         table: &str,
@@ -4773,6 +4776,7 @@ impl SqlMemoryStore {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn search_hybrid_from_scored_scoped(
         &self,
         table: &str,

--- a/memoria/crates/memoria-storage/tests/store_crud.rs
+++ b/memoria/crates/memoria-storage/tests/store_crud.rs
@@ -232,6 +232,117 @@ async fn test_search_vector_sets_retrieval_score() {
 }
 
 #[tokio::test]
+async fn test_search_vector_from_filtered_scoped_prefilters_by_session() {
+    let (store, uid) = setup().await;
+
+    sqlx::query("DELETE FROM mem_memories WHERE user_id = ?")
+        .bind(&uid)
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+    let mut target = make_memory(&format!("vec-scope-1-{uid}"), "target session", &uid);
+    target.session_id = Some("sess-target".to_string());
+    target.embedding = Some(dim_vec(1, 1.0));
+
+    let mut other = make_memory(&format!("vec-scope-2-{uid}"), "other session", &uid);
+    other.session_id = Some("sess-other".to_string());
+    other.embedding = Some(dim_vec(0, 1.0));
+
+    store.insert(&target).await.unwrap();
+    store.insert(&other).await.unwrap();
+
+    let global = store
+        .search_vector_from_filtered_scoped("mem_memories", &uid, &dim_vec(0, 1.0), 1, None, None)
+        .await
+        .expect("global vector search");
+    assert_eq!(
+        global.first().map(|m| m.memory_id.as_str()),
+        Some(other.memory_id.as_str()),
+        "global search should return the nearest cross-session memory",
+    );
+
+    let scoped = store
+        .search_vector_from_filtered_scoped(
+            "mem_memories",
+            &uid,
+            &dim_vec(0, 1.0),
+            1,
+            None,
+            Some("sess-target"),
+        )
+        .await
+        .expect("session-scoped vector search");
+    assert_eq!(
+        scoped.len(),
+        1,
+        "strict session search should still return a candidate"
+    );
+    assert_eq!(
+        scoped.first().map(|m| m.memory_id.as_str()),
+        Some(target.memory_id.as_str()),
+        "strict session search should pre-filter candidates before ranking",
+    );
+}
+
+#[tokio::test]
+async fn test_search_vector_from_filtered_scoped_fills_limit_with_session_candidates() {
+    let (store, uid) = setup().await;
+
+    let mk_vec = |x: f32, y: f32| {
+        let mut v = vec![0.0; test_dim()];
+        v[0] = x;
+        v[1] = y;
+        v
+    };
+
+    let mut target_a = make_memory(&format!("vec-scope-fill-1-{uid}"), "scoped a", &uid);
+    target_a.session_id = Some("sess-target".to_string());
+    target_a.embedding = Some(mk_vec(0.7, 0.3));
+
+    let mut target_b = make_memory(&format!("vec-scope-fill-2-{uid}"), "scoped b", &uid);
+    target_b.session_id = Some("sess-target".to_string());
+    target_b.embedding = Some(mk_vec(0.65, 0.35));
+
+    let mut other_a = make_memory(&format!("vec-scope-fill-3-{uid}"), "global a", &uid);
+    other_a.session_id = Some("sess-other".to_string());
+    other_a.embedding = Some(mk_vec(1.0, 0.0));
+
+    let mut other_b = make_memory(&format!("vec-scope-fill-4-{uid}"), "global b", &uid);
+    other_b.session_id = Some("sess-other".to_string());
+    other_b.embedding = Some(mk_vec(0.97, 0.03));
+
+    store.insert(&target_a).await.unwrap();
+    store.insert(&target_b).await.unwrap();
+    store.insert(&other_a).await.unwrap();
+    store.insert(&other_b).await.unwrap();
+
+    let scoped = store
+        .search_vector_from_filtered_scoped(
+            "mem_memories",
+            &uid,
+            &mk_vec(1.0, 0.0),
+            2,
+            None,
+            Some("sess-target"),
+        )
+        .await
+        .expect("session-scoped vector search");
+    assert_eq!(
+        scoped.len(),
+        2,
+        "strict session search should fill top_k from the filtered session candidate set",
+    );
+    let scoped_ids: std::collections::HashSet<&str> =
+        scoped.iter().map(|m| m.memory_id.as_str()).collect();
+    assert_eq!(
+        scoped_ids,
+        std::collections::HashSet::from([target_a.memory_id.as_str(), target_b.memory_id.as_str()]),
+        "strict session vector search should return both session-local candidates",
+    );
+}
+
+#[tokio::test]
 async fn test_search_hybrid_access_count_stays_tiebreaker() {
     let (store, uid) = setup().await;
 


### PR DESCRIPTION
## Summary
- thread strict session retrieval options through API, service, storage, and MCP
- skip graph retrieval when strict session scope is requested and keep default cross-session semantics unchanged
- add a strict scoped vector fallback plus REST/MCP regressions covering issue #184 semantics

## Testing
- DATABASE_URL=mysql://root:111@localhost:6001/memoria_test SQLX_OFFLINE=true cargo test -p memoria-storage --test store_crud test_search_vector_from_filtered_scoped_prefilters_by_session -- --nocapture
- DATABASE_URL=mysql://root:111@localhost:6001/memoria_test SQLX_OFFLINE=true cargo test -p memoria-storage --test store_crud test_search_vector_from_filtered_scoped_fills_limit_with_session_candidates -- --nocapture
- DATABASE_URL=mysql://root:111@localhost:6001/memoria_test SQLX_OFFLINE=true cargo test -p memoria-api --test api_e2e test_retrieve_filter_session_prefilters_and_skips_graph -- --nocapture
- DATABASE_URL=mysql://root:111@localhost:6001/memoria_test SQLX_OFFLINE=true cargo test -p memoria-api --test api_e2e test_retrieve_filter_session_preserves_top_k_with_session_candidates -- --nocapture
- DATABASE_URL=mysql://root:111@localhost:6001/memoria_test SQLX_OFFLINE=true cargo test -p memoria-api --test api_e2e test_mcp_memory_retrieve_filter_session_end_to_end -- --nocapture

Fixes #184