### PR TITLE
feat(memory): add session-scoped purge

### DIFF
--- a/memoria/crates/memoria-api/src/models.rs
+++ b/memoria/crates/memoria-api/src/models.rs
@@ -92,7 +92,69 @@ pub struct CorrectByQueryRequest {
 pub struct PurgeRequest {
     pub memory_ids: Option<Vec<String>>,
     pub topic: Option<String>,
+    pub session_id: Option<String>,
+    pub memory_types: Option<Vec<String>>,
     pub reason: Option<String>,
+}
+
+pub enum PurgeSelector {
+    MemoryIds(Vec<String>),
+    Topic(String),
+    Session {
+        session_id: String,
+        memory_types: Option<Vec<MemoryType>>,
+    },
+    None,
+}
+
+impl PurgeRequest {
+    pub fn selector(&self) -> Result<PurgeSelector, String> {
+        let topic = self
+            .topic
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        let session_id = self
+            .session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        if self.memory_types.is_some() && session_id.is_none() {
+            return Err("memory_types requires session_id".to_string());
+        }
+
+        let selector_count = usize::from(self.memory_ids.is_some())
+            + usize::from(topic.is_some())
+            + usize::from(session_id.is_some());
+        if selector_count > 1 {
+            return Err("provide only one of memory_ids, topic, or session_id".to_string());
+        }
+
+        if let Some(ids) = &self.memory_ids {
+            return Ok(PurgeSelector::MemoryIds(ids.clone()));
+        }
+        if let Some(topic) = topic {
+            return Ok(PurgeSelector::Topic(topic.to_string()));
+        }
+        if let Some(session_id) = session_id {
+            let memory_types = self
+                .memory_types
+                .as_ref()
+                .map(|types| {
+                    types
+                        .iter()
+                        .map(|memory_type| parse_memory_type(memory_type))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?
+                .filter(|types| !types.is_empty());
+            return Ok(PurgeSelector::Session {
+                session_id: session_id.to_string(),
+                memory_types,
+            });
+        }
+        Ok(PurgeSelector::None)
+    }
 }
 
 #[derive(Serialize)]

--- a/memoria/crates/memoria-api/src/models.rs
+++ b/memoria/crates/memoria-api/src/models.rs
@@ -109,6 +109,8 @@ pub enum PurgeSelector {
 
 impl PurgeRequest {
     pub fn selector(&self) -> Result<PurgeSelector, String> {
+        let memory_ids = self.memory_ids.as_ref().filter(|ids| !ids.is_empty());
+        let memory_types = self.memory_types.as_ref().filter(|types| !types.is_empty());
         let topic = self
             .topic
             .as_deref()
@@ -119,27 +121,25 @@ impl PurgeRequest {
             .as_deref()
             .map(str::trim)
             .filter(|s| !s.is_empty());
-        if self.memory_types.is_some() && session_id.is_none() {
+        if memory_types.is_some() && session_id.is_none() {
             return Err("memory_types requires session_id".to_string());
         }
 
-        let selector_count = usize::from(self.memory_ids.is_some())
+        let selector_count = usize::from(memory_ids.is_some())
             + usize::from(topic.is_some())
             + usize::from(session_id.is_some());
         if selector_count > 1 {
             return Err("provide only one of memory_ids, topic, or session_id".to_string());
         }
 
-        if let Some(ids) = &self.memory_ids {
+        if let Some(ids) = memory_ids {
             return Ok(PurgeSelector::MemoryIds(ids.clone()));
         }
         if let Some(topic) = topic {
             return Ok(PurgeSelector::Topic(topic.to_string()));
         }
         if let Some(session_id) = session_id {
-            let memory_types = self
-                .memory_types
-                .as_ref()
+            let memory_types = memory_types
                 .map(|types| {
                     types
                         .iter()
@@ -292,4 +292,44 @@ pub fn parse_memory_type(s: &str) -> Result<MemoryType, String> {
 
 pub fn parse_trust_tier(s: &str) -> Result<TrustTier, String> {
     TrustTier::from_str(s).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PurgeRequest, PurgeSelector};
+
+    #[test]
+    fn purge_selector_ignores_empty_arrays() {
+        let request = PurgeRequest {
+            memory_ids: Some(vec![]),
+            topic: None,
+            session_id: Some("sess-1".to_string()),
+            memory_types: Some(vec![]),
+            reason: None,
+        };
+
+        match request.selector().unwrap() {
+            PurgeSelector::Session {
+                session_id,
+                memory_types,
+            } => {
+                assert_eq!(session_id, "sess-1");
+                assert!(memory_types.is_none());
+            }
+            _ => panic!("expected session selector"),
+        }
+    }
+
+    #[test]
+    fn purge_selector_empty_memory_types_do_not_require_session() {
+        let request = PurgeRequest {
+            memory_ids: None,
+            topic: None,
+            session_id: None,
+            memory_types: Some(vec![]),
+            reason: None,
+        };
+
+        assert!(matches!(request.selector().unwrap(), PurgeSelector::None));
+    }
 }

--- a/memoria/crates/memoria-api/src/routes/memory.rs
+++ b/memoria/crates/memoria-api/src/routes/memory.rs
@@ -371,38 +371,51 @@ pub async fn purge_memories(
     AuthUser { user_id, is_master }: AuthUser,
     Json(req): Json<PurgeRequest>,
 ) -> ApiResult<PurgeResponse> {
-    let result = if let Some(ids) = &req.memory_ids {
-        if !is_master {
-            for id in ids {
-                let mem = state
-                    .service
-                    .get_for_user(&user_id, id)
-                    .await
-                    .map_err(api_err)?
-                    .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Memory not found: {id}")))?;
-                if mem.user_id != user_id {
-                    return Err((StatusCode::FORBIDDEN, format!("Not your memory: {id}")));
+    let selector = req
+        .selector()
+        .map_err(|e| (StatusCode::UNPROCESSABLE_ENTITY, e))?;
+    let result = match selector {
+        PurgeSelector::MemoryIds(ids) => {
+            if !is_master {
+                for id in &ids {
+                    let mem = state
+                        .service
+                        .get_for_user(&user_id, id)
+                        .await
+                        .map_err(api_err)?
+                        .ok_or_else(|| {
+                            (StatusCode::NOT_FOUND, format!("Memory not found: {id}"))
+                        })?;
+                    if mem.user_id != user_id {
+                        return Err((StatusCode::FORBIDDEN, format!("Not your memory: {id}")));
+                    }
                 }
             }
+            let id_refs: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
+            state
+                .service
+                .purge_batch(&user_id, &id_refs)
+                .await
+                .map_err(api_err)?
         }
-        let id_refs: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
-        state
+        PurgeSelector::Topic(topic) => state
             .service
-            .purge_batch(&user_id, &id_refs)
+            .purge_by_topic(&user_id, &topic)
             .await
-            .map_err(api_err)?
-    } else if let Some(topic) = &req.topic {
-        state
+            .map_err(api_err)?,
+        PurgeSelector::Session {
+            session_id,
+            memory_types,
+        } => state
             .service
-            .purge_by_topic(&user_id, topic)
+            .purge_by_session_id(&user_id, &session_id, memory_types.as_deref())
             .await
-            .map_err(api_err)?
-    } else {
-        memoria_service::PurgeResult {
+            .map_err(api_err)?,
+        PurgeSelector::None => memoria_service::PurgeResult {
             purged: 0,
             snapshot_name: None,
             warning: None,
-        }
+        },
     };
     Ok(Json(PurgeResponse {
         purged: result.purged,

--- a/memoria/crates/memoria-api/tests/api_db_verify.rs
+++ b/memoria/crates/memoria-api/tests/api_db_verify.rs
@@ -572,6 +572,80 @@ async fn test_purge_by_topic_batch_perf_verify_db() {
     println!("✅ purge by topic batch: 10 memories purged in one call");
 }
 
+#[tokio::test]
+#[serial]
+async fn test_purge_by_session_id_with_memory_types_verify_db() {
+    let (base, client, pool) = spawn_server().await;
+    let uid = uid();
+    let target_session = format!("session:test-smp-{}", uuid::Uuid::new_v4().simple());
+    let other_session = format!("session:test-smp-{}", uuid::Uuid::new_v4().simple());
+
+    for (content, memory_type, session_id) in [
+        ("target working alpha", "working", target_session.as_str()),
+        ("target working beta", "working", target_session.as_str()),
+        ("target semantic keep", "semantic", target_session.as_str()),
+        ("other working keep", "working", other_session.as_str()),
+    ] {
+        client
+            .post(format!("{base}/v1/memories"))
+            .header("X-User-Id", &uid)
+            .json(&json!({
+                "content": content,
+                "memory_type": memory_type,
+                "session_id": session_id,
+            }))
+            .send()
+            .await
+            .unwrap();
+    }
+    assert_eq!(db_count_active(&pool, &uid).await, 4);
+
+    let r = client
+        .post(format!("{base}/v1/memories/purge"))
+        .header("X-User-Id", &uid)
+        .json(&json!({
+            "session_id": target_session,
+            "memory_types": ["working"],
+            "reason": "session complete"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+    let body: Value = r.json().await.unwrap();
+    assert_eq!(body["purged"], 2);
+
+    let rows = sqlx::query(
+        "SELECT content, memory_type, session_id FROM mem_memories \
+         WHERE user_id = ? AND is_active > 0 ORDER BY content ASC",
+    )
+    .bind(&uid)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    let remaining: Vec<(String, String, String)> = rows
+        .into_iter()
+        .map(|row| {
+            (
+                row.get("content"),
+                row.get("memory_type"),
+                row.get("session_id"),
+            )
+        })
+        .collect();
+    assert_eq!(remaining.len(), 2);
+    assert!(remaining.iter().any(|(content, memory_type, session_id)| {
+        content == "target semantic keep"
+            && memory_type == "semantic"
+            && session_id == &target_session
+    }));
+    assert!(remaining.iter().any(|(content, memory_type, session_id)| {
+        content == "other working keep" && memory_type == "working" && session_id == &other_session
+    }));
+
+    println!("✅ purge by session_id: working memories removed without touching other active rows");
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // 4. BATCH STORE — verify all rows in DB with correct types
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -2523,6 +2523,22 @@ async fn test_remote_purge_by_session_id() {
     println!("✅ remote purge by session_id: {t}");
 }
 
+#[tokio::test]
+async fn test_remote_purge_rejects_invalid_memory_types_locally() {
+    use memoria_mcp::remote::RemoteClient;
+    let remote = RemoteClient::new("http://127.0.0.1:9", None, uid(), None);
+
+    let err = remote
+        .call(
+            "memory_purge",
+            json!({"session_id": "sess-target", "memory_types": ["not_a_real_type"]}),
+        )
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("Invalid memory type"), "{err}");
+    println!("✅ remote purge rejects invalid memory_types before API call");
+}
+
 // ── Episodic memory tests ─────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -2454,6 +2454,75 @@ async fn test_remote_purge_by_topic() {
     println!("✅ remote purge by topic: {t}");
 }
 
+#[tokio::test]
+async fn test_remote_purge_by_session_id() {
+    use memoria_mcp::remote::RemoteClient;
+    let (base, _) = spawn_api_for_remote().await;
+    let uid = uid();
+    let remote = RemoteClient::new(&base, None, uid.clone(), None);
+    let target_session = format!("session:test-smp-{}", uuid::Uuid::new_v4().simple());
+    let other_session = format!("session:test-smp-{}", uuid::Uuid::new_v4().simple());
+
+    remote
+        .call(
+            "memory_store",
+            json!({"content": "remote working alpha", "memory_type": "working", "session_id": target_session}),
+        )
+        .await
+        .unwrap();
+    remote
+        .call(
+            "memory_store",
+            json!({"content": "remote working beta", "memory_type": "working", "session_id": target_session}),
+        )
+        .await
+        .unwrap();
+    remote
+        .call(
+            "memory_store",
+            json!({"content": "remote semantic keep", "memory_type": "semantic", "session_id": target_session}),
+        )
+        .await
+        .unwrap();
+    remote
+        .call(
+            "memory_store",
+            json!({"content": "remote other keep", "memory_type": "working", "session_id": other_session}),
+        )
+        .await
+        .unwrap();
+
+    let r = remote
+        .call(
+            "memory_purge",
+            json!({"session_id": target_session, "memory_types": ["working"]}),
+        )
+        .await
+        .unwrap();
+    let t = r["content"][0]["text"].as_str().unwrap_or("");
+    assert!(t.contains("Purged 2"), "got: {t}");
+
+    let list = remote
+        .call("memory_list", json!({"limit": 10}))
+        .await
+        .unwrap();
+    let list_text = list["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        list_text.contains("remote semantic keep"),
+        "got: {list_text}"
+    );
+    assert!(list_text.contains("remote other keep"), "got: {list_text}");
+    assert!(
+        !list_text.contains("remote working alpha"),
+        "got: {list_text}"
+    );
+    assert!(
+        !list_text.contains("remote working beta"),
+        "got: {list_text}"
+    );
+    println!("✅ remote purge by session_id: {t}");
+}
+
 // ── Episodic memory tests ─────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/memoria/crates/memoria-cli/templates/claude_rule.md
+++ b/memoria/crates/memoria-cli/templates/claude_rule.md
@@ -40,7 +40,7 @@ Do NOT call `memory_store` for:
 `working` memories are session-scoped temporary context. They **persist and will be retrieved in future sessions** unless explicitly cleaned up.
 
 **When to purge working memories:**
-- Task or debug session is complete → `memory_purge(topic="<task keyword>", reason="task complete")`
+- Task or debug session is complete → `memory_purge(session_id="<session_id>", memory_types=["working"], reason="task complete")`
 - You stored a working memory that turned out to be wrong → `memory_purge(memory_id="...", reason="incorrect conclusion")`
 - User says "start fresh", "forget what we tried", "let's try a different approach"
 - Only purge completed tasks — leave active task working memories for next session

--- a/memoria/crates/memoria-cli/templates/claude_session_lifecycle.md
+++ b/memoria/crates/memoria-cli/templates/claude_session_lifecycle.md
@@ -39,7 +39,7 @@ When the conversation is winding down (user says thanks, goodbye, or stops engag
 ### 1. Clean up working memories
 
 ```
-memory_purge(topic="<task keyword>", reason="session complete")
+memory_purge(session_id="<session_id>", memory_types=["working"], reason="session complete")
 ```
 
 Only purge working memories for tasks that are actually done. Leave active task working memories for next session.

--- a/memoria/crates/memoria-cli/templates/codex_agents.md
+++ b/memoria/crates/memoria-cli/templates/codex_agents.md
@@ -44,7 +44,7 @@ Do NOT call `memory_store` for:
 `working` memories are session-scoped temporary context. They **persist and will be retrieved in future sessions** unless explicitly cleaned up.
 
 **When to purge working memories:**
-- Task or debug session is complete → `memory_purge(topic="<task keyword>", reason="task complete")`
+- Task or debug session is complete → `memory_purge(session_id="<session_id>", memory_types=["working"], reason="task complete")`
 - You stored a working memory that turned out to be wrong → `memory_purge(memory_id="...", reason="incorrect conclusion")`
 - User says "start fresh", "forget what we tried", "let's try a different approach"
 - Only purge completed tasks — leave active task working memories for next session
@@ -192,7 +192,7 @@ When the conversation is winding down (user says thanks, goodbye, or stops engag
 ### 1. Clean up working memories
 
 ```
-memory_purge(topic="<task keyword>", reason="session complete")
+memory_purge(session_id="<session_id>", memory_types=["working"], reason="session complete")
 ```
 
 Only purge working memories for tasks that are actually done. Leave active task working memories for next session.

--- a/memoria/crates/memoria-cli/templates/cursor_rule.md
+++ b/memoria/crates/memoria-cli/templates/cursor_rule.md
@@ -49,7 +49,7 @@ Do NOT call `memory_store` for:
 `working` memories are session-scoped temporary context. They **persist and will be retrieved in future sessions** unless explicitly cleaned up.
 
 **When to purge working memories:**
-- Task or debug session is complete → `memory_purge(topic="<task keyword>", reason="task complete")`
+- Task or debug session is complete → `memory_purge(session_id="<session_id>", memory_types=["working"], reason="task complete")`
 - You stored a working memory that turned out to be wrong → `memory_purge(memory_id="...", reason="incorrect conclusion")`
 - User says "start fresh", "forget what we tried", "let's try a different approach"
 - Only purge completed tasks — leave active task working memories for next session

--- a/memoria/crates/memoria-cli/templates/cursor_session_lifecycle.md
+++ b/memoria/crates/memoria-cli/templates/cursor_session_lifecycle.md
@@ -45,7 +45,7 @@ When the conversation is winding down (user says thanks, goodbye, or stops engag
 ### 1. Clean up working memories
 
 ```
-memory_purge(topic="<task keyword>", reason="session complete")
+memory_purge(session_id="<session_id>", memory_types=["working"], reason="session complete")
 ```
 
 Only purge working memories for tasks that are actually done. Leave active task working memories for next session.

--- a/memoria/crates/memoria-cli/templates/gemini_rule.md
+++ b/memoria/crates/memoria-cli/templates/gemini_rule.md
@@ -40,7 +40,7 @@ Do NOT call `memory_store` for:
 `working` memories are session-scoped temporary context. They **persist and will be retrieved in future sessions** unless explicitly cleaned up.
 
 **When to purge working memories:**
-- Task or debug session is complete → `memory_purge(topic="<task keyword>", reason="task complete")`
+- Task or debug session is complete → `memory_purge(session_id="<session_id>", memory_types=["working"], reason="task complete")`
 - You stored a working memory that turned out to be wrong → `memory_purge(memory_id="...", reason="incorrect conclusion")`
 - User says "start fresh", "forget what we tried", "let's try a different approach"
 - Only purge completed tasks — leave active task working memories for next session

--- a/memoria/crates/memoria-cli/templates/gemini_session_lifecycle.md
+++ b/memoria/crates/memoria-cli/templates/gemini_session_lifecycle.md
@@ -39,7 +39,7 @@ When the conversation is winding down (user says thanks, goodbye, or stops engag
 ### 1. Clean up working memories
 
 ```
-memory_purge(topic="<task keyword>", reason="session complete")
+memory_purge(session_id="<session_id>", memory_types=["working"], reason="session complete")
 ```
 
 Only purge working memories for tasks that are actually done. Leave active task working memories for next session.

--- a/memoria/crates/memoria-cli/templates/kiro_session_lifecycle.md
+++ b/memoria/crates/memoria-cli/templates/kiro_session_lifecycle.md
@@ -45,7 +45,7 @@ When the conversation is winding down (user says thanks, goodbye, or stops engag
 ### 1. Clean up working memories
 
 ```
-memory_purge(topic="<task keyword>", reason="session complete")
+memory_purge(session_id="<session_id>", memory_types=["working"], reason="session complete")
 ```
 
 Only purge working memories for tasks that are actually done. Leave active task working memories for next session.

--- a/memoria/crates/memoria-cli/templates/kiro_steering.md
+++ b/memoria/crates/memoria-cli/templates/kiro_steering.md
@@ -44,7 +44,7 @@ Do NOT call `memory_store` for:
 `working` memories are session-scoped temporary context. They **persist and will be retrieved in future sessions** unless explicitly cleaned up.
 
 **When to purge working memories:**
-- Task or debug session is complete → `memory_purge(topic="<task keyword>", reason="task complete")`
+- Task or debug session is complete → `memory_purge(session_id="<session_id>", memory_types=["working"], reason="task complete")`
 - You stored a working memory that turned out to be wrong → `memory_purge(memory_id="...", reason="incorrect conclusion")`
 - User says "start fresh", "forget what we tried", "let's try a different approach"
 - Only purge completed tasks — leave active task working memories for next session

--- a/memoria/crates/memoria-mcp/src/lib.rs
+++ b/memoria/crates/memoria-mcp/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod git_tools;
+pub mod purge_args;
 pub mod remote;
 mod server;
 pub mod tools;

--- a/memoria/crates/memoria-mcp/src/purge_args.rs
+++ b/memoria/crates/memoria-mcp/src/purge_args.rs
@@ -1,0 +1,64 @@
+use anyhow::Result;
+use memoria_core::MemoryType;
+use serde_json::Value;
+use std::str::FromStr;
+
+pub(crate) struct MemoryPurgeArgs {
+    pub(crate) memory_id: Option<String>,
+    pub(crate) topic: Option<String>,
+    pub(crate) session_id: Option<String>,
+    pub(crate) memory_types: Option<Vec<MemoryType>>,
+}
+
+pub(crate) fn parse_memory_purge_args(args: &Value) -> Result<MemoryPurgeArgs> {
+    let memory_id = args["memory_id"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let topic = args["topic"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let session_id = args["session_id"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let memory_types = match args.get("memory_types") {
+        None | Some(Value::Null) => None,
+        Some(Value::Array(values)) => Some(
+            values
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .ok_or_else(|| anyhow::anyhow!("memory_types entries must be strings"))
+                        .and_then(|value| {
+                            MemoryType::from_str(value).map_err(|e| anyhow::anyhow!("{e}"))
+                        })
+                })
+                .collect::<Result<Vec<_>>>()?,
+        ),
+        Some(_) => return Err(anyhow::anyhow!("memory_types must be an array of strings")),
+    }
+    .filter(|types| !types.is_empty());
+    if memory_types.is_some() && session_id.is_none() {
+        return Err(anyhow::anyhow!("memory_types requires session_id"));
+    }
+    let selector_count = usize::from(memory_id.is_some())
+        + usize::from(topic.is_some())
+        + usize::from(session_id.is_some());
+    if selector_count > 1 {
+        return Err(anyhow::anyhow!(
+            "Provide only one of memory_id, topic, or session_id"
+        ));
+    }
+    Ok(MemoryPurgeArgs {
+        memory_id,
+        topic,
+        session_id,
+        memory_types,
+    })
+}

--- a/memoria/crates/memoria-mcp/src/remote.rs
+++ b/memoria/crates/memoria-mcp/src/remote.rs
@@ -1,6 +1,7 @@
 //! Remote mode: proxy all MCP tool calls to a Memoria REST API server.
 //! Mirrors Python's HTTPBackend.
 
+use crate::purge_args::parse_memory_purge_args;
 use anyhow::Result;
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -10,13 +11,6 @@ pub struct RemoteClient {
     base_url: String,
     #[allow(dead_code)]
     user_id: String,
-}
-
-struct MemoryPurgeArgs {
-    memory_id: Option<String>,
-    topic: Option<String>,
-    session_id: Option<String>,
-    memory_types: Option<Vec<String>>,
 }
 
 impl RemoteClient {
@@ -79,57 +73,6 @@ impl RemoteClient {
             body
         };
         anyhow::bail!("API error {status}: {msg}")
-    }
-
-    fn parse_memory_purge_args(args: &Value) -> Result<MemoryPurgeArgs> {
-        let memory_id = args["memory_id"]
-            .as_str()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_string);
-        let topic = args["topic"]
-            .as_str()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_string);
-        let session_id = args["session_id"]
-            .as_str()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_string);
-        let memory_types = match args.get("memory_types") {
-            None | Some(Value::Null) => None,
-            Some(Value::Array(values)) => Some(
-                values
-                    .iter()
-                    .map(|value| {
-                        value
-                            .as_str()
-                            .map(str::to_string)
-                            .ok_or_else(|| anyhow::anyhow!("memory_types entries must be strings"))
-                    })
-                    .collect::<Result<Vec<_>>>()?,
-            ),
-            Some(_) => return Err(anyhow::anyhow!("memory_types must be an array of strings")),
-        }
-        .filter(|types| !types.is_empty());
-        if memory_types.is_some() && session_id.is_none() {
-            return Err(anyhow::anyhow!("memory_types requires session_id"));
-        }
-        let selector_count = usize::from(memory_id.is_some())
-            + usize::from(topic.is_some())
-            + usize::from(session_id.is_some());
-        if selector_count > 1 {
-            return Err(anyhow::anyhow!(
-                "Provide only one of memory_id, topic, or session_id"
-            ));
-        }
-        Ok(MemoryPurgeArgs {
-            memory_id,
-            topic,
-            session_id,
-            memory_types,
-        })
     }
 
     pub async fn call(&self, name: &str, args: Value) -> Result<Value> {
@@ -234,7 +177,7 @@ impl RemoteClient {
             }
 
             "memory_purge" => {
-                let purge_args = Self::parse_memory_purge_args(&args)?;
+                let purge_args = parse_memory_purge_args(&args)?;
                 if let Some(memory_id) = purge_args.memory_id {
                     let ids: Vec<&str> = memory_id
                         .split(',')
@@ -271,7 +214,12 @@ impl RemoteClient {
                         .post(self.url("/v1/memories/purge"))
                         .json(&json!({
                             "session_id": session_id,
-                            "memory_types": purge_args.memory_types,
+                            "memory_types": purge_args.memory_types.map(|memory_types| {
+                                memory_types
+                                    .into_iter()
+                                    .map(|memory_type| memory_type.to_string())
+                                    .collect::<Vec<_>>()
+                            }),
                         }))
                         .send()
                         .await?;

--- a/memoria/crates/memoria-mcp/src/remote.rs
+++ b/memoria/crates/memoria-mcp/src/remote.rs
@@ -12,6 +12,13 @@ pub struct RemoteClient {
     user_id: String,
 }
 
+struct MemoryPurgeArgs {
+    memory_id: Option<String>,
+    topic: Option<String>,
+    session_id: Option<String>,
+    memory_types: Option<Vec<String>>,
+}
+
 impl RemoteClient {
     pub fn new(api_url: &str, token: Option<&str>, user_id: String, tool: Option<&str>) -> Self {
         let mut headers = reqwest::header::HeaderMap::new();
@@ -72,6 +79,57 @@ impl RemoteClient {
             body
         };
         anyhow::bail!("API error {status}: {msg}")
+    }
+
+    fn parse_memory_purge_args(args: &Value) -> Result<MemoryPurgeArgs> {
+        let memory_id = args["memory_id"]
+            .as_str()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        let topic = args["topic"]
+            .as_str()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        let session_id = args["session_id"]
+            .as_str()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        let memory_types = match args.get("memory_types") {
+            None | Some(Value::Null) => None,
+            Some(Value::Array(values)) => Some(
+                values
+                    .iter()
+                    .map(|value| {
+                        value
+                            .as_str()
+                            .map(str::to_string)
+                            .ok_or_else(|| anyhow::anyhow!("memory_types entries must be strings"))
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+            ),
+            Some(_) => return Err(anyhow::anyhow!("memory_types must be an array of strings")),
+        }
+        .filter(|types| !types.is_empty());
+        if memory_types.is_some() && session_id.is_none() {
+            return Err(anyhow::anyhow!("memory_types requires session_id"));
+        }
+        let selector_count = usize::from(memory_id.is_some())
+            + usize::from(topic.is_some())
+            + usize::from(session_id.is_some());
+        if selector_count > 1 {
+            return Err(anyhow::anyhow!(
+                "Provide only one of memory_id, topic, or session_id"
+            ));
+        }
+        Ok(MemoryPurgeArgs {
+            memory_id,
+            topic,
+            session_id,
+            memory_types,
+        })
     }
 
     pub async fn call(&self, name: &str, args: Value) -> Result<Value> {
@@ -176,9 +234,8 @@ impl RemoteClient {
             }
 
             "memory_purge" => {
-                let memory_id = args["memory_id"].as_str().unwrap_or("");
-                let topic = args["topic"].as_str().unwrap_or("");
-                if !memory_id.is_empty() {
+                let purge_args = Self::parse_memory_purge_args(&args)?;
+                if let Some(memory_id) = purge_args.memory_id {
                     let ids: Vec<&str> = memory_id
                         .split(',')
                         .map(str::trim)
@@ -196,7 +253,7 @@ impl RemoteClient {
                         "Purged {} memory(s)",
                         body["purged"].as_i64().unwrap_or(count as i64)
                     )))
-                } else if !topic.is_empty() {
+                } else if let Some(topic) = purge_args.topic {
                     let r = self
                         .client
                         .post(self.url("/v1/memories/purge"))
@@ -208,8 +265,24 @@ impl RemoteClient {
                         "Purged {} memory(s) matching '{topic}'",
                         body["purged"].as_i64().unwrap_or(0)
                     )))
+                } else if let Some(session_id) = purge_args.session_id {
+                    let r = self
+                        .client
+                        .post(self.url("/v1/memories/purge"))
+                        .json(&json!({
+                            "session_id": session_id,
+                            "memory_types": purge_args.memory_types,
+                        }))
+                        .send()
+                        .await?;
+                    let body = Self::parse_response(r).await?;
+                    Ok(Self::mcp_text(&format!(
+                        "Purged {} memory(s) for session '{}'",
+                        body["purged"].as_i64().unwrap_or(0),
+                        session_id
+                    )))
                 } else {
-                    Ok(Self::mcp_text("Provide memory_id or topic"))
+                    Ok(Self::mcp_text("Provide memory_id, topic, or session_id"))
                 }
             }
 

--- a/memoria/crates/memoria-mcp/src/tools.rs
+++ b/memoria/crates/memoria-mcp/src/tools.rs
@@ -51,6 +51,13 @@ enum ToolCallName {
     Unknown(String),
 }
 
+struct MemoryPurgeArgs {
+    memory_id: Option<String>,
+    topic: Option<String>,
+    session_id: Option<String>,
+    memory_types: Option<Vec<MemoryType>>,
+}
+
 const MEMORY_STORE_DESCRIPTION: &str = concat!(
     "Store a new memory. Set trust_tier explicitly when certainty matters: ",
     "T1 for directly stated or explicitly confirmed facts/preferences/decisions, ",
@@ -66,6 +73,59 @@ const TRUST_TIER_DESCRIPTION: &str = concat!(
     "prefer T3 if unsure. ",
     "T4 = speculative, reflective, or otherwise unverified hypothesis."
 );
+
+fn parse_memory_purge_args(args: &Value) -> Result<MemoryPurgeArgs> {
+    let memory_id = args["memory_id"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let topic = args["topic"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let session_id = args["session_id"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let memory_types = match args.get("memory_types") {
+        None | Some(Value::Null) => None,
+        Some(Value::Array(values)) => Some(
+            values
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .ok_or_else(|| anyhow::anyhow!("memory_types entries must be strings"))
+                        .and_then(|value| {
+                            MemoryType::from_str(value).map_err(|e| anyhow::anyhow!("{e}"))
+                        })
+                })
+                .collect::<Result<Vec<_>>>()?,
+        ),
+        Some(_) => return Err(anyhow::anyhow!("memory_types must be an array of strings")),
+    }
+    .filter(|types| !types.is_empty());
+    if memory_types.is_some() && session_id.is_none() {
+        return Err(anyhow::anyhow!("memory_types requires session_id"));
+    }
+    let selector_count = usize::from(memory_id.is_some())
+        + usize::from(topic.is_some())
+        + usize::from(session_id.is_some());
+    if selector_count > 1 {
+        return Err(anyhow::anyhow!(
+            "Provide only one of memory_id, topic, or session_id"
+        ));
+    }
+    Ok(MemoryPurgeArgs {
+        memory_id,
+        topic,
+        session_id,
+        memory_types,
+    })
+}
 
 pub(crate) const MEMORY_CAPABILITIES_TEXT: &str = concat!(
     "Available tools: memory_store, memory_retrieve, memory_search, ",
@@ -145,12 +205,14 @@ pub fn list() -> Value {
         },
         {
             "name": "memory_purge",
-            "description": "Delete memories by ID (single or comma-separated batch) or by topic keyword",
+            "description": "Delete memories by ID, by topic keyword, or by exact session_id with optional memory type filtering",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "memory_id": {"type": "string", "description": "Single ID or comma-separated batch"},
                     "topic": {"type": "string", "description": "Keyword — bulk-delete all matching memories"},
+                    "session_id": {"type": "string", "description": "Exact session identifier — bulk-delete memories from that session"},
+                    "memory_types": {"type": "array", "items": {"type": "string", "enum": ["semantic", "working", "episodic", "profile", "tool_result", "procedural"]}, "description": "Optional memory type filter. Only valid with session_id"},
                     "reason": {"type": "string"}
                 }
             }
@@ -424,9 +486,8 @@ pub async fn call(
         }
 
         ToolCallName::MemoryPurge => {
-            let memory_id = args["memory_id"].as_str().unwrap_or("");
-            let topic = args["topic"].as_str().unwrap_or("");
-            if !memory_id.is_empty() {
+            let purge_args = parse_memory_purge_args(&args)?;
+            if let Some(memory_id) = purge_args.memory_id {
                 // Batch: comma-separated IDs
                 let ids: Vec<&str> = memory_id
                     .split(',')
@@ -438,15 +499,26 @@ pub async fn call(
                     &format!("Purged {} memory(s)", result.purged),
                     &result,
                 )))
-            } else if !topic.is_empty() {
+            } else if let Some(topic) = purge_args.topic {
                 // Bulk by keyword: exact text match then purge
-                let result = service.purge_by_topic(user_id, topic).await?;
+                let result = service.purge_by_topic(user_id, &topic).await?;
                 Ok(mcp_text(&format_purge_msg(
                     &format!("Purged {} memory(s) matching '{topic}'", result.purged),
                     &result,
                 )))
+            } else if let Some(session_id) = purge_args.session_id {
+                let result = service
+                    .purge_by_session_id(user_id, &session_id, purge_args.memory_types.as_deref())
+                    .await?;
+                Ok(mcp_text(&format_purge_msg(
+                    &format!(
+                        "Purged {} memory(s) for session '{session_id}'",
+                        result.purged
+                    ),
+                    &result,
+                )))
             } else {
-                Ok(mcp_text("Provide memory_id or topic"))
+                Ok(mcp_text("Provide memory_id, topic, or session_id"))
             }
         }
 

--- a/memoria/crates/memoria-mcp/src/tools.rs
+++ b/memoria/crates/memoria-mcp/src/tools.rs
@@ -1,6 +1,7 @@
 //! 8 core MCP tools for Phase 2.
 //! Phase 4 will add 14 more (Git-for-Data, admin, graph).
 
+use crate::purge_args::parse_memory_purge_args;
 use anyhow::Result;
 use memoria_core::{MemoryType, TrustTier};
 use memoria_git::GitForDataService;
@@ -51,13 +52,6 @@ enum ToolCallName {
     Unknown(String),
 }
 
-struct MemoryPurgeArgs {
-    memory_id: Option<String>,
-    topic: Option<String>,
-    session_id: Option<String>,
-    memory_types: Option<Vec<MemoryType>>,
-}
-
 const MEMORY_STORE_DESCRIPTION: &str = concat!(
     "Store a new memory. Set trust_tier explicitly when certainty matters: ",
     "T1 for directly stated or explicitly confirmed facts/preferences/decisions, ",
@@ -73,59 +67,6 @@ const TRUST_TIER_DESCRIPTION: &str = concat!(
     "prefer T3 if unsure. ",
     "T4 = speculative, reflective, or otherwise unverified hypothesis."
 );
-
-fn parse_memory_purge_args(args: &Value) -> Result<MemoryPurgeArgs> {
-    let memory_id = args["memory_id"]
-        .as_str()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
-    let topic = args["topic"]
-        .as_str()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
-    let session_id = args["session_id"]
-        .as_str()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
-    let memory_types = match args.get("memory_types") {
-        None | Some(Value::Null) => None,
-        Some(Value::Array(values)) => Some(
-            values
-                .iter()
-                .map(|value| {
-                    value
-                        .as_str()
-                        .ok_or_else(|| anyhow::anyhow!("memory_types entries must be strings"))
-                        .and_then(|value| {
-                            MemoryType::from_str(value).map_err(|e| anyhow::anyhow!("{e}"))
-                        })
-                })
-                .collect::<Result<Vec<_>>>()?,
-        ),
-        Some(_) => return Err(anyhow::anyhow!("memory_types must be an array of strings")),
-    }
-    .filter(|types| !types.is_empty());
-    if memory_types.is_some() && session_id.is_none() {
-        return Err(anyhow::anyhow!("memory_types requires session_id"));
-    }
-    let selector_count = usize::from(memory_id.is_some())
-        + usize::from(topic.is_some())
-        + usize::from(session_id.is_some());
-    if selector_count > 1 {
-        return Err(anyhow::anyhow!(
-            "Provide only one of memory_id, topic, or session_id"
-        ));
-    }
-    Ok(MemoryPurgeArgs {
-        memory_id,
-        topic,
-        session_id,
-        memory_types,
-    })
-}
 
 pub(crate) const MEMORY_CAPABILITIES_TEXT: &str = concat!(
     "Available tools: memory_store, memory_retrieve, memory_search, ",

--- a/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
@@ -396,6 +396,63 @@ async fn test_purge_topic() {
     println!("✅ purge topic 'rust': {t}");
 }
 
+// ── 12b. memory_purge: exact session cleanup with memory_types filter ─────────
+
+#[tokio::test]
+async fn test_purge_session_id_with_memory_types() {
+    let (svc, uid) = setup().await;
+    let target_session = format!("session:test-smp-{}", Uuid::new_v4().simple());
+    let other_session = format!("session:test-smp-{}", Uuid::new_v4().simple());
+
+    call(
+        "memory_store",
+        json!({"content": "local working alpha", "memory_type": "working", "session_id": target_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+    call(
+        "memory_store",
+        json!({"content": "local working beta", "memory_type": "working", "session_id": target_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+    call(
+        "memory_store",
+        json!({"content": "local semantic keep", "memory_type": "semantic", "session_id": target_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+    call(
+        "memory_store",
+        json!({"content": "local other keep", "memory_type": "working", "session_id": other_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+
+    let r = call(
+        "memory_purge",
+        json!({"session_id": target_session, "memory_types": ["working"]}),
+        &svc,
+        &uid,
+    )
+    .await;
+    let t = text(&r);
+    assert!(t.contains("Purged 2"), "{t}");
+
+    let active = svc.list_active(&uid, 10).await.unwrap();
+    let contents: Vec<&str> = active.iter().map(|m| m.content.as_str()).collect();
+    assert_eq!(active.len(), 2);
+    assert!(contents.contains(&"local semantic keep"));
+    assert!(contents.contains(&"local other keep"));
+    assert!(!contents.contains(&"local working alpha"));
+    assert!(!contents.contains(&"local working beta"));
+    println!("✅ purge session_id with memory_types: {t}");
+}
+
 // ── 13. memory_purge: no target returns error ─────────────────────────────────
 
 #[tokio::test]

--- a/memoria/crates/memoria-service/src/service.rs
+++ b/memoria/crates/memoria-service/src/service.rs
@@ -1996,7 +1996,9 @@ impl MemoryService {
                 warning,
             })
         } else {
-            let mut memories = self.store.list_active(user_id, 10_000).await?;
+            // Trait-only fallback used by tests: load the full active set so session purges
+            // stay exact instead of silently capping at an arbitrary slice.
+            let mut memories = self.store.list_active(user_id, i64::MAX).await?;
             memories.retain(|memory| memory.session_id.as_deref() == Some(session_id));
             if let Some(memory_types) = memory_types {
                 memories.retain(|memory| memory_types.contains(&memory.memory_type));

--- a/memoria/crates/memoria-service/src/service.rs
+++ b/memoria/crates/memoria-service/src/service.rs
@@ -1943,23 +1943,16 @@ impl MemoryService {
             let (snap, warning) = sql.create_safety_snapshot("purge").await;
             let table = sql.active_table(user_id).await?;
             let ids = sql.find_ids_by_topic(&table, user_id, topic).await?;
-            if !ids.is_empty() {
-                // Batch soft-delete in chunks
-                sql.soft_delete_batch_from(&table, &ids).await?;
-                // Batch entity cleanup
-                sql.cleanup_entity_data_batch(&ids).await;
-            }
             let reason = format!("topic:{topic}");
-            for id in &ids {
-                self.send_edit_log(
-                    user_id,
-                    "purge",
-                    Some(id.as_str()),
-                    None,
-                    &reason,
-                    snap.as_deref(),
-                );
-            }
+            self.purge_sql_ids(
+                user_id,
+                sql.as_ref(),
+                &table,
+                &ids,
+                &reason,
+                snap.as_deref(),
+            )
+            .await?;
             Ok(PurgeResult {
                 purged: ids.len(),
                 snapshot_name: snap,
@@ -1972,6 +1965,80 @@ impl MemoryService {
                 warning: None,
             })
         }
+    }
+
+    pub async fn purge_by_session_id(
+        &self,
+        user_id: &str,
+        session_id: &str,
+        memory_types: Option<&[MemoryType]>,
+    ) -> Result<PurgeResult, MemoriaError> {
+        if self.sql_store.is_some() {
+            let sql = self.user_sql_store(user_id).await?;
+            let (snap, warning) = sql.create_safety_snapshot("purge").await;
+            let table = sql.active_table(user_id).await?;
+            let ids = sql
+                .find_ids_by_session_id(&table, user_id, session_id, memory_types)
+                .await?;
+            let reason = format!("session:{session_id}");
+            self.purge_sql_ids(
+                user_id,
+                sql.as_ref(),
+                &table,
+                &ids,
+                &reason,
+                snap.as_deref(),
+            )
+            .await?;
+            Ok(PurgeResult {
+                purged: ids.len(),
+                snapshot_name: snap,
+                warning,
+            })
+        } else {
+            let mut memories = self.store.list_active(user_id, 10_000).await?;
+            memories.retain(|memory| memory.session_id.as_deref() == Some(session_id));
+            if let Some(memory_types) = memory_types {
+                memories.retain(|memory| memory_types.contains(&memory.memory_type));
+            }
+            for memory in &memories {
+                self.store.soft_delete(&memory.memory_id).await?;
+            }
+            Ok(PurgeResult {
+                purged: memories.len(),
+                snapshot_name: None,
+                warning: None,
+            })
+        }
+    }
+
+    async fn purge_sql_ids(
+        &self,
+        user_id: &str,
+        sql: &SqlMemoryStore,
+        table: &str,
+        ids: &[String],
+        reason: &str,
+        snapshot_name: Option<&str>,
+    ) -> Result<(), MemoriaError> {
+        if !ids.is_empty() {
+            sql.soft_delete_batch_from(table, ids).await?;
+            sql.cleanup_entity_data_batch(ids).await;
+        }
+        for id in ids {
+            self.send_edit_log(
+                user_id,
+                "purge",
+                Some(id.as_str()),
+                None,
+                reason,
+                snapshot_name,
+            );
+            self.report(StatsEvent::MemoryDeactivated {
+                user_id: user_id.to_string(),
+            });
+        }
+        Ok(())
     }
 
     pub async fn get(&self, memory_id: &str) -> Result<Option<Memory>, MemoriaError> {

--- a/memoria/crates/memoria-service/tests/service_unit.rs
+++ b/memoria/crates/memoria-service/tests/service_unit.rs
@@ -263,6 +263,48 @@ async fn test_purge_by_session_id_filters_memory_type() {
 }
 
 #[tokio::test]
+async fn test_purge_by_session_id_fallback_is_not_capped() {
+    let svc = make_service();
+    let target_count = 10_005usize;
+    for index in 0..target_count {
+        svc.store_memory(
+            "u1",
+            &format!("target working {index}"),
+            MemoryType::Working,
+            Some("sess-target".to_string()),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+    svc.store_memory(
+        "u1",
+        "keep semantic",
+        MemoryType::Semantic,
+        Some("sess-target".to_string()),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let memory_types = [MemoryType::Working];
+    let result = svc
+        .purge_by_session_id("u1", "sess-target", Some(&memory_types))
+        .await
+        .unwrap();
+    assert_eq!(result.purged, target_count);
+
+    let list = svc.list_active("u1", i64::MAX).await.unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].content, "keep semantic");
+    println!("✅ purge_by_session_id fallback scans full active set");
+}
+
+#[tokio::test]
 async fn test_memory_types() {
     let svc = make_service();
     for mt in [

--- a/memoria/crates/memoria-service/tests/service_unit.rs
+++ b/memoria/crates/memoria-service/tests/service_unit.rs
@@ -218,6 +218,51 @@ async fn test_list_active_excludes_deleted() {
 }
 
 #[tokio::test]
+async fn test_purge_by_session_id_filters_memory_type() {
+    let svc = make_service();
+    for (content, memory_type, session_id) in [
+        (
+            "remove working a",
+            MemoryType::Working,
+            Some("sess-target".to_string()),
+        ),
+        (
+            "remove working b",
+            MemoryType::Working,
+            Some("sess-target".to_string()),
+        ),
+        (
+            "keep semantic",
+            MemoryType::Semantic,
+            Some("sess-target".to_string()),
+        ),
+        (
+            "keep other session",
+            MemoryType::Working,
+            Some("sess-other".to_string()),
+        ),
+    ] {
+        svc.store_memory("u1", content, memory_type, session_id, None, None, None)
+            .await
+            .unwrap();
+    }
+
+    let memory_types = [MemoryType::Working];
+    let result = svc
+        .purge_by_session_id("u1", "sess-target", Some(&memory_types))
+        .await
+        .unwrap();
+    assert_eq!(result.purged, 2);
+
+    let list = svc.list_active("u1", 10).await.unwrap();
+    let contents: Vec<&str> = list.iter().map(|m| m.content.as_str()).collect();
+    assert_eq!(list.len(), 2);
+    assert!(contents.contains(&"keep semantic"));
+    assert!(contents.contains(&"keep other session"));
+    println!("✅ purge_by_session_id filters working memories only");
+}
+
+#[tokio::test]
 async fn test_memory_types() {
     let svc = make_service();
     for mt in [

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -5,7 +5,7 @@ use memoria_core::{
     interfaces::MemoryStore, nullable_str, nullable_str_from_row, MemoriaError, Memory, MemoryType,
     TrustTier,
 };
-use sqlx::{mysql::MySqlPool, Row};
+use sqlx::{mysql::MySqlPool, MySql, QueryBuilder, Row};
 use std::borrow::Cow;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
@@ -4530,6 +4530,37 @@ impl SqlMemoryStore {
             .await
             .map_err(db_err)?;
         Ok(rows.into_iter().map(|r| r.0).collect())
+    }
+
+    pub async fn find_ids_by_session_id(
+        &self,
+        table: &str,
+        user_id: &str,
+        session_id: &str,
+        memory_types: Option<&[MemoryType]>,
+    ) -> Result<Vec<String>, MemoriaError> {
+        let mut conn = self.conn().await?;
+        let mut query_builder: QueryBuilder<MySql> =
+            QueryBuilder::new(format!("SELECT memory_id FROM {table} WHERE user_id = "));
+        query_builder
+            .push_bind(user_id)
+            .push(" AND session_id = ")
+            .push_bind(session_id)
+            .push(" AND is_active = 1");
+        if let Some(memory_types) = memory_types.filter(|types| !types.is_empty()) {
+            query_builder.push(" AND memory_type IN (");
+            let mut separated = query_builder.separated(", ");
+            for memory_type in memory_types {
+                separated.push_bind(memory_type.to_string());
+            }
+            separated.push_unseparated(")");
+        }
+        let rows = query_builder
+            .build_query_as::<(String,)>()
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(db_err)?;
+        Ok(rows.into_iter().map(|row| row.0).collect())
     }
 
     #[tracing::instrument(skip(self))]


### PR DESCRIPTION
## Summary
- add `session_id` and optional `memory_types` support to `POST /v1/memories/purge`
- implement indexed session purge in service/storage and expose it through MCP local/remote paths
- update session-cleanup templates and add DB/API/MCP end-to-end coverage

## Testing
- cargo clippy -p memoria-api -p memoria-service -p memoria-storage -p memoria-mcp -- -D warnings
- DATABASE_URL=mysql://root:111@localhost:6001/memoria_test SQLX_OFFLINE=true EMBEDDING_PROVIDER=mock cargo test -p memoria-service --test service_unit test_purge_by_session_id_filters_memory_type -- --nocapture
- DATABASE_URL=mysql://root:111@localhost:6001/memoria_test SQLX_OFFLINE=true EMBEDDING_PROVIDER=mock cargo test -p memoria-api --test api_db_verify test_purge_by_session_id_with_memory_types_verify_db -- --nocapture
- DATABASE_URL=mysql://root:111@localhost:6001/memoria_test SQLX_OFFLINE=true EMBEDDING_PROVIDER=mock cargo test -p memoria-api --test api_e2e test_remote_purge_by_session_id -- --nocapture
- DATABASE_URL=mysql://root:111@localhost:6001/memoria_test SQLX_OFFLINE=true EMBEDDING_PROVIDER=mock cargo test -p memoria-mcp --test core_tools_e2e test_purge_session_id_with_memory_types -- --nocapture

Fixes #182