### PR TITLE
fix(multidb): default fresh deployments to multi-db

### DIFF
--- a/docs/per-user-database-architecture.md
+++ b/docs/per-user-database-architecture.md
@@ -603,6 +603,9 @@ SELECT COUNT(*) FROM `<db_name-from-registry>`.mem_memories WHERE is_active = 1;
 
 如果你只是要让新版 multi-db 服务正常启动并工作，最小集合是：
 
+> 最新运行时在**全新空环境**下，即使没显式设置 `MEMORIA_MULTI_DB`，也会自动按 multi-db 启动。
+> 但生产环境仍然建议把 `MEMORIA_MULTI_DB=1` 和 `MEMORIA_SHARED_DATABASE_URL` 明确写出来，避免歧义，也兼容旧版本节点。
+
 ```bash
 DATABASE_URL=<shared-db-url>
 MEMORIA_MULTI_DB=1
@@ -620,7 +623,7 @@ EMBEDDING_DIM=<must-match-schema>
 | 变量 | 是否迁移后重启必需 | 说明 |
 |---|---|---|
 | `DATABASE_URL` | 是 | multi-db 模式下应指向 shared DB |
-| `MEMORIA_MULTI_DB` | 是 | 置为 `1` / `true` 打开新架构 |
+| `MEMORIA_MULTI_DB` | 建议显式设置 | 置为 `1` / `true` 可强制打开新架构；最新运行时对 fresh empty 环境会自动切到 multi-db |
 | `MEMORIA_SHARED_DATABASE_URL` | 是 | 显式告诉服务 shared DB 在哪；**不要依赖默认推导** |
 | `EMBEDDING_PROVIDER` | 基本必需 | 不设会退回默认 `mock`，检索语义会变掉 |
 | `EMBEDDING_BASE_URL` | 基本必需 | HTTP embedding 服务地址 |

--- a/memoria/crates/memoria-api/tests/api_multi_db_routing.rs
+++ b/memoria/crates/memoria-api/tests/api_multi_db_routing.rs
@@ -3,6 +3,52 @@ use serial_test::serial;
 use sqlx::{mysql::MySqlPoolOptions, MySqlPool};
 use std::{sync::Arc, time::Duration};
 
+struct MultiDbTestServer {
+    base: String,
+    client: reqwest::Client,
+    router: Arc<memoria_storage::DbRouter>,
+    shared_db_url: String,
+    state: memoria_api::AppState,
+    shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    server_handle: tokio::task::JoinHandle<()>,
+}
+
+impl MultiDbTestServer {
+    async fn cleanup(mut self, user_db_names: &[String], mut direct_pools: Vec<MySqlPool>) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        self.server_handle
+            .await
+            .expect("server task should shut down cleanly");
+        self.state.service.drain_edit_log().await;
+        self.state.drain_flushers().await;
+
+        let shared_pool = self.router.shared_pool().clone();
+        let global_user_pool = self.router.global_user_pool().clone();
+        let mut db_names = sqlx::query_scalar::<_, String>(
+            "SELECT DISTINCT db_name FROM mem_user_registry WHERE status = 'active'",
+        )
+        .fetch_all(&shared_pool)
+        .await
+        .unwrap_or_default();
+        db_names.extend_from_slice(user_db_names);
+        db_names.sort();
+        db_names.dedup();
+
+        for pool in direct_pools.drain(..) {
+            pool.close().await;
+        }
+
+        drop(self.client);
+        drop(self.state);
+        drop(self.router);
+        shared_pool.close().await;
+        global_user_pool.close().await;
+        cleanup_databases(&self.shared_db_url, &db_names).await;
+    }
+}
+
 fn test_dim() -> usize {
     std::env::var("EMBEDDING_DIM")
         .ok()
@@ -38,6 +84,42 @@ fn uid(prefix: &str) -> String {
     format!("{prefix}_{}", uuid::Uuid::new_v4().simple())
 }
 
+fn split_db_url(database_url: &str) -> (&str, &str) {
+    let suffix_start = database_url.find(['?', '#']).unwrap_or(database_url.len());
+    let without_suffix = &database_url[..suffix_start];
+    without_suffix
+        .rsplit_once('/')
+        .expect("database url must include db name")
+}
+
+fn quote_ident(name: &str) -> String {
+    format!("`{}`", name.replace('`', "``"))
+}
+
+async fn cleanup_databases(shared_db_url: &str, user_db_names: &[String]) {
+    let (base_url, shared_db_name) = split_db_url(shared_db_url);
+    let admin_pool = MySqlPoolOptions::new()
+        .max_connections(1)
+        .connect(base_url)
+        .await
+        .expect("connect admin pool");
+
+    for db_name in user_db_names {
+        sqlx::raw_sql(&format!("DROP DATABASE IF EXISTS {}", quote_ident(db_name)))
+            .execute(&admin_pool)
+            .await
+            .expect("drop user db");
+    }
+    sqlx::raw_sql(&format!(
+        "DROP DATABASE IF EXISTS {}",
+        quote_ident(shared_db_name)
+    ))
+    .execute(&admin_pool)
+    .await
+    .expect("drop shared db");
+    admin_pool.close().await;
+}
+
 async fn wait_for_server(client: &reqwest::Client, base: &str, pool: &MySqlPool) {
     for _ in 0..20 {
         if client.get(format!("{base}/health")).send().await.is_ok() {
@@ -56,12 +138,7 @@ async fn wait_for_server(client: &reqwest::Client, base: &str, pool: &MySqlPool)
     panic!("DB not ready after 1s");
 }
 
-async fn spawn_multi_db_server() -> (
-    String,
-    reqwest::Client,
-    Arc<memoria_storage::DbRouter>,
-    String,
-) {
+async fn spawn_multi_db_server() -> MultiDbTestServer {
     use memoria_git::GitForDataService;
     use memoria_service::MemoryService;
     use memoria_storage::{DbRouter, SqlMemoryStore};
@@ -101,18 +178,34 @@ async fn spawn_multi_db_server() -> (
         .await,
     );
     let state = memoria_api::AppState::new(service, git, String::new());
-    let app = memoria_api::build_router(state);
+    let app = memoria_api::build_router(state.clone());
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind");
     let port = listener.local_addr().expect("local addr").port();
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
 
     let client = reqwest::Client::builder().no_proxy().build().unwrap();
     let base = format!("http://127.0.0.1:{port}");
     wait_for_server(&client, &base, &shared_pool).await;
-    (base, client, router, shared_db_url)
+    MultiDbTestServer {
+        base,
+        client,
+        router,
+        shared_db_url,
+        state,
+        shutdown_tx: Some(shutdown_tx),
+        server_handle,
+    }
 }
 
 async fn store_memory(
@@ -174,29 +267,39 @@ async fn count_user_memories(pool: &MySqlPool, user_id: &str) -> i64 {
 #[tokio::test]
 #[serial]
 async fn api_multi_db_routes_reads_and_writes_to_each_users_database() {
-    let (base, client, router, shared_db_url) = spawn_multi_db_server().await;
+    let server = spawn_multi_db_server().await;
     let user_a = uid("api_multi_a");
     let user_b = uid("api_multi_b");
 
-    let memory_a = store_memory(&base, &client, &user_a, "alpha memory").await;
-    let memory_b = store_memory(&base, &client, &user_b, "beta memory").await;
+    let memory_a = store_memory(&server.base, &server.client, &user_a, "alpha memory").await;
+    let memory_b = store_memory(&server.base, &server.client, &user_b, "beta memory").await;
 
-    let db_a = router.user_db_name(&user_a).await.expect("user A db");
-    let db_b = router.user_db_name(&user_b).await.expect("user B db");
+    let db_a = server
+        .router
+        .user_db_name(&user_a)
+        .await
+        .expect("user A db");
+    let db_b = server
+        .router
+        .user_db_name(&user_b)
+        .await
+        .expect("user B db");
     assert_ne!(
         db_a, db_b,
         "multi-db API test must route users to different databases"
     );
 
-    let listed_a = list_memory_ids(&base, &client, &user_a).await;
-    let listed_b = list_memory_ids(&base, &client, &user_b).await;
+    let listed_a = list_memory_ids(&server.base, &server.client, &user_a).await;
+    let listed_b = list_memory_ids(&server.base, &server.client, &user_b).await;
     assert_eq!(listed_a, vec![memory_a]);
     assert_eq!(listed_b, vec![memory_b]);
 
-    let pool_a = user_db_pool(&shared_db_url, &db_a).await;
-    let pool_b = user_db_pool(&shared_db_url, &db_b).await;
+    let pool_a = user_db_pool(&server.shared_db_url, &db_a).await;
+    let pool_b = user_db_pool(&server.shared_db_url, &db_b).await;
     assert_eq!(count_user_memories(&pool_a, &user_a).await, 1);
     assert_eq!(count_user_memories(&pool_a, &user_b).await, 0);
     assert_eq!(count_user_memories(&pool_b, &user_b).await, 1);
     assert_eq!(count_user_memories(&pool_b, &user_a).await, 0);
+
+    server.cleanup(&[db_a, db_b], vec![pool_a, pool_b]).await;
 }

--- a/memoria/crates/memoria-api/tests/api_multi_db_routing.rs
+++ b/memoria/crates/memoria-api/tests/api_multi_db_routing.rs
@@ -1,0 +1,202 @@
+use serde_json::{json, Value};
+use serial_test::serial;
+use sqlx::{mysql::MySqlPoolOptions, MySqlPool};
+use std::{sync::Arc, time::Duration};
+
+fn test_dim() -> usize {
+    std::env::var("EMBEDDING_DIM")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1024)
+}
+
+fn db_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string())
+}
+
+fn replace_db_name(database_url: &str, db_name: &str) -> String {
+    let suffix_start = database_url.find(['?', '#']).unwrap_or(database_url.len());
+    let (without_suffix, suffix) = database_url.split_at(suffix_start);
+    let (base, _) = without_suffix
+        .rsplit_once('/')
+        .expect("database url must include db name");
+    format!("{base}/{db_name}{suffix}")
+}
+
+fn shared_db_url() -> String {
+    replace_db_name(
+        &db_url(),
+        &format!(
+            "memoria_api_multi_{}",
+            &uuid::Uuid::new_v4().simple().to_string()[..8]
+        ),
+    )
+}
+
+fn uid(prefix: &str) -> String {
+    format!("{prefix}_{}", uuid::Uuid::new_v4().simple())
+}
+
+async fn wait_for_server(client: &reqwest::Client, base: &str, pool: &MySqlPool) {
+    for _ in 0..20 {
+        if client.get(format!("{base}/health")).send().await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+
+    for _ in 0..20 {
+        if sqlx::query("SELECT 1").execute(pool).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+
+    panic!("DB not ready after 1s");
+}
+
+async fn spawn_multi_db_server() -> (
+    String,
+    reqwest::Client,
+    Arc<memoria_storage::DbRouter>,
+    String,
+) {
+    use memoria_git::GitForDataService;
+    use memoria_service::MemoryService;
+    use memoria_storage::{DbRouter, SqlMemoryStore};
+
+    let shared_db_url = shared_db_url();
+    memoria_test_utils::wait_for_mysql_ready(&shared_db_url, Duration::from_secs(30)).await;
+
+    let router = Arc::new(
+        DbRouter::connect(&shared_db_url, test_dim(), uuid::Uuid::new_v4().to_string())
+            .await
+            .expect("router"),
+    );
+    let shared_pool = router.shared_pool().clone();
+    let shared_pool_max_connections = router.shared_pool_max_connections();
+    let mut store = SqlMemoryStore::from_existing_pool(
+        shared_pool.clone(),
+        test_dim(),
+        uuid::Uuid::new_v4().to_string(),
+        Some(shared_db_url.clone()),
+        Some(shared_pool_max_connections),
+        "api_multi_db_shared_pool",
+    );
+    store.migrate_shared().await.expect("migrate_shared");
+    store.set_db_router(router.clone());
+
+    let git = Arc::new(GitForDataService::new(
+        shared_pool.clone(),
+        router.shared_db_name().to_string(),
+    ));
+    let service = Arc::new(
+        MemoryService::new_sql_with_llm_and_router(
+            Arc::new(store),
+            Some(router.clone()),
+            None,
+            None,
+        )
+        .await,
+    );
+    let state = memoria_api::AppState::new(service, git, String::new());
+    let app = memoria_api::build_router(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let port = listener.local_addr().expect("local addr").port();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let client = reqwest::Client::builder().no_proxy().build().unwrap();
+    let base = format!("http://127.0.0.1:{port}");
+    wait_for_server(&client, &base, &shared_pool).await;
+    (base, client, router, shared_db_url)
+}
+
+async fn store_memory(
+    base: &str,
+    client: &reqwest::Client,
+    user_id: &str,
+    content: &str,
+) -> String {
+    let response = client
+        .post(format!("{base}/v1/memories"))
+        .header("X-User-Id", user_id)
+        .json(&json!({ "content": content }))
+        .send()
+        .await
+        .expect("store request");
+    assert_eq!(response.status(), 201);
+    let body: Value = response.json().await.expect("store response body");
+    body["memory_id"].as_str().expect("memory_id").to_string()
+}
+
+async fn list_memory_ids(base: &str, client: &reqwest::Client, user_id: &str) -> Vec<String> {
+    let response = client
+        .get(format!("{base}/v1/memories"))
+        .header("X-User-Id", user_id)
+        .send()
+        .await
+        .expect("list request");
+    assert_eq!(response.status(), 200);
+    let body: Value = response.json().await.expect("list response body");
+    body["items"]
+        .as_array()
+        .expect("items")
+        .iter()
+        .map(|item| {
+            item["memory_id"]
+                .as_str()
+                .expect("list memory_id")
+                .to_string()
+        })
+        .collect()
+}
+
+async fn user_db_pool(shared_db_url: &str, db_name: &str) -> MySqlPool {
+    MySqlPoolOptions::new()
+        .max_connections(1)
+        .connect(&replace_db_name(shared_db_url, db_name))
+        .await
+        .expect("connect user db")
+}
+
+async fn count_user_memories(pool: &MySqlPool, user_id: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM mem_memories WHERE user_id = ?")
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .expect("count user memories")
+}
+
+#[tokio::test]
+#[serial]
+async fn api_multi_db_routes_reads_and_writes_to_each_users_database() {
+    let (base, client, router, shared_db_url) = spawn_multi_db_server().await;
+    let user_a = uid("api_multi_a");
+    let user_b = uid("api_multi_b");
+
+    let memory_a = store_memory(&base, &client, &user_a, "alpha memory").await;
+    let memory_b = store_memory(&base, &client, &user_b, "beta memory").await;
+
+    let db_a = router.user_db_name(&user_a).await.expect("user A db");
+    let db_b = router.user_db_name(&user_b).await.expect("user B db");
+    assert_ne!(
+        db_a, db_b,
+        "multi-db API test must route users to different databases"
+    );
+
+    let listed_a = list_memory_ids(&base, &client, &user_a).await;
+    let listed_b = list_memory_ids(&base, &client, &user_b).await;
+    assert_eq!(listed_a, vec![memory_a]);
+    assert_eq!(listed_b, vec![memory_b]);
+
+    let pool_a = user_db_pool(&shared_db_url, &db_a).await;
+    let pool_b = user_db_pool(&shared_db_url, &db_b).await;
+    assert_eq!(count_user_memories(&pool_a, &user_a).await, 1);
+    assert_eq!(count_user_memories(&pool_a, &user_b).await, 0);
+    assert_eq!(count_user_memories(&pool_b, &user_b).await, 1);
+    assert_eq!(count_user_memories(&pool_b, &user_a).await, 0);
+}

--- a/memoria/crates/memoria-cli/src/main.rs
+++ b/memoria/crates/memoria-cli/src/main.rs
@@ -434,54 +434,76 @@ async fn connect_git_pool(database_url: &str, multi_db: bool) -> Result<sqlx::My
 }
 
 #[cfg(feature = "server-runtime")]
-async fn bootstrap_runtime_topology(cfg: &mut memoria_service::Config) -> Result<()> {
-    use memoria_storage::{
-        detect_runtime_topology, execute_legacy_single_db_to_multi_db,
-        LegacyToMultiDbMigrationOptions, RuntimeTopology,
-    };
+fn apply_detected_runtime_topology(
+    cfg: &mut memoria_service::Config,
+    topology: memoria_storage::RuntimeTopology,
+) -> Option<memoria_storage::PendingLegacyMultiDbMigration> {
+    use memoria_storage::RuntimeTopology;
 
-    if cfg.multi_db {
-        return Ok(());
-    }
-
-    match detect_runtime_topology(&cfg.db_url, &cfg.shared_db_url).await? {
-        RuntimeTopology::FreshSingleDb => Ok(()),
+    match topology {
+        RuntimeTopology::FreshSingleDb => {
+            tracing::info!(
+                shared_db_url = %redact_url(&cfg.shared_db_url),
+                "Detected fresh deployment; continuing startup in multi-db mode"
+            );
+            enable_runtime_multi_db(cfg);
+            None
+        }
         RuntimeTopology::MultiDbReady => {
             tracing::info!(
                 shared_db_url = %redact_url(&cfg.shared_db_url),
                 "Detected completed shared registry behind legacy config; continuing in multi-db mode"
             );
             enable_runtime_multi_db(cfg);
-            Ok(())
+            None
         }
-        RuntimeTopology::PendingLegacyMigration(pending) => {
-            let migration_concurrency = configured_legacy_migration_concurrency();
-            tracing::info!(
-                legacy_db_name = %pending.legacy_db_name,
-                shared_db_name = %pending.shared_db_name,
-                users = pending.legacy_users.len(),
-                missing_users = pending.missing_users.len(),
-                migration_concurrency,
-                "Auto-migrating legacy single-db deployment before startup"
-            );
-            execute_legacy_single_db_to_multi_db(
-                &cfg.db_url,
-                &cfg.shared_db_url,
-                cfg.embedding_dim,
-                LegacyToMultiDbMigrationOptions {
-                    user_ids: Vec::new(),
-                    concurrency: migration_concurrency,
-                },
-            )
-            .await?;
-            enable_runtime_multi_db(cfg);
-            tracing::info!(
-                shared_db_url = %redact_url(&cfg.shared_db_url),
-                "Legacy migration completed; continuing startup in multi-db mode"
-            );
-            Ok(())
-        }
+        RuntimeTopology::PendingLegacyMigration(pending) => Some(pending),
     }
+}
+
+#[cfg(feature = "server-runtime")]
+async fn bootstrap_runtime_topology(cfg: &mut memoria_service::Config) -> Result<()> {
+    use memoria_storage::{
+        detect_runtime_topology, execute_legacy_single_db_to_multi_db,
+        LegacyToMultiDbMigrationOptions,
+    };
+
+    if cfg.multi_db {
+        return Ok(());
+    }
+
+    let Some(pending) = apply_detected_runtime_topology(
+        cfg,
+        detect_runtime_topology(&cfg.db_url, &cfg.shared_db_url).await?,
+    ) else {
+        return Ok(());
+    };
+
+    let migration_concurrency = configured_legacy_migration_concurrency();
+    tracing::info!(
+        legacy_db_name = %pending.legacy_db_name,
+        shared_db_name = %pending.shared_db_name,
+        users = pending.legacy_users.len(),
+        missing_users = pending.missing_users.len(),
+        migration_concurrency,
+        "Auto-migrating legacy single-db deployment before startup"
+    );
+    execute_legacy_single_db_to_multi_db(
+        &cfg.db_url,
+        &cfg.shared_db_url,
+        cfg.embedding_dim,
+        LegacyToMultiDbMigrationOptions {
+            user_ids: Vec::new(),
+            concurrency: migration_concurrency,
+        },
+    )
+    .await?;
+    enable_runtime_multi_db(cfg);
+    tracing::info!(
+        shared_db_url = %redact_url(&cfg.shared_db_url),
+        "Legacy migration completed; continuing startup in multi-db mode"
+    );
+    Ok(())
 }
 
 #[cfg(feature = "server-runtime")]
@@ -3458,7 +3480,10 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "server-runtime")]
-    use super::{configured_legacy_migration_concurrency, LEGACY_MIGRATION_MAX_CONCURRENCY_ENV};
+    use super::{
+        apply_detected_runtime_topology, configured_legacy_migration_concurrency,
+        LEGACY_MIGRATION_MAX_CONCURRENCY_ENV,
+    };
     use super::{
         enable_runtime_multi_db, redact_url, run_with_edit_log_drain, validate_embedding_config,
         Cli, Commands, MigrationCommands,
@@ -3468,6 +3493,8 @@ mod tests {
     use memoria_core::{interfaces::MemoryStore, MemoriaError, Memory};
     use memoria_service::{Config, MemoryService};
     use memoria_storage::OwnedEditLogEntry;
+    #[cfg(feature = "server-runtime")]
+    use memoria_storage::{PendingLegacyMultiDbMigration, RuntimeTopology};
     #[cfg(feature = "server-runtime")]
     use std::sync::OnceLock;
     use std::sync::{Arc, Mutex};
@@ -3755,6 +3782,52 @@ mod tests {
         assert!(cfg.multi_db);
         assert_eq!(cfg.db_name, "memoria_shared");
         assert_eq!(cfg.db_url, "mysql://root:111@localhost:6001/memoria");
+    }
+
+    #[cfg(feature = "server-runtime")]
+    #[test]
+    fn fresh_topology_bootstrap_defaults_to_multi_db() {
+        let mut cfg = test_config();
+
+        let pending = apply_detected_runtime_topology(&mut cfg, RuntimeTopology::FreshSingleDb);
+
+        assert!(pending.is_none());
+        assert!(cfg.multi_db);
+        assert_eq!(cfg.db_name, "memoria_shared");
+        assert_eq!(cfg.db_url, "mysql://root:111@localhost:6001/memoria");
+    }
+
+    #[cfg(feature = "server-runtime")]
+    #[test]
+    fn multi_db_ready_bootstrap_keeps_multi_db_enabled() {
+        let mut cfg = test_config();
+
+        let pending = apply_detected_runtime_topology(&mut cfg, RuntimeTopology::MultiDbReady);
+
+        assert!(pending.is_none());
+        assert!(cfg.multi_db);
+        assert_eq!(cfg.db_name, "memoria_shared");
+    }
+
+    #[cfg(feature = "server-runtime")]
+    #[test]
+    fn pending_migration_bootstrap_waits_for_migration_before_switching() {
+        let mut cfg = test_config();
+        let pending = PendingLegacyMultiDbMigration {
+            legacy_db_name: "memoria".to_string(),
+            shared_db_name: "memoria_shared".to_string(),
+            legacy_users: vec!["alice".to_string(), "bob".to_string()],
+            missing_users: vec!["bob".to_string()],
+        };
+
+        let migration = apply_detected_runtime_topology(
+            &mut cfg,
+            RuntimeTopology::PendingLegacyMigration(pending.clone()),
+        );
+
+        assert_eq!(migration, Some(pending));
+        assert!(!cfg.multi_db);
+        assert_eq!(cfg.db_name, "memoria");
     }
 
     #[test]


### PR DESCRIPTION
## What type of PR is this?

- [x] fix (bug fix)
- [x] docs (documentation)
- [x] test (adding or updating tests)

## Which issue(s) this PR fixes

Fixes #

## What this PR does / why we need it

Fresh empty deployments on the latest runtime still stayed in single-db unless `MEMORIA_MULTI_DB` was set explicitly, even though new-version fresh environments are intended to run multi-db by default.

This PR changes the fresh auto-detect startup path to enable multi-db by default while keeping the other startup paths intact:

- `FreshSingleDb` now enables multi-db during runtime bootstrap
- `PendingLegacyMigration` still migrates legacy single-db data before switching to multi-db
- `MultiDbReady` still enters multi-db directly
- add bootstrap unit tests for fresh / pending-migration / ready behavior
- add an API multi-db routing integration test
- document that fresh empty deployments default to multi-db while explicit multi-db envs are still recommended in production

## Testing

- `cargo test -p memoria-cli fresh_topology_bootstrap_defaults_to_multi_db -- --nocapture`
- `cargo test -p memoria-cli multi_db_ready_bootstrap_keeps_multi_db_enabled -- --nocapture`
- `cargo test -p memoria-cli pending_migration_bootstrap_waits_for_migration_before_switching -- --nocapture`
- `cargo test -p memoria-storage classify_runtime_topology_detects_fresh_single_db -- --nocapture`
- `cargo test -p memoria-api api_multi_db_routes_reads_and_writes_to_each_users_database -- --nocapture`
- `cargo test -p memoria-mcp test_multi_db_snapshot_rollback_isolates_users -- --nocapture`
- full `memoria serve` smoke on isolated Docker MatrixOne for fresh / ready / pending-migration startup states
