### PR TITLE
test: migrate API and MCP e2e to multi-db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help check-env up down status logs logs-db \
         up-db down-db up-api down-api rebuild-api health \
         dev build build-local check \
-        test test-unit test-integration test-e2e bench dev-bench \
+        test test-unit test-integration test-e2e test-e2e-mcp bench dev-bench \
         new-key list-keys revoke-keys \
         clean reset
 
@@ -47,6 +47,7 @@ help:
 	@echo "  make test               All tests (needs DB)"
 	@echo "  make test-unit          Unit tests (no DB)"
 	@echo "  make test-e2e           E2E API tests (needs DB)"
+	@echo "  make test-e2e-mcp       E2E MCP tests (needs DB)"
 	@echo "  make bench              Run benchmark (needs: make up)"
 	@echo "  make dev-bench          Load test API (DURATION=60 USERS=10 SEED=20 RPS=0 SCENARIO=all)"
 	@echo ""
@@ -202,6 +203,89 @@ test-e2e:
 		LLM_BASE_URL=$${MEMORIA_LLM_BASE_URL:-} \
 		LLM_MODEL=$${MEMORIA_LLM_MODEL:-} \
 		cargo test -p memoria-api --test api_e2e
+
+test-e2e-mcp:
+	@cd memoria && DATABASE_URL=$(TEST_DB_URL) SQLX_OFFLINE=true \
+		EMBEDDING_API_KEY=$${MEMORIA_EMBEDDING_API_KEY:-} \
+		EMBEDDING_BASE_URL=$${MEMORIA_EMBEDDING_BASE_URL:-} \
+		EMBEDDING_MODEL=$${MEMORIA_EMBEDDING_MODEL:-BAAI/bge-m3} \
+		EMBEDDING_DIM=$${MEMORIA_EMBEDDING_DIM:-1024} \
+		LLM_API_KEY=$${MEMORIA_LLM_API_KEY:-} \
+		LLM_BASE_URL=$${MEMORIA_LLM_BASE_URL:-} \
+		LLM_MODEL=$${MEMORIA_LLM_MODEL:-} \
+		cargo test -p memoria-mcp --test mcp_e2e -- --test-threads=1
+	@cd memoria && DATABASE_URL=$(TEST_DB_URL) SQLX_OFFLINE=true \
+		EMBEDDING_API_KEY=$${MEMORIA_EMBEDDING_API_KEY:-} \
+		EMBEDDING_BASE_URL=$${MEMORIA_EMBEDDING_BASE_URL:-} \
+		EMBEDDING_MODEL=$${MEMORIA_EMBEDDING_MODEL:-BAAI/bge-m3} \
+		EMBEDDING_DIM=$${MEMORIA_EMBEDDING_DIM:-1024} \
+		LLM_API_KEY=$${MEMORIA_LLM_API_KEY:-} \
+		LLM_BASE_URL=$${MEMORIA_LLM_BASE_URL:-} \
+		LLM_MODEL=$${MEMORIA_LLM_MODEL:-} \
+		cargo test -p memoria-mcp --test core_tools_e2e -- --test-threads=1
+	@cd memoria && DATABASE_URL=$(TEST_DB_URL) SQLX_OFFLINE=true \
+		EMBEDDING_API_KEY=$${MEMORIA_EMBEDDING_API_KEY:-} \
+		EMBEDDING_BASE_URL=$${MEMORIA_EMBEDDING_BASE_URL:-} \
+		EMBEDDING_MODEL=$${MEMORIA_EMBEDDING_MODEL:-BAAI/bge-m3} \
+		EMBEDDING_DIM=$${MEMORIA_EMBEDDING_DIM:-1024} \
+		LLM_API_KEY=$${MEMORIA_LLM_API_KEY:-} \
+		LLM_BASE_URL=$${MEMORIA_LLM_BASE_URL:-} \
+		LLM_MODEL=$${MEMORIA_LLM_MODEL:-} \
+		cargo test -p memoria-mcp --test branch_e2e -- --test-threads=1
+	@cd memoria && DATABASE_URL=$(TEST_DB_URL) SQLX_OFFLINE=true \
+		EMBEDDING_API_KEY=$${MEMORIA_EMBEDDING_API_KEY:-} \
+		EMBEDDING_BASE_URL=$${MEMORIA_EMBEDDING_BASE_URL:-} \
+		EMBEDDING_MODEL=$${MEMORIA_EMBEDDING_MODEL:-BAAI/bge-m3} \
+		EMBEDDING_DIM=$${MEMORIA_EMBEDDING_DIM:-1024} \
+		LLM_API_KEY=$${MEMORIA_LLM_API_KEY:-} \
+		LLM_BASE_URL=$${MEMORIA_LLM_BASE_URL:-} \
+		LLM_MODEL=$${MEMORIA_LLM_MODEL:-} \
+		cargo test -p memoria-mcp --test feedback_e2e -- --test-threads=1
+	@cd memoria && DATABASE_URL=$(TEST_DB_URL) SQLX_OFFLINE=true \
+		EMBEDDING_API_KEY=$${MEMORIA_EMBEDDING_API_KEY:-} \
+		EMBEDDING_BASE_URL=$${MEMORIA_EMBEDDING_BASE_URL:-} \
+		EMBEDDING_MODEL=$${MEMORIA_EMBEDDING_MODEL:-BAAI/bge-m3} \
+		EMBEDDING_DIM=$${MEMORIA_EMBEDDING_DIM:-1024} \
+		LLM_API_KEY=$${MEMORIA_LLM_API_KEY:-} \
+		LLM_BASE_URL=$${MEMORIA_LLM_BASE_URL:-} \
+		LLM_MODEL=$${MEMORIA_LLM_MODEL:-} \
+		cargo test -p memoria-mcp --test integration_full -- --test-threads=1
+	@cd memoria && DATABASE_URL=$(TEST_DB_URL) SQLX_OFFLINE=true \
+		EMBEDDING_API_KEY=$${MEMORIA_EMBEDDING_API_KEY:-} \
+		EMBEDDING_BASE_URL=$${MEMORIA_EMBEDDING_BASE_URL:-} \
+		EMBEDDING_MODEL=$${MEMORIA_EMBEDDING_MODEL:-BAAI/bge-m3} \
+		EMBEDDING_DIM=$${MEMORIA_EMBEDDING_DIM:-1024} \
+		LLM_API_KEY=$${MEMORIA_LLM_API_KEY:-} \
+		LLM_BASE_URL=$${MEMORIA_LLM_BASE_URL:-} \
+		LLM_MODEL=$${MEMORIA_LLM_MODEL:-} \
+		cargo test -p memoria-mcp --test perf_optimizations_e2e -- --test-threads=1
+	@cd memoria && DATABASE_URL=$(TEST_DB_URL) SQLX_OFFLINE=true \
+		EMBEDDING_API_KEY=$${MEMORIA_EMBEDDING_API_KEY:-} \
+		EMBEDDING_BASE_URL=$${MEMORIA_EMBEDDING_BASE_URL:-} \
+		EMBEDDING_MODEL=$${MEMORIA_EMBEDDING_MODEL:-BAAI/bge-m3} \
+		EMBEDDING_DIM=$${MEMORIA_EMBEDDING_DIM:-1024} \
+		LLM_API_KEY=$${MEMORIA_LLM_API_KEY:-} \
+		LLM_BASE_URL=$${MEMORIA_LLM_BASE_URL:-} \
+		LLM_MODEL=$${MEMORIA_LLM_MODEL:-} \
+		cargo test -p memoria-mcp --test snapshot_e2e -- --test-threads=1
+	@cd memoria && DATABASE_URL=$(TEST_DB_URL) SQLX_OFFLINE=true \
+		EMBEDDING_API_KEY=$${MEMORIA_EMBEDDING_API_KEY:-} \
+		EMBEDDING_BASE_URL=$${MEMORIA_EMBEDDING_BASE_URL:-} \
+		EMBEDDING_MODEL=$${MEMORIA_EMBEDDING_MODEL:-BAAI/bge-m3} \
+		EMBEDDING_DIM=$${MEMORIA_EMBEDDING_DIM:-1024} \
+		LLM_API_KEY=$${MEMORIA_LLM_API_KEY:-} \
+		LLM_BASE_URL=$${MEMORIA_LLM_BASE_URL:-} \
+		LLM_MODEL=$${MEMORIA_LLM_MODEL:-} \
+		cargo test -p memoria-mcp --test edit_log_e2e -- --test-threads=1
+	@cd memoria && DATABASE_URL=$(TEST_DB_URL) SQLX_OFFLINE=true \
+		EMBEDDING_API_KEY=$${MEMORIA_EMBEDDING_API_KEY:-} \
+		EMBEDDING_BASE_URL=$${MEMORIA_EMBEDDING_BASE_URL:-} \
+		EMBEDDING_MODEL=$${MEMORIA_EMBEDDING_MODEL:-BAAI/bge-m3} \
+		EMBEDDING_DIM=$${MEMORIA_EMBEDDING_DIM:-1024} \
+		LLM_API_KEY=$${MEMORIA_LLM_API_KEY:-} \
+		LLM_BASE_URL=$${MEMORIA_LLM_BASE_URL:-} \
+		LLM_MODEL=$${MEMORIA_LLM_MODEL:-} \
+		cargo test -p memoria-mcp --test graph_e2e -- --test-threads=1
 
 # ── Benchmark ───────────────────────────────────────────────────────
 

--- a/memoria/Cargo.lock
+++ b/memoria/Cargo.lock
@@ -2311,10 +2311,15 @@ name = "memoria-test-utils"
 version = "0.3.2"
 dependencies = [
  "axum",
+ "memoria-core",
  "memoria-embedding",
+ "memoria-git",
+ "memoria-service",
+ "memoria-storage",
  "serde_json",
  "sqlx",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/memoria/crates/memoria-api/src/routes/admin.rs
+++ b/memoria/crates/memoria-api/src/routes/admin.rs
@@ -342,6 +342,46 @@ pub async fn health_hygiene_global(
         .sql_store
         .as_ref()
         .ok_or((StatusCode::SERVICE_UNAVAILABLE, "SQL store required".into()))?;
+    if let Some(router) = sql.db_router() {
+        let user_ids = router.list_active_users().await.map_err(api_err)?;
+        let mut inactive = 0i64;
+        let mut stale_working = 0i64;
+        let mut orphan_mel = 0i64;
+        let mut orphan_el = 0i64;
+        let mut orphan_graph_nodes = 0i64;
+        let mut orphan_stats = 0i64;
+
+        for user_id in user_ids {
+            let user_store = state.service.user_sql_store(&user_id).await.map_err(api_err)?;
+            let hygiene = user_store.health_hygiene(&user_id).await.map_err(db_err)?;
+            inactive += hygiene["inactive_memories"].as_i64().unwrap_or(0);
+            stale_working += hygiene["stale_working_memories"].as_i64().unwrap_or(0);
+            orphan_mel += hygiene["orphan_memory_entity_links"].as_i64().unwrap_or(0);
+            orphan_el += hygiene["orphan_entity_links"].as_i64().unwrap_or(0);
+            orphan_graph_nodes += hygiene["orphan_graph_nodes"].as_i64().unwrap_or(0);
+
+            let memory_stats_table = user_store.t("mem_memories_stats");
+            let memories_table = user_store.t("mem_memories");
+            let (user_orphan_stats,): (i64,) = sqlx::query_as(&format!(
+                "SELECT COUNT(*) FROM {memory_stats_table} s \
+                 LEFT JOIN {memories_table} m ON s.memory_id = m.memory_id \
+                 WHERE m.memory_id IS NULL"
+            ))
+            .fetch_one(user_store.pool())
+            .await
+            .map_err(db_err)?;
+            orphan_stats += user_orphan_stats;
+        }
+
+        return Ok(Json(serde_json::json!({
+            "inactive_memories": inactive,
+            "stale_working_memories": stale_working,
+            "orphan_memory_entity_links": orphan_mel,
+            "orphan_entity_links": orphan_el,
+            "orphan_graph_nodes": orphan_graph_nodes,
+            "orphan_stats": orphan_stats,
+        })));
+    }
     let result = sql.health_hygiene_global().await.map_err(db_err)?;
     Ok(Json(result))
 }

--- a/memoria/crates/memoria-api/src/routes/memory.rs
+++ b/memoria/crates/memoria-api/src/routes/memory.rs
@@ -51,7 +51,11 @@ async fn find_memory_any_user(
             .await
             .map_err(api_err_typed)?;
         let table = sql.active_table(&candidate).await.map_err(api_err_typed)?;
-        if let Some(memory) = sql.get_from(&table, memory_id).await.map_err(api_err_typed)? {
+        if let Some(memory) = sql
+            .get_from(&table, memory_id)
+            .await
+            .map_err(api_err_typed)?
+        {
             return Ok(Some((candidate, memory)));
         }
     }
@@ -319,10 +323,11 @@ pub async fn get_memory(
         return Ok(Json(Some(memory.into())));
     }
 
-    if let Some((owner_id, memory)) = find_memory_any_user(&state, &id).await? {
-        if !is_master && owner_id != user_id {
-            return Err((StatusCode::FORBIDDEN, "Not your memory".to_string()));
-        }
+    if !is_master {
+        return Ok(Json(None));
+    }
+
+    if let Some((_, memory)) = find_memory_any_user(&state, &id).await? {
         return Ok(Json(Some(memory.into())));
     }
 
@@ -341,25 +346,16 @@ pub async fn correct_memory(
             .map(|(owner_id, _)| owner_id)
             .unwrap_or_else(|| user_id.clone())
     } else {
-        match state
+        if state
             .service
             .get_for_user(&user_id, &id)
             .await
             .map_err(api_err_typed)?
+            .is_none()
         {
-            Some(memory) => {
-                if memory.user_id != user_id {
-                    return Err((StatusCode::FORBIDDEN, "Not your memory".to_string()));
-                }
-                user_id.clone()
-            }
-            None => {
-                if find_memory_any_user(&state, &id).await?.is_some() {
-                    return Err((StatusCode::FORBIDDEN, "Not your memory".to_string()));
-                }
-                return Err((StatusCode::NOT_FOUND, "Memory not found".to_string()));
-            }
+            return Err((StatusCode::NOT_FOUND, "Memory not found".to_string()));
         }
+        user_id.clone()
     };
     let m = state
         .service
@@ -404,25 +400,16 @@ pub async fn delete_memory(
             .map(|(owner_id, _)| owner_id)
             .unwrap_or_else(|| user_id.clone())
     } else {
-        match state
+        if state
             .service
             .get_for_user(&user_id, &id)
             .await
             .map_err(api_err_typed)?
+            .is_none()
         {
-            Some(memory) => {
-                if memory.user_id != user_id {
-                    return Err((StatusCode::FORBIDDEN, "Not your memory".to_string()));
-                }
-                user_id.clone()
-            }
-            None => {
-                if find_memory_any_user(&state, &id).await?.is_some() {
-                    return Err((StatusCode::FORBIDDEN, "Not your memory".to_string()));
-                }
-                return Err((StatusCode::NOT_FOUND, "Memory not found".to_string()));
-            }
+            return Err((StatusCode::NOT_FOUND, "Memory not found".to_string()));
         }
+        user_id.clone()
     };
     let _ = state
         .service

--- a/memoria/crates/memoria-api/src/routes/memory.rs
+++ b/memoria/crates/memoria-api/src/routes/memory.rs
@@ -33,6 +33,32 @@ pub fn api_err_typed(e: memoria_core::MemoriaError) -> (StatusCode, String) {
     (status, e.to_string())
 }
 
+async fn find_memory_any_user(
+    state: &AppState,
+    memory_id: &str,
+) -> Result<Option<(String, memoria_core::Memory)>, (StatusCode, String)> {
+    let shared = state.service.shared_sql_store().map_err(api_err_typed)?;
+    let Some(router) = shared.db_router() else {
+        let memory = state.service.get(memory_id).await.map_err(api_err_typed)?;
+        return Ok(memory.map(|m| (m.user_id.clone(), m)));
+    };
+
+    let user_ids = router.list_active_users().await.map_err(api_err_typed)?;
+    for candidate in user_ids {
+        let sql = state
+            .service
+            .user_sql_store(&candidate)
+            .await
+            .map_err(api_err_typed)?;
+        let table = sql.active_table(&candidate).await.map_err(api_err_typed)?;
+        if let Some(memory) = sql.get_from(&table, memory_id).await.map_err(api_err_typed)? {
+            return Ok(Some((candidate, memory)));
+        }
+    }
+
+    Ok(None)
+}
+
 #[derive(Deserialize, Default)]
 pub struct ListQuery {
     pub memory_type: Option<String>,
@@ -284,17 +310,23 @@ pub async fn get_memory(
     AuthUser { user_id, is_master }: AuthUser,
     Path(id): Path<String>,
 ) -> ApiResult<Option<MemoryResponse>> {
-    let m = state
+    let owned = state
         .service
         .get_for_user(&user_id, &id)
         .await
-        .map_err(api_err)?;
-    if let Some(ref mem) = m {
-        if !is_master && mem.user_id != user_id {
+        .map_err(api_err_typed)?;
+    if let Some(memory) = owned {
+        return Ok(Json(Some(memory.into())));
+    }
+
+    if let Some((owner_id, memory)) = find_memory_any_user(&state, &id).await? {
+        if !is_master && owner_id != user_id {
             return Err((StatusCode::FORBIDDEN, "Not your memory".to_string()));
         }
+        return Ok(Json(Some(memory.into())));
     }
-    Ok(Json(m.map(Into::into)))
+
+    Ok(Json(None))
 }
 
 pub async fn correct_memory(
@@ -303,22 +335,37 @@ pub async fn correct_memory(
     Path(id): Path<String>,
     Json(req): Json<CorrectRequest>,
 ) -> ApiResult<MemoryResponse> {
-    if !is_master {
-        let existing = state
+    let effective_user_id = if is_master {
+        find_memory_any_user(&state, &id)
+            .await?
+            .map(|(owner_id, _)| owner_id)
+            .unwrap_or_else(|| user_id.clone())
+    } else {
+        match state
             .service
             .get_for_user(&user_id, &id)
             .await
-            .map_err(api_err)?
-            .ok_or_else(|| (StatusCode::NOT_FOUND, "Memory not found".to_string()))?;
-        if existing.user_id != user_id {
-            return Err((StatusCode::FORBIDDEN, "Not your memory".to_string()));
+            .map_err(api_err_typed)?
+        {
+            Some(memory) => {
+                if memory.user_id != user_id {
+                    return Err((StatusCode::FORBIDDEN, "Not your memory".to_string()));
+                }
+                user_id.clone()
+            }
+            None => {
+                if find_memory_any_user(&state, &id).await?.is_some() {
+                    return Err((StatusCode::FORBIDDEN, "Not your memory".to_string()));
+                }
+                return Err((StatusCode::NOT_FOUND, "Memory not found".to_string()));
+            }
         }
-    }
+    };
     let m = state
         .service
-        .correct(&user_id, &id, &req.new_content)
+        .correct(&effective_user_id, &id, &req.new_content)
         .await
-        .map_err(api_err)?;
+        .map_err(api_err_typed)?;
     Ok(Json(m.into()))
 }
 
@@ -351,18 +398,37 @@ pub async fn delete_memory(
     AuthUser { user_id, is_master }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    if !is_master {
-        let existing = state
+    let effective_user_id = if is_master {
+        find_memory_any_user(&state, &id)
+            .await?
+            .map(|(owner_id, _)| owner_id)
+            .unwrap_or_else(|| user_id.clone())
+    } else {
+        match state
             .service
             .get_for_user(&user_id, &id)
             .await
-            .map_err(api_err)?
-            .ok_or_else(|| (StatusCode::NOT_FOUND, "Memory not found".to_string()))?;
-        if existing.user_id != user_id {
-            return Err((StatusCode::FORBIDDEN, "Not your memory".to_string()));
+            .map_err(api_err_typed)?
+        {
+            Some(memory) => {
+                if memory.user_id != user_id {
+                    return Err((StatusCode::FORBIDDEN, "Not your memory".to_string()));
+                }
+                user_id.clone()
+            }
+            None => {
+                if find_memory_any_user(&state, &id).await?.is_some() {
+                    return Err((StatusCode::FORBIDDEN, "Not your memory".to_string()));
+                }
+                return Err((StatusCode::NOT_FOUND, "Memory not found".to_string()));
+            }
         }
-    }
-    let _ = state.service.purge(&user_id, &id).await.map_err(api_err)?;
+    };
+    let _ = state
+        .service
+        .purge(&effective_user_id, &id)
+        .await
+        .map_err(api_err_typed)?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/memoria/crates/memoria-api/tests/api_db_verify.rs
+++ b/memoria/crates/memoria-api/tests/api_db_verify.rs
@@ -1,5 +1,7 @@
 /// Comprehensive API tests that verify DB state after every operation.
 /// Each test simulates real user workflows and checks all DB fields.
+mod support;
+
 use serde_json::{json, Value};
 use serial_test::serial;
 use sqlx::{MySqlPool, Row};
@@ -18,98 +20,58 @@ fn uid() -> String {
     format!("dbv_{}", uuid::Uuid::new_v4().simple())
 }
 
-async fn spawn_server() -> (String, reqwest::Client, MySqlPool) {
-    use memoria_git::GitForDataService;
-    use memoria_service::{Config, MemoryService};
-    use memoria_storage::SqlMemoryStore;
-    use std::sync::Arc;
-
-    let cfg = Config::from_env();
-    let db = db_url();
-    memoria_test_utils::wait_for_mysql_ready(&db, std::time::Duration::from_secs(30)).await;
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let pool = MySqlPool::connect(&db).await.expect("pool");
-    let git = Arc::new(GitForDataService::new(pool.clone(), &cfg.db_name));
-    let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    let state = memoria_api::AppState::new(service, git, String::new());
-    let app = memoria_api::build_router(state);
-
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind");
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move { axum::serve(listener, app).await });
-
-    let client = reqwest::Client::builder().no_proxy().build().unwrap();
-    let base = format!("http://127.0.0.1:{port}");
-    wait_for_server(&client, &base, &pool).await;
-    (base, client, pool)
+async fn spawn_server() -> (String, reqwest::Client, support::multi_db::ApiTestServer) {
+    let server = support::multi_db::spawn_api_server(
+        "api_db_verify",
+        test_dim(),
+        String::new(),
+        None,
+        None,
+        None,
+        false,
+    )
+    .await;
+    (server.base.clone(), server.client.clone(), server)
 }
 
-async fn spawn_server_with_master_key(master_key: &str) -> (String, reqwest::Client, MySqlPool) {
-    use memoria_git::GitForDataService;
-    use memoria_service::{Config, MemoryService};
-    use memoria_storage::SqlMemoryStore;
-    use std::sync::Arc;
-
-    let cfg = Config::from_env();
-    let db = db_url();
-    memoria_test_utils::wait_for_mysql_ready(&db, std::time::Duration::from_secs(30)).await;
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let pool = MySqlPool::connect(&db).await.expect("pool");
-    let git = Arc::new(GitForDataService::new(pool.clone(), &cfg.db_name));
-    let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    let state = memoria_api::AppState::new(service, git, master_key.to_string());
-    let app = memoria_api::build_router(state);
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-    let client = reqwest::Client::builder().no_proxy().build().unwrap();
-    let base = format!("http://127.0.0.1:{port}");
-    wait_for_server(&client, &base, &pool).await;
-    (base, client, pool)
-}
-
-async fn wait_for_server(client: &reqwest::Client, base: &str, pool: &MySqlPool) {
-    // Wait for axum to accept connections
-    for _ in 0..20 {
-        if client.get(format!("{base}/health")).send().await.is_ok() {
-            break;
-        }
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-    }
-    // Verify DB is reachable via the pool
-    for _ in 0..20 {
-        if sqlx::query("SELECT 1").execute(pool).await.is_ok() {
-            return;
-        }
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-    }
-    panic!("DB not ready after 1s");
+async fn spawn_server_with_master_key(
+    master_key: &str,
+) -> (String, reqwest::Client, support::multi_db::ApiTestServer) {
+    let server = support::multi_db::spawn_api_server(
+        "api_db_verify",
+        test_dim(),
+        master_key.to_string(),
+        None,
+        None,
+        None,
+        false,
+    )
+    .await;
+    (server.base.clone(), server.client.clone(), server)
 }
 
 /// Query a single memory row from DB by memory_id.
-async fn db_get_memory(pool: &MySqlPool, mid: &str) -> sqlx::mysql::MySqlRow {
+async fn db_get_memory(
+    server: &support::multi_db::ApiTestServer,
+    user_id: &str,
+    mid: &str,
+) -> sqlx::mysql::MySqlRow {
+    let pool = server.user_db_pool(user_id).await;
     sqlx::query("SELECT * FROM mem_memories WHERE memory_id = ?")
         .bind(mid)
-        .fetch_one(pool)
+        .fetch_one(&pool)
         .await
         .expect("db_get_memory")
 }
 
 /// Count active memories for a user.
-async fn db_count_active(pool: &MySqlPool, user_id: &str) -> i64 {
+async fn db_count_active(server: &support::multi_db::ApiTestServer, user_id: &str) -> i64 {
+    let pool = server.user_db_pool(user_id).await;
     sqlx::query_scalar::<_, i64>(
         "SELECT COUNT(*) FROM mem_memories WHERE user_id = ? AND is_active > 0",
     )
     .bind(user_id)
-    .fetch_one(pool)
+    .fetch_one(&pool)
     .await
     .unwrap()
 }
@@ -130,7 +92,7 @@ fn db_opt(row: &sqlx::mysql::MySqlRow, col: &str) -> Option<String> {
 #[tokio::test]
 #[serial]
 async fn test_store_verify_all_db_fields() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     // Store with all optional fields
@@ -162,7 +124,7 @@ async fn test_store_verify_all_db_fields() {
     assert!(body["observed_at"].as_str().is_some());
 
     // Verify DB row — every column
-    let row = db_get_memory(&pool, mid).await;
+    let row = db_get_memory(&server, &uid, mid).await;
     assert_eq!(row.get::<String, _>("memory_id"), mid);
     assert_eq!(row.get::<String, _>("user_id"), uid);
     assert_eq!(row.get::<String, _>("memory_type"), "profile");
@@ -199,7 +161,7 @@ async fn test_store_verify_all_db_fields() {
 #[tokio::test]
 #[serial]
 async fn test_store_defaults() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     // Store with minimal fields — check defaults
@@ -221,7 +183,7 @@ async fn test_store_defaults() {
     assert!(body["session_id"].is_null());
 
     // DB defaults
-    let row = db_get_memory(&pool, mid).await;
+    let row = db_get_memory(&server, &uid, mid).await;
     assert_eq!(row.get::<String, _>("memory_type"), "semantic");
     assert_eq!(
         row.get::<Option<String>, _>("trust_tier").as_deref(),
@@ -246,7 +208,7 @@ async fn test_store_defaults() {
 #[tokio::test]
 #[serial]
 async fn test_correct_by_id_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     // Store original
@@ -278,7 +240,7 @@ async fn test_correct_by_id_verify_db() {
     assert_eq!(body["memory_type"], "profile");
 
     // Verify OLD row in DB: deactivated, superseded_by points to new
-    let old_row = db_get_memory(&pool, &old_mid).await;
+    let old_row = db_get_memory(&server, &uid, &old_mid).await;
     assert_eq!(
         old_row.get::<i8, _>("is_active"),
         0,
@@ -296,7 +258,7 @@ async fn test_correct_by_id_verify_db() {
     );
 
     // Verify NEW row in DB: active, correct content, same type
-    let new_row = db_get_memory(&pool, new_mid).await;
+    let new_row = db_get_memory(&server, &uid, new_mid).await;
     assert_eq!(new_row.get::<i8, _>("is_active"), 1);
     assert_eq!(
         new_row.get::<String, _>("content"),
@@ -307,7 +269,7 @@ async fn test_correct_by_id_verify_db() {
     assert_eq!(db_opt(&new_row, "superseded_by"), None);
 
     // Active count should be 1 (old deactivated, new active)
-    assert_eq!(db_count_active(&pool, &uid).await, 1);
+    assert_eq!(db_count_active(&server, &uid).await, 1);
 
     println!("✅ correct: old deactivated, superseded_by={new_mid}, new row active");
 }
@@ -315,8 +277,9 @@ async fn test_correct_by_id_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_correct_by_query_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
 
     client
         .post(format!("{base}/v1/memories"))
@@ -343,7 +306,7 @@ async fn test_correct_by_query_verify_db() {
     assert_eq!(body["content"], "Project uses MatrixOne database");
 
     // DB: only 1 active memory, content is the corrected one
-    assert_eq!(db_count_active(&pool, &uid).await, 1);
+    assert_eq!(db_count_active(&server, &uid).await, 1);
     let rows = sqlx::query("SELECT content FROM mem_memories WHERE user_id = ? AND is_active > 0")
         .bind(&uid)
         .fetch_all(&pool)
@@ -364,7 +327,7 @@ async fn test_correct_by_query_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_delete_single_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -381,7 +344,7 @@ async fn test_delete_single_verify_db() {
 
     // Before delete: active
     assert_eq!(
-        db_get_memory(&pool, &mid).await.get::<i8, _>("is_active"),
+        db_get_memory(&server, &uid, &mid).await.get::<i8, _>("is_active"),
         1
     );
 
@@ -395,14 +358,14 @@ async fn test_delete_single_verify_db() {
     assert_eq!(r.status(), 204);
 
     // After delete: soft-deleted (is_active=0), row still exists
-    let row = db_get_memory(&pool, &mid).await;
+    let row = db_get_memory(&server, &uid, &mid).await;
     assert_eq!(row.get::<i8, _>("is_active"), 0, "should be soft-deleted");
     assert_eq!(
         row.get::<String, _>("content"),
         "to be deleted",
         "content preserved"
     );
-    assert_eq!(db_count_active(&pool, &uid).await, 0);
+    assert_eq!(db_count_active(&server, &uid).await, 0);
 
     println!("✅ delete: is_active=0, row preserved");
 }
@@ -410,7 +373,7 @@ async fn test_delete_single_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_purge_bulk_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     let mut ids = Vec::new();
@@ -429,7 +392,7 @@ async fn test_purge_bulk_verify_db() {
                 .to_string(),
         );
     }
-    assert_eq!(db_count_active(&pool, &uid).await, 4);
+    assert_eq!(db_count_active(&server, &uid).await, 4);
 
     // Purge first 3
     let r = client
@@ -445,15 +408,18 @@ async fn test_purge_bulk_verify_db() {
 
     // DB: 3 deactivated, 1 still active
     for mid in &ids[..3] {
-        assert_eq!(db_get_memory(&pool, mid).await.get::<i8, _>("is_active"), 0);
+        assert_eq!(
+            db_get_memory(&server, &uid, mid).await.get::<i8, _>("is_active"),
+            0
+        );
     }
     assert_eq!(
-        db_get_memory(&pool, &ids[3])
+        db_get_memory(&server, &uid, &ids[3])
             .await
             .get::<i8, _>("is_active"),
         1
     );
-    assert_eq!(db_count_active(&pool, &uid).await, 1);
+    assert_eq!(db_count_active(&server, &uid).await, 1);
 
     println!("✅ purge bulk: 3 deactivated, 1 remains active");
 }
@@ -461,8 +427,9 @@ async fn test_purge_bulk_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_purge_by_topic_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
 
     // Store memories with a common keyword
     for content in ["topic_xyz alpha", "topic_xyz beta", "unrelated gamma"] {
@@ -474,7 +441,7 @@ async fn test_purge_by_topic_verify_db() {
             .await
             .unwrap();
     }
-    assert_eq!(db_count_active(&pool, &uid).await, 3);
+    assert_eq!(db_count_active(&server, &uid).await, 3);
 
     // Purge by topic
     let r = client
@@ -489,7 +456,7 @@ async fn test_purge_by_topic_verify_db() {
     assert_eq!(body["purged"], 2);
 
     // DB: 2 deactivated, "unrelated gamma" still active
-    assert_eq!(db_count_active(&pool, &uid).await, 1);
+    assert_eq!(db_count_active(&server, &uid).await, 1);
     let rows = sqlx::query("SELECT content FROM mem_memories WHERE user_id = ? AND is_active > 0")
         .bind(&uid)
         .fetch_all(&pool)
@@ -503,7 +470,7 @@ async fn test_purge_by_topic_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_purge_by_topic_special_chars_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     // Content with special chars that fulltext can't match — triggers LIKE fallback
@@ -520,7 +487,7 @@ async fn test_purge_by_topic_special_chars_verify_db() {
             .await
             .unwrap();
     }
-    assert_eq!(db_count_active(&pool, &uid).await, 3);
+    assert_eq!(db_count_active(&server, &uid).await, 3);
 
     // Purge with special char topic — sanitize strips [#, fulltext may miss,
     // LIKE fallback should find them
@@ -535,14 +502,14 @@ async fn test_purge_by_topic_special_chars_verify_db() {
     let body: Value = r.json().await.unwrap();
     assert_eq!(body["purged"], 1, "should purge the [#100] memory");
 
-    assert_eq!(db_count_active(&pool, &uid).await, 2);
+    assert_eq!(db_count_active(&server, &uid).await, 2);
     println!("✅ purge by topic with special chars: LIKE fallback works");
 }
 
 #[tokio::test]
 #[serial]
 async fn test_purge_by_topic_batch_perf_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     // Store 10 memories with same topic — verifies batch soft_delete
@@ -555,7 +522,7 @@ async fn test_purge_by_topic_batch_perf_verify_db() {
             .await
             .unwrap();
     }
-    assert_eq!(db_count_active(&pool, &uid).await, 10);
+    assert_eq!(db_count_active(&server, &uid).await, 10);
 
     let r = client
         .post(format!("{base}/v1/memories/purge"))
@@ -568,15 +535,16 @@ async fn test_purge_by_topic_batch_perf_verify_db() {
     let body: Value = r.json().await.unwrap();
     assert_eq!(body["purged"], 10, "should batch-purge all 10");
 
-    assert_eq!(db_count_active(&pool, &uid).await, 0);
+    assert_eq!(db_count_active(&server, &uid).await, 0);
     println!("✅ purge by topic batch: 10 memories purged in one call");
 }
 
 #[tokio::test]
 #[serial]
 async fn test_purge_by_session_id_with_memory_types_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
     let target_session = format!("session:test-smp-{}", uuid::Uuid::new_v4().simple());
     let other_session = format!("session:test-smp-{}", uuid::Uuid::new_v4().simple());
 
@@ -598,7 +566,7 @@ async fn test_purge_by_session_id_with_memory_types_verify_db() {
             .await
             .unwrap();
     }
-    assert_eq!(db_count_active(&pool, &uid).await, 4);
+    assert_eq!(db_count_active(&server, &uid).await, 4);
 
     let r = client
         .post(format!("{base}/v1/memories/purge"))
@@ -653,7 +621,7 @@ async fn test_purge_by_session_id_with_memory_types_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_batch_store_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     let r = client.post(format!("{base}/v1/memories/batch"))
@@ -670,18 +638,18 @@ async fn test_batch_store_verify_db() {
 
     // Verify each row in DB
     let mid_a = body[0]["memory_id"].as_str().unwrap();
-    let row_a = db_get_memory(&pool, mid_a).await;
+    let row_a = db_get_memory(&server, &uid, mid_a).await;
     assert_eq!(row_a.get::<String, _>("content"), "batch A");
     assert_eq!(row_a.get::<String, _>("memory_type"), "semantic");
     // store_batch may or may not pass session_id through — check what DB has
     assert_eq!(row_a.get::<i8, _>("is_active"), 1);
 
     let mid_b = body[1]["memory_id"].as_str().unwrap();
-    let row_b = db_get_memory(&pool, mid_b).await;
+    let row_b = db_get_memory(&server, &uid, mid_b).await;
     assert_eq!(row_b.get::<String, _>("memory_type"), "profile");
 
     let mid_c = body[2]["memory_id"].as_str().unwrap();
-    let row_c = db_get_memory(&pool, mid_c).await;
+    let row_c = db_get_memory(&server, &uid, mid_c).await;
     assert_eq!(row_c.get::<String, _>("memory_type"), "procedural");
     assert_eq!(
         row_c.get::<Option<String>, _>("trust_tier").as_deref(),
@@ -694,7 +662,7 @@ async fn test_batch_store_verify_db() {
         "confidence should be in (0,1], got {conf}"
     );
 
-    assert_eq!(db_count_active(&pool, &uid).await, 3);
+    assert_eq!(db_count_active(&server, &uid).await, 3);
 
     println!("✅ batch store: 3 rows verified in DB with correct types/tiers/sessions");
 }
@@ -706,7 +674,7 @@ async fn test_batch_store_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_list_matches_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     // Store 3, delete 1
@@ -756,7 +724,7 @@ async fn test_list_matches_db() {
     assert!(listed_ids.contains(&ids[2].as_str()));
 
     // Cross-check with DB
-    assert_eq!(db_count_active(&pool, &uid).await, 2);
+    assert_eq!(db_count_active(&server, &uid).await, 2);
 
     println!("✅ list: returns only active memories, matches DB count");
 }
@@ -764,7 +732,7 @@ async fn test_list_matches_db() {
 #[tokio::test]
 #[serial]
 async fn test_get_single_memory_all_fields() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -796,7 +764,7 @@ async fn test_get_single_memory_all_fields() {
     let body: Value = r.json().await.unwrap();
 
     // Verify every response field matches DB
-    let row = db_get_memory(&pool, &mid).await;
+    let row = db_get_memory(&server, &uid, &mid).await;
     assert_eq!(body["memory_id"], mid);
     assert_eq!(body["user_id"], uid);
     assert_eq!(body["content"], row.get::<String, _>("content"));
@@ -818,7 +786,7 @@ async fn test_get_single_memory_all_fields() {
 #[tokio::test]
 #[serial]
 async fn test_search_returns_correct_fields() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     client
@@ -843,7 +811,7 @@ async fn test_search_returns_correct_fields() {
 
     // Verify against DB
     let mid = m["memory_id"].as_str().unwrap();
-    let row = db_get_memory(&pool, mid).await;
+    let row = db_get_memory(&server, &uid, mid).await;
     assert_eq!(m["content"], row.get::<String, _>("content"));
     assert_eq!(m["memory_type"], row.get::<String, _>("memory_type"));
     assert_eq!(m["user_id"], row.get::<String, _>("user_id"));
@@ -859,9 +827,10 @@ async fn test_search_returns_correct_fields() {
 #[serial]
 async fn test_api_key_lifecycle_verify_db() {
     let mk = "test-mk-db-verify";
-    let (base, client, pool) = spawn_server_with_master_key(mk).await;
+    let (base, client, server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let uid = uid();
+    let pool = server.shared_pool();
 
     // 1. Create key
     let r = client
@@ -964,7 +933,7 @@ async fn test_api_key_lifecycle_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_admin_stats_match_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     // Store 3 memories
@@ -1006,7 +975,7 @@ async fn test_admin_stats_match_db() {
     assert_eq!(body["memory_count"].as_i64().unwrap(), 3);
 
     // Cross-check with DB
-    assert_eq!(db_count_active(&pool, &uid).await, 3);
+    assert_eq!(db_count_active(&server, &uid).await, 3);
 
     println!("✅ admin stats: user has 3 memories, totals consistent");
 }
@@ -1014,8 +983,9 @@ async fn test_admin_stats_match_db() {
 #[tokio::test]
 #[serial]
 async fn test_admin_delete_user_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
 
     // Store memories
     for i in 0..3 {
@@ -1027,7 +997,7 @@ async fn test_admin_delete_user_verify_db() {
             .await
             .unwrap();
     }
-    assert_eq!(db_count_active(&pool, &uid).await, 3);
+    assert_eq!(db_count_active(&server, &uid).await, 3);
 
     // DELETE /admin/users/:id
     let r = client
@@ -1038,7 +1008,7 @@ async fn test_admin_delete_user_verify_db() {
     assert_eq!(r.status(), 200);
 
     // DB: all memories deactivated
-    assert_eq!(db_count_active(&pool, &uid).await, 0);
+    assert_eq!(db_count_active(&server, &uid).await, 0);
 
     // DB: rows still exist (soft delete)
     let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mem_memories WHERE user_id = ?")
@@ -1064,9 +1034,10 @@ async fn test_admin_delete_user_verify_db() {
 #[serial]
 async fn test_admin_list_revoke_user_keys_verify_db() {
     let mk = "test-mk-admin-keys-db";
-    let (base, client, pool) = spawn_server_with_master_key(mk).await;
+    let (base, client, server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let uid = uid();
+    let pool = server.shared_pool();
 
     // Create 2 keys
     for i in 0..2 {
@@ -1128,8 +1099,9 @@ async fn test_admin_list_revoke_user_keys_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_governance_quarantine_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
 
     // Store a low-confidence memory (should be quarantined)
     let r = client
@@ -1184,7 +1156,7 @@ async fn test_governance_quarantine_verify_db() {
 
     // Normal memory should still be active
     assert!(
-        db_count_active(&pool, &uid).await >= 1,
+        db_count_active(&server, &uid).await >= 1,
         "normal memory should survive"
     );
 }
@@ -1192,8 +1164,9 @@ async fn test_governance_quarantine_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_governance_cooldown_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
 
     client
         .post(format!("{base}/v1/memories"))
@@ -1246,8 +1219,9 @@ async fn test_governance_cooldown_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_governance_orphan_graph_cleanup_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
 
     // 1. Store a memory so we have a valid memory_id
     let r = client
@@ -1382,9 +1356,11 @@ async fn test_governance_orphan_graph_cleanup_verify_db() {
 #[serial]
 async fn test_admin_governance_orphan_graph_cleanup_verify_db() {
     let mk = "test-master-key-orphan-admin";
-    let (base, client, pool) = spawn_server_with_master_key(mk).await;
+    let (base, client, server) = spawn_server_with_master_key(mk).await;
     let uid = uid();
     let auth = format!("Bearer {mk}");
+    let _sql = server.user_store(&uid).await;
+    let pool = server.user_db_pool(&uid).await;
 
     // 1. Insert fake inactive memory + orphan rows
     let fake_mid = format!("{:032x}", uuid::Uuid::new_v4().as_u128());
@@ -1503,8 +1479,9 @@ async fn test_admin_governance_orphan_graph_cleanup_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_observe_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
 
     let r = client
         .post(format!("{base}/v1/observe"))
@@ -1552,7 +1529,7 @@ async fn test_observe_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_history_chain_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
 
     // Store v1
@@ -1595,27 +1572,27 @@ async fn test_history_chain_verify_db() {
         .to_string();
 
     // DB: verify superseded_by chain v1→v2→v3
-    let row_v1 = db_get_memory(&pool, &mid_v1).await;
+    let row_v1 = db_get_memory(&server, &uid, &mid_v1).await;
     assert_eq!(row_v1.get::<i8, _>("is_active"), 0);
     assert_eq!(
         db_opt(&row_v1, "superseded_by").as_deref(),
         Some(mid_v2.as_str())
     );
 
-    let row_v2 = db_get_memory(&pool, &mid_v2).await;
+    let row_v2 = db_get_memory(&server, &uid, &mid_v2).await;
     assert_eq!(row_v2.get::<i8, _>("is_active"), 0);
     assert_eq!(
         db_opt(&row_v2, "superseded_by").as_deref(),
         Some(mid_v3.as_str())
     );
 
-    let row_v3 = db_get_memory(&pool, &mid_v3).await;
+    let row_v3 = db_get_memory(&server, &uid, &mid_v3).await;
     assert_eq!(row_v3.get::<i8, _>("is_active"), 1);
     assert_eq!(db_opt(&row_v3, "superseded_by"), None);
     assert_eq!(row_v3.get::<String, _>("content"), "version 3");
 
     // Only 1 active
-    assert_eq!(db_count_active(&pool, &uid).await, 1);
+    assert_eq!(db_count_active(&server, &uid).await, 1);
 
     // GET history for v1 — should show the chain
     let r = client
@@ -1638,8 +1615,9 @@ async fn test_history_chain_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_branch_lifecycle_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
 
     // Store on main
     client
@@ -1756,8 +1734,9 @@ async fn test_branch_lifecycle_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_pipeline_sensitivity_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
 
     let r = client
         .post(format!("{base}/v1/pipeline/run"))
@@ -1778,7 +1757,7 @@ async fn test_pipeline_sensitivity_verify_db() {
     assert_eq!(body["memories_rejected"].as_i64().unwrap(), 1);
 
     // DB: only 2 safe memories stored
-    assert_eq!(db_count_active(&pool, &uid).await, 2);
+    assert_eq!(db_count_active(&server, &uid).await, 2);
 
     // DB: no memory contains the sensitive content
     let contents: Vec<String> =
@@ -1808,8 +1787,9 @@ async fn test_pipeline_sensitivity_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_entity_link_verify_db() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
 
     // Store a memory
     let r = client
@@ -1902,9 +1882,10 @@ async fn test_entity_link_verify_db() {
 #[serial]
 async fn test_auth_master_key_verify_db() {
     let mk = "test-mk-auth-flow";
-    let (base, client, pool) = spawn_server_with_master_key(mk).await;
+    let (base, client, server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let uid = uid();
+    let pool = server.shared_pool();
 
     // Master key → can store
     let r = client
@@ -1922,7 +1903,7 @@ async fn test_auth_master_key_verify_db() {
         .to_string();
 
     // DB: memory stored under correct user
-    let row = db_get_memory(&pool, &mid).await;
+    let row = db_get_memory(&server, &uid, &mid).await;
     assert_eq!(row.get::<String, _>("user_id"), uid);
 
     // Wrong key → 401
@@ -1976,8 +1957,9 @@ async fn test_auth_master_key_verify_db() {
 #[tokio::test]
 #[serial]
 async fn test_full_user_workflow() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
 
     // ── Session 1: User sets up preferences ──
     let r = client.post(format!("{base}/v1/memories"))
@@ -2000,7 +1982,7 @@ async fn test_full_user_workflow() {
         .json(&json!({"content": "Deploy with: make deploy", "memory_type": "procedural", "session_id": "s1"}))
         .send().await.unwrap();
 
-    assert_eq!(db_count_active(&pool, &uid).await, 3);
+    assert_eq!(db_count_active(&server, &uid).await, 3);
 
     // ── Session 2: User retrieves and corrects ──
     // Retrieve
@@ -2026,22 +2008,22 @@ async fn test_full_user_workflow() {
 
     // DB: old deactivated, new active, chain correct
     assert_eq!(
-        db_get_memory(&pool, &pref_mid)
+        db_get_memory(&server, &uid, &pref_mid)
             .await
             .get::<i8, _>("is_active"),
         0
     );
     assert_eq!(
-        db_opt(&db_get_memory(&pool, &pref_mid).await, "superseded_by").as_deref(),
+        db_opt(&db_get_memory(&server, &uid, &pref_mid).await, "superseded_by").as_deref(),
         Some(new_pref_mid.as_str())
     );
     assert_eq!(
-        db_get_memory(&pool, &new_pref_mid)
+        db_get_memory(&server, &uid, &new_pref_mid)
             .await
             .get::<i8, _>("is_active"),
         1
     );
-    assert_eq!(db_count_active(&pool, &uid).await, 3); // 3 active (1 replaced)
+    assert_eq!(db_count_active(&server, &uid).await, 3); // 3 active (1 replaced)
 
     // ── Session 3: Snapshot before risky change ──
     let snap = format!(
@@ -2065,11 +2047,11 @@ async fn test_full_user_workflow() {
         .as_str()
         .unwrap()
         .to_string();
-    assert_eq!(db_count_active(&pool, &uid).await, 4);
+    assert_eq!(db_count_active(&server, &uid).await, 4);
 
     // DB: working memory has correct type
     assert_eq!(
-        db_get_memory(&pool, &working_mid)
+        db_get_memory(&server, &uid, &working_mid)
             .await
             .get::<String, _>("memory_type"),
         "working"
@@ -2146,14 +2128,14 @@ async fn test_full_user_workflow() {
 
     // DB: working memory deactivated
     assert_eq!(
-        db_get_memory(&pool, &working_mid)
+        db_get_memory(&server, &uid, &working_mid)
             .await
             .get::<i8, _>("is_active"),
         0
     );
 
     // ── Final state check ──
-    let active = db_count_active(&pool, &uid).await;
+    let active = db_count_active(&server, &uid).await;
     assert!(
         active >= 4,
         "should have at least 4 active memories, got {active}"
@@ -2288,8 +2270,9 @@ async fn graph_node_active(pool: &MySqlPool, mid: &str) -> bool {
 #[tokio::test]
 #[serial]
 async fn test_delete_cleans_graph_and_entity_links() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
     let mid = store_with_entity_links(&base, &client, &pool, &uid, "REST delete graph test").await;
 
     // Verify graph node + entity links exist
@@ -2334,8 +2317,9 @@ async fn test_delete_cleans_graph_and_entity_links() {
 #[tokio::test]
 #[serial]
 async fn test_purge_bulk_cleans_graph_and_entity_links() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
     let mid1 =
         store_with_entity_links(&base, &client, &pool, &uid, "REST bulk purge graph A").await;
     let mid2 =
@@ -2377,8 +2361,9 @@ async fn test_purge_bulk_cleans_graph_and_entity_links() {
 #[tokio::test]
 #[serial]
 async fn test_purge_topic_cleans_graph_and_entity_links() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
     let mid = store_with_entity_links(
         &base,
         &client,
@@ -2418,8 +2403,9 @@ async fn test_purge_topic_cleans_graph_and_entity_links() {
 #[tokio::test]
 #[serial]
 async fn test_correct_by_id_cleans_graph_and_entity_links() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
     let old_mid = store_with_entity_links(
         &base,
         &client,
@@ -2465,8 +2451,9 @@ async fn test_correct_by_id_cleans_graph_and_entity_links() {
 #[tokio::test]
 #[serial]
 async fn test_correct_by_query_cleans_graph_and_entity_links() {
-    let (base, client, pool) = spawn_server().await;
+    let (base, client, server) = spawn_server().await;
     let uid = uid();
+    let pool = server.user_db_pool(&uid).await;
     let old_mid = store_with_entity_links(
         &base,
         &client,

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -1321,6 +1321,85 @@ async fn test_master_key_can_impersonate_and_access_any_user() {
     assert_eq!(r.status(), 403, "API key must not access admin routes");
 }
 
+#[tokio::test]
+async fn test_non_master_cannot_probe_other_users_memory_ids() {
+    let mk = "test-master-key-tenant-isolation";
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
+    let auth = format!("Bearer {mk}");
+    let owner = uid();
+    let intruder = uid();
+    let owner_key = create_api_key_for_user(&client, &base, &auth, &owner, "owner-key").await;
+    let intruder_key =
+        create_api_key_for_user(&client, &base, &auth, &intruder, "intruder-key").await;
+
+    let r = client
+        .post(format!("{base}/v1/memories"))
+        .header("Authorization", format!("Bearer {owner_key}"))
+        .json(&json!({ "content": "owner private memory", "memory_type": "semantic" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 201);
+    let memory_id = r.json::<Value>().await.unwrap()["memory_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let r = client
+        .get(format!("{base}/v1/memories/{memory_id}"))
+        .header("Authorization", format!("Bearer {intruder_key}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        200,
+        "foreign GET must match missing-memory response"
+    );
+    assert!(r.json::<Value>().await.unwrap().is_null());
+
+    let r = client
+        .put(format!("{base}/v1/memories/{memory_id}/correct"))
+        .header("Authorization", format!("Bearer {intruder_key}"))
+        .json(&json!({ "new_content": "intruder overwrite" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        404,
+        "foreign correct must look like missing memory"
+    );
+
+    let r = client
+        .delete(format!("{base}/v1/memories/{memory_id}"))
+        .header("Authorization", format!("Bearer {intruder_key}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        404,
+        "foreign delete must look like missing memory"
+    );
+
+    let r = client
+        .get(format!("{base}/v1/memories/{memory_id}"))
+        .header("Authorization", format!("Bearer {owner_key}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        200,
+        "failed probes must not mutate owner memory"
+    );
+    assert_eq!(
+        r.json::<Value>().await.unwrap()["content"],
+        "owner private memory"
+    );
+}
+
 // ── 10b-7. revoked API key returns 401 ───────────────────────────────────────
 
 #[tokio::test]
@@ -3622,7 +3701,7 @@ async fn test_admin_set_user_params() {
     let pool = server.shared_pool();
     let config_table = server.shared_table("mem_user_memory_config");
     let _ = sqlx::query(&format!(
-            "CREATE TABLE IF NOT EXISTS {config_table} (\
+        "CREATE TABLE IF NOT EXISTS {config_table} (\
              user_id VARCHAR(128) PRIMARY KEY, \
              strategy_key VARCHAR(64) DEFAULT NULL, \
              params_json JSON DEFAULT NULL, \
@@ -3630,10 +3709,12 @@ async fn test_admin_set_user_params() {
     ))
     .execute(&pool)
     .await;
-    let _ = sqlx::query(&format!("INSERT IGNORE INTO {config_table} (user_id) VALUES (?)"))
-        .bind(&uid)
-        .execute(&pool)
-        .await;
+    let _ = sqlx::query(&format!(
+        "INSERT IGNORE INTO {config_table} (user_id) VALUES (?)"
+    ))
+    .bind(&uid)
+    .execute(&pool)
+    .await;
 
     // Set params
     let params = json!({"vector_weight": 0.7, "keyword_weight": 0.3, "max_results": 20});
@@ -5042,9 +5123,14 @@ async fn test_distributed_lock_acquire_release() {
     use memoria_service::DistributedLock;
     use std::time::Duration;
 
-    let ctx =
-        memoria_test_utils::MultiDbTestContext::new(&db_url(), "api_e2e_lock", test_dim(), None, None)
-            .await;
+    let ctx = memoria_test_utils::MultiDbTestContext::new(
+        &db_url(),
+        "api_e2e_lock",
+        test_dim(),
+        None,
+        None,
+    )
+    .await;
     let store = ctx.shared_store();
 
     let lock_key = format!("test_lock_{}", uuid::Uuid::new_v4().simple());
@@ -6090,15 +6176,14 @@ async fn test_last_used_batcher_coalesces_and_flushes() {
 
     // Verify last_used_at was updated for all 3 keys
     for hash in &hashes {
-        let row: Option<(Option<chrono::NaiveDateTime>,)> =
-            sqlx::query_as(&format!(
-                "SELECT last_used_at FROM {} WHERE key_hash = ?",
-                store.t("mem_api_keys")
-            ))
-                .bind(hash)
-                .fetch_optional(store.pool())
-                .await
-                .expect("query");
+        let row: Option<(Option<chrono::NaiveDateTime>,)> = sqlx::query_as(&format!(
+            "SELECT last_used_at FROM {} WHERE key_hash = ?",
+            store.t("mem_api_keys")
+        ))
+        .bind(hash)
+        .fetch_optional(store.pool())
+        .await
+        .expect("query");
         let (last_used,) = row.expect("key should exist");
         assert!(
             last_used.is_some(),
@@ -6176,15 +6261,14 @@ async fn test_api_key_auth_uses_batcher_not_fire_and_forget() {
         "{:x}",
         <sha2::Sha256 as sha2::Digest>::digest(raw_key.as_bytes())
     );
-    let row: Option<(Option<chrono::NaiveDateTime>,)> =
-        sqlx::query_as(&format!(
-            "SELECT last_used_at FROM {} WHERE key_hash = ?",
-            verify_store.t("mem_api_keys")
-        ))
-            .bind(&key_hash)
-            .fetch_optional(verify_store.pool())
-            .await
-            .expect("query");
+    let row: Option<(Option<chrono::NaiveDateTime>,)> = sqlx::query_as(&format!(
+        "SELECT last_used_at FROM {} WHERE key_hash = ?",
+        verify_store.t("mem_api_keys")
+    ))
+    .bind(&key_hash)
+    .fetch_optional(verify_store.pool())
+    .await
+    .expect("query");
     let (last_used,) = row.expect("key should exist");
     assert!(
         last_used.is_some(),
@@ -6422,10 +6506,10 @@ async fn test_remote_purge_cleans_graph_and_entity_links() {
         "SELECT COUNT(*) FROM {} WHERE memory_id = ?",
         user_store.t("mem_entity_links")
     ))
-        .bind(&mid)
-        .fetch_one(user_store.pool())
-        .await
-        .unwrap();
+    .bind(&mid)
+    .fetch_one(user_store.pool())
+    .await
+    .unwrap();
     assert_eq!(
         cnt, 0,
         "mem_entity_links should be cleaned after remote purge"
@@ -6502,10 +6586,10 @@ async fn test_remote_purge_topic_cleans_graph_and_entity_links() {
         "SELECT COUNT(*) FROM {} WHERE memory_id = ?",
         user_store.t("mem_entity_links")
     ))
-        .bind(&mid)
-        .fetch_one(user_store.pool())
-        .await
-        .unwrap();
+    .bind(&mid)
+    .fetch_one(user_store.pool())
+    .await
+    .unwrap();
     assert_eq!(cnt, 0, "entity links should be cleaned after topic purge");
 
     println!("✅ remote purge topic: graph + entity links cleaned");
@@ -6522,9 +6606,13 @@ async fn test_remote_correct_cleans_graph_and_entity_links() {
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
     let user_store = server.user_store(&uid).await;
 
-    let old_mid =
-        remote_store_with_links(&remote, &user_store, &uid, "Remote correct graph old content")
-            .await;
+    let old_mid = remote_store_with_links(
+        &remote,
+        &user_store,
+        &uid,
+        "Remote correct graph old content",
+    )
+    .await;
 
     // Correct
     let r = remote
@@ -6552,10 +6640,10 @@ async fn test_remote_correct_cleans_graph_and_entity_links() {
         "SELECT COUNT(*) FROM {} WHERE memory_id = ?",
         user_store.t("mem_entity_links")
     ))
-        .bind(&old_mid)
-        .fetch_one(user_store.pool())
-        .await
-        .unwrap();
+    .bind(&old_mid)
+    .fetch_one(user_store.pool())
+    .await
+    .unwrap();
     assert_eq!(
         cnt, 0,
         "old entity links should be cleaned after remote correct"
@@ -6606,15 +6694,14 @@ async fn test_remote_correct_by_query_cleans_graph_and_entity_links() {
             cnt, 0,
             "old graph node should be deactivated after remote correct by query"
         );
-        let cnt: i64 =
-            sqlx::query_scalar(&format!(
-                "SELECT COUNT(*) FROM {} WHERE memory_id = ?",
-                user_store.t("mem_entity_links")
-            ))
-                .bind(&old_mid)
-                .fetch_one(user_store.pool())
-                .await
-                .unwrap();
+        let cnt: i64 = sqlx::query_scalar(&format!(
+            "SELECT COUNT(*) FROM {} WHERE memory_id = ?",
+            user_store.t("mem_entity_links")
+        ))
+        .bind(&old_mid)
+        .fetch_one(user_store.pool())
+        .await
+        .unwrap();
         assert_eq!(
             cnt, 0,
             "old entity links should be cleaned after remote correct by query"

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -3,6 +3,8 @@ use serde_json::{json, Value};
 /// Requires DATABASE_URL env var.
 use std::sync::Arc;
 
+mod support;
+
 fn test_dim() -> usize {
     std::env::var("EMBEDDING_DIM")
         .ok()
@@ -106,50 +108,25 @@ fn try_embedding() -> Option<(String, String, String)> {
 }
 
 /// Spawn the API server on a random port, return (base_url, client).
-async fn spawn_server() -> (String, reqwest::Client) {
-    use memoria_git::GitForDataService;
-    use memoria_service::{Config, MemoryService};
-    use memoria_storage::SqlMemoryStore;
-    use sqlx::mysql::MySqlPool;
-
-    let cfg = Config::from_env();
-    let db = db_url();
-
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let pool = MySqlPool::connect(&db).await.expect("pool");
-    let git = Arc::new(GitForDataService::new(pool, &cfg.db_name));
-    let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    let state = memoria_api::AppState::new(service, git, String::new());
-
-    let app = memoria_api::build_router(state);
-
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind");
-    let port = listener.local_addr().unwrap().port();
-    let handle = tokio::spawn(async move { axum::serve(listener, app).await });
-
-    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-    if handle.is_finished() {
-        panic!("Server task finished unexpectedly");
-    }
-
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .expect("client");
-    let base = format!("http://127.0.0.1:{port}");
-    (base, client)
+async fn spawn_server() -> (String, reqwest::Client, support::multi_db::ApiTestServer) {
+    let server = support::multi_db::spawn_api_server(
+        "api_e2e",
+        test_dim(),
+        String::new(),
+        None,
+        None,
+        None,
+        false,
+    )
+    .await;
+    (server.base.clone(), server.client.clone(), server)
 }
 
 // ── 1. health ─────────────────────────────────────────────────────────────────
 
 #[tokio::test]
 async fn test_api_health() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let r = client
         .get(format!("{base}/health"))
         .send()
@@ -164,7 +141,7 @@ async fn test_api_health() {
 
 #[tokio::test]
 async fn test_api_store_and_list() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -210,7 +187,7 @@ async fn test_api_store_and_list() {
 
 #[tokio::test]
 async fn test_api_list_no_embedding_and_limit() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store 3 memories: 2 semantic + 1 profile, with small delays for distinct created_at
@@ -336,7 +313,7 @@ async fn test_api_list_no_embedding_and_limit() {
 
 #[tokio::test]
 async fn test_api_list_cursor_with_type_filter() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store 3 semantic + 1 profile
@@ -395,7 +372,7 @@ async fn test_api_list_cursor_with_type_filter() {
 
 #[tokio::test]
 async fn test_api_list_excludes_deleted() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store 2 memories
@@ -443,7 +420,7 @@ async fn test_api_list_excludes_deleted() {
 
 #[tokio::test]
 async fn test_api_list_empty() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid(); // fresh user, no memories
 
     let body: Value = client
@@ -464,7 +441,7 @@ async fn test_api_list_empty() {
 
 #[tokio::test]
 async fn test_api_list_limit_cap() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store 2 memories, request limit=9999 — should still work (capped internally)
@@ -498,7 +475,7 @@ async fn test_api_list_limit_cap() {
 
 #[tokio::test]
 async fn test_api_list_invalid_cursor() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store 1 memory so user exists
@@ -544,7 +521,7 @@ async fn test_api_list_invalid_cursor() {
 
 #[tokio::test]
 async fn test_api_list_user_isolation() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid_a = uid();
     let uid_b = uid();
 
@@ -602,7 +579,7 @@ async fn test_api_list_user_isolation() {
 
 #[tokio::test]
 async fn test_api_list_default_limit() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store 3 memories, don't pass limit param
@@ -640,7 +617,7 @@ async fn test_api_list_default_limit() {
 
 #[tokio::test]
 async fn test_api_list_has_more_at_limit_boundary() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store 2 memories
@@ -700,7 +677,7 @@ async fn test_api_list_has_more_at_limit_boundary() {
 
 #[tokio::test]
 async fn test_api_batch_store() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -723,7 +700,7 @@ async fn test_api_batch_store() {
 
 #[tokio::test]
 async fn test_api_retrieve() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     client
@@ -754,7 +731,7 @@ async fn test_api_retrieve() {
 
 #[tokio::test]
 async fn test_api_correct() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -786,7 +763,7 @@ async fn test_api_correct() {
 
 #[tokio::test]
 async fn test_api_delete() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -815,7 +792,7 @@ async fn test_api_delete() {
 
 #[tokio::test]
 async fn test_api_purge_bulk() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let mut ids = Vec::new();
@@ -852,7 +829,7 @@ async fn test_api_purge_bulk() {
 
 #[tokio::test]
 async fn test_api_profile() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     client
@@ -879,7 +856,7 @@ async fn test_api_profile() {
 
 #[tokio::test]
 async fn test_api_governance() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -897,32 +874,20 @@ async fn test_api_governance() {
 
 // ── Helper: spawn server with master key ─────────────────────────────────────
 
-async fn spawn_server_with_master_key(master_key: &str) -> (String, reqwest::Client) {
-    use memoria_git::GitForDataService;
-    use memoria_service::{Config, MemoryService};
-    use memoria_storage::SqlMemoryStore;
-    use sqlx::mysql::MySqlPool;
-
-    let cfg = Config::from_env();
-    let db = db_url();
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let pool = MySqlPool::connect(&db).await.expect("pool");
-    let git = Arc::new(GitForDataService::new(pool, &cfg.db_name));
-    let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    let state = memoria_api::AppState::new(service, git, master_key.to_string())
-        .init_auth_pool(&db, false)
-        .await
-        .expect("init auth pool");
-    let app = memoria_api::build_router(state);
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-    let client = reqwest::Client::builder().no_proxy().build().unwrap();
-    (format!("http://127.0.0.1:{port}"), client)
+async fn spawn_server_with_master_key(
+    master_key: &str,
+) -> (String, reqwest::Client, support::multi_db::ApiTestServer) {
+    let server = support::multi_db::spawn_api_server(
+        "api_e2e_master",
+        test_dim(),
+        master_key.to_string(),
+        None,
+        None,
+        None,
+        true,
+    )
+    .await;
+    (server.base.clone(), server.client.clone(), server)
 }
 
 async fn create_api_key_for_user(
@@ -951,7 +916,7 @@ async fn create_api_key_for_user(
 #[tokio::test]
 async fn test_api_auth_required() {
     let mk = "test-master-key-12345";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
 
     // No token → 401
     let r = client
@@ -990,7 +955,7 @@ async fn test_api_auth_required() {
 #[tokio::test]
 async fn test_api_key_crud() {
     let mk = "test-master-key-crud";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let uid = uid();
 
@@ -1121,7 +1086,7 @@ async fn test_api_key_crud() {
 #[tokio::test]
 async fn test_api_key_cannot_get_other_users_memory() {
     let mk = "test-master-key-memory-read";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let owner_id = uid();
     let attacker_id = uid();
@@ -1154,7 +1119,7 @@ async fn test_api_key_cannot_get_other_users_memory() {
 #[tokio::test]
 async fn test_api_key_cannot_correct_other_users_memory() {
     let mk = "test-master-key-memory-correct";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let owner_id = uid();
     let attacker_id = uid();
@@ -1189,23 +1154,20 @@ async fn test_api_key_cannot_correct_other_users_memory() {
 #[tokio::test]
 async fn test_api_key_cannot_get_other_users_task_status() {
     use memoria_service::AsyncTaskStore;
-    use memoria_storage::SqlMemoryStore;
 
     let mk = "test-master-key-task-status";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let owner_id = uid();
     let attacker_id = uid();
     let attacker_key =
         create_api_key_for_user(&client, &base, &auth, &attacker_id, "attacker-task").await;
 
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
+    let store = server.shared_store();
 
     let task_id = format!("task_{}", uuid::Uuid::new_v4().simple());
     store
+        .as_ref()
         .create_task(&task_id, "instance_authz", &owner_id)
         .await
         .unwrap();
@@ -1224,7 +1186,7 @@ async fn test_api_key_cannot_get_other_users_task_status() {
 #[tokio::test]
 async fn test_api_key_cannot_delete_other_users_memory() {
     let mk = "test-master-key-memory-delete";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let owner_id = uid();
     let attacker_id = uid();
@@ -1261,7 +1223,7 @@ async fn test_api_key_cannot_delete_other_users_memory() {
 #[tokio::test]
 async fn test_api_key_list_only_own_memories() {
     let mk = "test-master-key-list-isolation";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let user_a = uid();
     let user_b = uid();
@@ -1302,7 +1264,7 @@ async fn test_api_key_list_only_own_memories() {
 #[tokio::test]
 async fn test_master_key_can_impersonate_and_access_any_user() {
     let mk = "test-master-key-impersonate";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let user_a = uid();
     let key_a = create_api_key_for_user(&client, &base, &auth, &user_a, "imp-a").await;
@@ -1364,7 +1326,7 @@ async fn test_master_key_can_impersonate_and_access_any_user() {
 #[tokio::test]
 async fn test_revoked_api_key_returns_401() {
     let mk = "test-master-key-revoked";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let uid = uid();
 
@@ -1425,7 +1387,7 @@ async fn test_revoked_api_key_returns_401() {
 
 #[tokio::test]
 async fn test_api_observe_turn() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Observe with assistant + user messages
@@ -1482,7 +1444,7 @@ async fn test_api_observe_turn() {
 
 #[tokio::test]
 async fn test_api_observe_empty_messages() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Empty messages array → should return 200 with empty memories
@@ -1506,7 +1468,7 @@ async fn test_api_observe_empty_messages() {
 
 #[tokio::test]
 async fn test_api_retrieve_top_k_respected() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store 5 memories
@@ -1540,7 +1502,7 @@ async fn test_api_retrieve_top_k_respected() {
 
 #[tokio::test]
 async fn test_api_search_returns_fields() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     client
@@ -1579,7 +1541,7 @@ async fn test_api_search_returns_fields() {
 
 #[tokio::test]
 async fn test_api_store_missing_content() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -1595,7 +1557,7 @@ async fn test_api_store_missing_content() {
 
 #[tokio::test]
 async fn test_api_delete_nonexistent() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -1611,7 +1573,7 @@ async fn test_api_delete_nonexistent() {
 
 #[tokio::test]
 async fn test_api_correct_nonexistent() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -1634,7 +1596,7 @@ async fn test_api_correct_nonexistent() {
 
 #[tokio::test]
 async fn test_api_memory_history() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store a memory
@@ -1691,7 +1653,7 @@ async fn test_api_memory_history() {
 
 #[tokio::test]
 async fn test_api_memory_history_not_found() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -1707,7 +1669,7 @@ async fn test_api_memory_history_not_found() {
 // ── Remote mode E2E tests ─────────────────────────────────────────────────────
 
 /// Spawn API server + test remote MCP client against it.
-async fn spawn_api_for_remote() -> (String, reqwest::Client) {
+async fn spawn_api_for_remote() -> (String, reqwest::Client, support::multi_db::ApiTestServer) {
     // Reuse spawn_server but return the base URL for RemoteClient
     spawn_server().await
 }
@@ -1716,7 +1678,7 @@ async fn spawn_api_for_remote() -> (String, reqwest::Client) {
 async fn test_remote_store_retrieve() {
     use memoria_mcp::remote::RemoteClient;
 
-    let (base, _) = spawn_api_for_remote().await;
+    let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
 
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
@@ -1759,7 +1721,7 @@ async fn test_remote_store_retrieve() {
 async fn test_remote_correct_purge() {
     use memoria_mcp::remote::RemoteClient;
 
-    let (base, _) = spawn_api_for_remote().await;
+    let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
 
@@ -1806,7 +1768,7 @@ async fn test_remote_correct_purge() {
 async fn test_remote_governance() {
     use memoria_mcp::remote::RemoteClient;
 
-    let (base, _) = spawn_api_for_remote().await;
+    let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
 
@@ -1826,7 +1788,7 @@ async fn test_remote_governance() {
 async fn test_remote_capabilities() {
     use memoria_mcp::remote::RemoteClient;
 
-    let (base, _) = spawn_api_for_remote().await;
+    let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
 
@@ -1845,7 +1807,7 @@ async fn test_remote_capabilities() {
 #[tokio::test]
 async fn test_remote_list_search_profile() {
     use memoria_mcp::remote::RemoteClient;
-    let (base, _) = spawn_api_for_remote().await;
+    let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
 
@@ -1901,7 +1863,7 @@ async fn test_remote_list_search_profile() {
 #[tokio::test]
 async fn test_remote_snapshot_branch() {
     use memoria_mcp::remote::RemoteClient;
-    let (base, _) = spawn_api_for_remote().await;
+    let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
 
@@ -2020,7 +1982,7 @@ async fn test_remote_snapshot_branch() {
 #[tokio::test]
 async fn test_remote_reflect_extract_entities() {
     use memoria_mcp::remote::RemoteClient;
-    let (base, _) = spawn_api_for_remote().await;
+    let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
 
@@ -2097,7 +2059,7 @@ async fn test_remote_reflect_extract_entities() {
 #[tokio::test]
 async fn test_reflect_no_llm_falls_back_to_candidates() {
     // When LLM is not configured, mode=auto should return candidates (not error)
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     client
@@ -2137,7 +2099,7 @@ async fn test_reflect_no_llm_falls_back_to_candidates() {
 
 #[tokio::test]
 async fn test_extract_entities_no_llm_falls_back_to_candidates() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     client
@@ -2172,7 +2134,7 @@ async fn test_extract_entities_no_llm_falls_back_to_candidates() {
 
 #[tokio::test]
 async fn test_governance_pollution_detection() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store 3 memories then supersede 2 of them → ratio=2/5=0.4 > 0.3 → polluted
@@ -2223,17 +2185,10 @@ async fn test_governance_pollution_detection() {
 #[tokio::test]
 async fn test_reflect_with_llm() {
     let (llm, _shutdown) = spawn_fake_llm().await;
-    let (base, client) = spawn_server_with_llm(llm).await;
+    let (base, client, server) = spawn_server_with_llm(llm).await;
     let uid = uid();
 
-    let store = memoria_storage::SqlMemoryStore::connect(
-        &db_url(),
-        test_dim(),
-        uuid::Uuid::new_v4().to_string(),
-    )
-    .await
-    .expect("connect");
-    store.migrate().await.expect("migrate");
+    let store = server.user_store(&uid).await;
     let graph = store.graph_store();
     for (idx, content) in [
         "Project uses Rust for all backend services",
@@ -2318,7 +2273,7 @@ async fn test_reflect_with_llm() {
 #[tokio::test]
 async fn test_extract_entities_with_llm() {
     let (llm, _shutdown) = spawn_fake_llm().await;
-    let (base, client) = spawn_server_with_llm(llm).await;
+    let (base, client, _server) = spawn_server_with_llm(llm).await;
     let uid = uid();
 
     client
@@ -2379,7 +2334,7 @@ async fn test_extract_entities_with_llm() {
 #[tokio::test]
 async fn test_remote_consolidate() {
     use memoria_mcp::remote::RemoteClient;
-    let (base, _) = spawn_api_for_remote().await;
+    let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
 
@@ -2398,7 +2353,7 @@ async fn test_remote_consolidate() {
 #[tokio::test]
 async fn test_remote_correct_by_query() {
     use memoria_mcp::remote::RemoteClient;
-    let (base, _) = spawn_api_for_remote().await;
+    let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
 
@@ -2432,7 +2387,7 @@ async fn test_remote_correct_by_query() {
 #[tokio::test]
 async fn test_remote_purge_by_topic() {
     use memoria_mcp::remote::RemoteClient;
-    let (base, _) = spawn_api_for_remote().await;
+    let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
 
@@ -2457,7 +2412,7 @@ async fn test_remote_purge_by_topic() {
 #[tokio::test]
 async fn test_remote_purge_by_session_id() {
     use memoria_mcp::remote::RemoteClient;
-    let (base, _) = spawn_api_for_remote().await;
+    let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
     let target_session = format!("session:test-smp-{}", uuid::Uuid::new_v4().simple());
@@ -2543,7 +2498,7 @@ async fn test_remote_purge_rejects_invalid_memory_types_locally() {
 
 #[tokio::test]
 async fn test_episodic_no_llm_returns_503() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store some memories with a session_id
@@ -2569,89 +2524,55 @@ async fn test_episodic_no_llm_returns_503() {
 
 async fn spawn_server_with_llm(
     llm: Arc<memoria_embedding::LlmClient>,
-) -> (String, reqwest::Client) {
-    use memoria_git::GitForDataService;
-    use memoria_service::{Config, MemoryService};
-    use memoria_storage::SqlMemoryStore;
-    use sqlx::mysql::MySqlPool;
-
-    let cfg = Config::from_env();
-    let db = db_url();
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let pool = MySqlPool::connect(&db).await.expect("pool");
-    let git = Arc::new(GitForDataService::new(pool, &cfg.db_name));
-    let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, Some(llm)).await);
-    let state = memoria_api::AppState::new(service, git, String::new());
-    let app = memoria_api::build_router(state);
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-    let client = reqwest::Client::builder().no_proxy().build().unwrap();
-    (format!("http://127.0.0.1:{port}"), client)
+) -> (String, reqwest::Client, support::multi_db::ApiTestServer) {
+    let server = support::multi_db::spawn_api_server(
+        "api_e2e_llm",
+        test_dim(),
+        String::new(),
+        None,
+        Some(llm),
+        None,
+        false,
+    )
+    .await;
+    (server.base.clone(), server.client.clone(), server)
 }
 
 async fn spawn_server_with_embedding(
     emb_key: String,
     base_url: String,
     model: String,
-) -> (String, reqwest::Client) {
+) -> (String, reqwest::Client, support::multi_db::ApiTestServer) {
     use memoria_embedding::HttpEmbedder;
-    use memoria_git::GitForDataService;
-    use memoria_service::{Config, MemoryService};
-    use memoria_storage::SqlMemoryStore;
-    use sqlx::mysql::MySqlPool;
-
-    let cfg = Config::from_env();
-    let db = db_url();
-    let store = SqlMemoryStore::connect(&db, 1024, uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let pool = MySqlPool::connect(&db).await.expect("pool");
-    let git = Arc::new(GitForDataService::new(pool, &cfg.db_name));
     let embedder = Arc::new(HttpEmbedder::new(base_url, emb_key, model, 1024));
-    let service =
-        Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), Some(embedder), None).await);
-    let state = memoria_api::AppState::new(service, git, String::new());
-    let app = memoria_api::build_router(state);
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-    let client = reqwest::Client::builder().no_proxy().build().unwrap();
-    (format!("http://127.0.0.1:{port}"), client)
+    let server = support::multi_db::spawn_api_server(
+        "api_e2e_embedding",
+        1024,
+        String::new(),
+        Some(embedder),
+        None,
+        None,
+        false,
+    )
+    .await;
+    (server.base.clone(), server.client.clone(), server)
 }
 
 async fn spawn_server_with_custom_embedder_and_pool(
     embedder: Arc<dyn memoria_core::interfaces::EmbeddingProvider>,
     dim: usize,
-) -> (String, reqwest::Client, sqlx::MySqlPool) {
-    use memoria_git::GitForDataService;
-    use memoria_service::{Config, MemoryService};
-    use memoria_storage::SqlMemoryStore;
-
-    let cfg = Config::from_env();
-    let db = db_url();
-    let store = SqlMemoryStore::connect(&db, dim, uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let pool = store.pool().clone();
-    let git = Arc::new(GitForDataService::new(pool.clone(), &cfg.db_name));
-    let service =
-        Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), Some(embedder), None).await);
-    let state = memoria_api::AppState::new(service, git, String::new());
-    let app = memoria_api::build_router(state);
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-    let client = reqwest::Client::builder().no_proxy().build().unwrap();
-    (format!("http://127.0.0.1:{port}"), client, pool)
+) -> (String, reqwest::Client, support::multi_db::ApiTestServer) {
+    let server = support::multi_db::spawn_api_server(
+        "api_e2e_custom_embedder",
+        dim,
+        String::new(),
+        Some(embedder),
+        None,
+        None,
+        false,
+    )
+    .await;
+    (server.base.clone(), server.client.clone(), server)
 }
 
 async fn store_memory_for_session(
@@ -2678,7 +2599,7 @@ async fn store_memory_for_session(
 #[tokio::test]
 async fn test_episodic_no_memories_returns_error() {
     let (llm, _shutdown) = spawn_fake_llm().await;
-    let (base, client) = spawn_server_with_llm(llm).await;
+    let (base, client, _server) = spawn_server_with_llm(llm).await;
     let uid = uid();
 
     // No memories for this session → 500
@@ -2695,7 +2616,7 @@ async fn test_episodic_no_memories_returns_error() {
 
 #[tokio::test]
 async fn test_episodic_async_task_polling() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Without LLM, async mode should still create a task (that will fail)
@@ -2715,7 +2636,7 @@ async fn test_episodic_async_task_polling() {
 #[tokio::test]
 async fn test_episodic_with_llm_sync() {
     let (llm, _shutdown) = spawn_fake_llm().await;
-    let (base, client) = spawn_server_with_llm(llm).await;
+    let (base, client, _server) = spawn_server_with_llm(llm).await;
     let uid = uid();
     let session_id = format!(
         "ep_sess_{}",
@@ -2776,7 +2697,7 @@ async fn test_episodic_with_llm_sync() {
 #[tokio::test]
 async fn test_episodic_with_llm_async() {
     let (llm, _shutdown) = spawn_fake_llm().await;
-    let (base, client) = spawn_server_with_llm(llm).await;
+    let (base, client, _server) = spawn_server_with_llm(llm).await;
     let uid = uid();
     let session_id = format!(
         "ep_async_{}",
@@ -2847,7 +2768,7 @@ async fn test_episodic_with_llm_async() {
 
 #[tokio::test]
 async fn test_admin_stats_and_users() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let user = uid();
 
     // Store a memory first
@@ -2925,7 +2846,7 @@ async fn test_admin_stats_and_users() {
 
 #[tokio::test]
 async fn test_admin_trigger_governance() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let user = uid();
 
     // Store a memory
@@ -2975,7 +2896,7 @@ async fn test_admin_trigger_governance() {
 
 #[tokio::test]
 async fn test_health_endpoints() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let user = uid();
 
     // Store some memories
@@ -3053,7 +2974,7 @@ async fn test_health_endpoints() {
 #[tokio::test]
 async fn test_admin_health_hygiene_global() {
     let mk = "test-master-key-hygiene";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
 
     let r = client
@@ -3083,7 +3004,7 @@ async fn test_admin_health_hygiene_global() {
 
 #[tokio::test]
 async fn test_sandbox_validation() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let user = uid();
 
     // Store some base memories
@@ -3117,7 +3038,7 @@ async fn test_sandbox_validation() {
 
 #[tokio::test]
 async fn test_retrieve_with_explain() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let user = uid();
 
     client
@@ -3208,7 +3129,7 @@ async fn test_explain_verbose_candidate_scores() {
         println!("⏭️  test_explain_verbose_candidate_scores skipped (EMBEDDING_API_KEY not set)");
         return;
     };
-    let (base, client) = spawn_server_with_embedding(key, base_url, model).await;
+    let (base, client, _server) = spawn_server_with_embedding(key, base_url, model).await;
     let uid = uid();
 
     // Store a few memories
@@ -3276,10 +3197,11 @@ async fn test_explain_verbose_candidate_scores() {
 async fn test_retrieve_filter_session_prefilters_and_skips_graph() {
     use memoria_storage::{GraphEdge, GraphNode, GraphStore, NodeType};
 
-    let (base, client, pool) =
+    let (base, client, server) =
         spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
             .await;
     let uid = uid();
+    let user_store = server.user_store(&uid).await;
 
     let target_mid =
         store_memory_for_session(&client, &base, &uid, "target-session memory", "sess-target")
@@ -3289,7 +3211,10 @@ async fn test_retrieve_filter_session_prefilters_and_skips_graph() {
     let other_second_mid =
         store_memory_for_session(&client, &base, &uid, "other-session second", "sess-other").await;
 
-    let graph = GraphStore::new(pool, test_dim());
+    let mut graph = GraphStore::new(user_store.pool().clone(), test_dim());
+    if let Some(db_name) = user_store.db_name() {
+        graph.set_db_name(db_name.to_string());
+    }
     graph.migrate().await.expect("graph migrate");
 
     let make_node = |memory_id: &str, session_id: &str, content: &str| GraphNode {
@@ -3398,7 +3323,7 @@ async fn test_retrieve_filter_session_prefilters_and_skips_graph() {
 
 #[tokio::test]
 async fn test_retrieve_filter_session_requires_session_id() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let user = uid();
 
     let r = client
@@ -3430,7 +3355,7 @@ async fn test_retrieve_filter_session_requires_session_id() {
 
 #[tokio::test]
 async fn test_retrieve_filter_session_preserves_top_k_with_session_candidates() {
-    let (base, client, _pool) =
+    let (base, client, _server) =
         spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
             .await;
     let uid = uid();
@@ -3490,7 +3415,7 @@ async fn test_retrieve_filter_session_preserves_top_k_with_session_candidates() 
 
 #[tokio::test]
 async fn test_pipeline_run() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let user = uid();
 
     // Normal candidates — should all be stored
@@ -3541,7 +3466,7 @@ async fn test_pipeline_run() {
 #[tokio::test]
 async fn test_admin_list_user_keys() {
     let mk = "test-mk-list-keys";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let uid = uid();
 
@@ -3580,7 +3505,7 @@ async fn test_admin_list_user_keys() {
 #[tokio::test]
 async fn test_admin_list_user_keys_empty() {
     let mk = "test-mk-list-keys-empty";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let uid = uid(); // fresh user, no keys
 
@@ -3604,7 +3529,7 @@ async fn test_admin_list_user_keys_empty() {
 #[tokio::test]
 async fn test_admin_revoke_all_user_keys() {
     let mk = "test-mk-revoke-all";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let uid = uid();
 
@@ -3667,7 +3592,7 @@ async fn test_admin_revoke_all_user_keys() {
 #[tokio::test]
 async fn test_admin_revoke_all_user_keys_idempotent() {
     let mk = "test-mk-revoke-idem";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let uid = uid(); // no keys
 
@@ -3689,27 +3614,26 @@ async fn test_admin_revoke_all_user_keys_idempotent() {
 #[tokio::test]
 async fn test_admin_set_user_params() {
     let mk = "test-mk-set-params";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let uid = uid();
 
     // Ensure the config table exists (may not be in Rust migration yet)
-    if let Ok(pool) = sqlx::mysql::MySqlPool::connect(&db_url()).await {
-        let _ = sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mem_user_memory_config (\
+    let pool = server.shared_pool();
+    let config_table = server.shared_table("mem_user_memory_config");
+    let _ = sqlx::query(&format!(
+            "CREATE TABLE IF NOT EXISTS {config_table} (\
              user_id VARCHAR(128) PRIMARY KEY, \
              strategy_key VARCHAR(64) DEFAULT NULL, \
              params_json JSON DEFAULT NULL, \
-             updated_at DATETIME DEFAULT NULL)",
-        )
+             updated_at DATETIME DEFAULT NULL)"
+    ))
+    .execute(&pool)
+    .await;
+    let _ = sqlx::query(&format!("INSERT IGNORE INTO {config_table} (user_id) VALUES (?)"))
+        .bind(&uid)
         .execute(&pool)
         .await;
-        // Insert a row for the user
-        let _ = sqlx::query("INSERT IGNORE INTO mem_user_memory_config (user_id) VALUES (?)")
-            .bind(&uid)
-            .execute(&pool)
-            .await;
-    }
 
     // Set params
     let params = json!({"vector_weight": 0.7, "keyword_weight": 0.3, "max_results": 20});
@@ -3732,7 +3656,7 @@ async fn test_admin_set_user_params() {
 
 #[tokio::test]
 async fn test_snapshot_get_detail() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store memories
@@ -3895,7 +3819,7 @@ async fn test_snapshot_get_detail() {
 
 #[tokio::test]
 async fn test_snapshot_diff() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store 2 memories
@@ -4015,7 +3939,7 @@ async fn test_snapshot_diff() {
 
 #[tokio::test]
 async fn test_snapshot_diff_no_changes() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store a memory
@@ -4070,7 +3994,7 @@ async fn test_snapshot_diff_no_changes() {
 
 #[tokio::test]
 async fn test_api_snapshot_limit_is_per_user() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid_a = uid();
     let uid_b = uid();
     let names_a: Vec<String> = (0..20)
@@ -4187,7 +4111,7 @@ async fn test_api_snapshot_limit_is_per_user() {
 
 #[tokio::test]
 async fn test_api_snapshot_detail_is_scoped_to_owner() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid_a = uid();
     let uid_b = uid();
     let snap = format!(
@@ -4235,7 +4159,7 @@ async fn test_api_snapshot_detail_is_scoped_to_owner() {
 
 #[tokio::test]
 async fn test_batch_store_invalid_type_rejects_all() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // One valid, one invalid type → should reject entire batch
@@ -4255,7 +4179,7 @@ async fn test_batch_store_invalid_type_rejects_all() {
 
 #[tokio::test]
 async fn test_batch_store_all_types() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -4286,7 +4210,7 @@ async fn test_batch_store_all_types() {
 
 #[tokio::test]
 async fn test_batch_store_empty() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -4305,7 +4229,7 @@ async fn test_batch_store_empty() {
 
 #[tokio::test]
 async fn test_batch_store_sensitivity_filter() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Batch with a sensitive item — store_batch checks sensitivity
@@ -4333,7 +4257,7 @@ async fn test_batch_store_with_embedding() {
         println!("⏭️  test_batch_store_with_embedding skipped (EMBEDDING_API_KEY not set)");
         return;
     };
-    let (base, client) = spawn_server_with_embedding(key, base_url, model).await;
+    let (base, client, _server) = spawn_server_with_embedding(key, base_url, model).await;
     let uid = uid();
 
     // Batch store 5 items — should use embed_batch (single API call)
@@ -4389,7 +4313,7 @@ async fn test_batch_store_with_embedding() {
 #[tokio::test]
 async fn test_remote_admin_list_revoke_keys() {
     let mk = "test-mk-remote-keys";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let uid = uid();
 
@@ -4433,7 +4357,7 @@ async fn test_remote_admin_list_revoke_keys() {
 #[tokio::test]
 async fn test_remote_snapshot_detail_and_diff() {
     use memoria_mcp::remote::RemoteClient;
-    let (base, _) = spawn_api_for_remote().await;
+    let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
 
@@ -4602,7 +4526,7 @@ fn test_signer_public_b64() -> String {
 /// Full plugin lifecycle: signer → publish → list → review → score → binding → activate → matrix → events → rules
 #[tokio::test]
 async fn test_plugin_full_lifecycle() {
-    let (base, c) = spawn_server().await;
+    let (base, c, _server) = spawn_server().await;
     let signer_name = format!("e2e-signer-{}", uuid::Uuid::new_v4().simple());
     let plugin_name = format!("e2e-plugin-{}", uuid::Uuid::new_v4().simple());
 
@@ -4771,7 +4695,7 @@ async fn test_plugin_full_lifecycle() {
 /// Dev-mode publish: skips signature verification, auto-approves.
 #[tokio::test]
 async fn test_plugin_dev_mode_publish() {
-    let (base, c) = spawn_server().await;
+    let (base, c, _server) = spawn_server().await;
     let plugin_name = format!("e2e-dev-{}", uuid::Uuid::new_v4().simple());
 
     // Build an UNSIGNED package (no signer registered, no valid signature)
@@ -4825,7 +4749,7 @@ async fn test_plugin_dev_mode_publish() {
 /// Error: publish without manifest.json
 #[tokio::test]
 async fn test_plugin_publish_missing_manifest() {
-    let (base, c) = spawn_server().await;
+    let (base, c, _server) = spawn_server().await;
 
     use base64::engine::general_purpose::STANDARD as B64;
     use base64::Engine;
@@ -4850,7 +4774,7 @@ async fn test_plugin_publish_missing_manifest() {
 /// Error: publish with path traversal filename
 #[tokio::test]
 async fn test_plugin_publish_path_traversal_rejected() {
-    let (base, c) = spawn_server().await;
+    let (base, c, _server) = spawn_server().await;
 
     use base64::engine::general_purpose::STANDARD as B64;
     use base64::Engine;
@@ -4873,7 +4797,7 @@ async fn test_plugin_publish_path_traversal_rejected() {
 /// Error: review a non-existent package
 #[tokio::test]
 async fn test_plugin_review_nonexistent() {
-    let (base, c) = spawn_server().await;
+    let (base, c, _server) = spawn_server().await;
 
     let r = c
         .post(format!(
@@ -4890,7 +4814,7 @@ async fn test_plugin_review_nonexistent() {
 /// Signer upsert is idempotent
 #[tokio::test]
 async fn test_plugin_signer_upsert_idempotent() {
-    let (base, c) = spawn_server().await;
+    let (base, c, _server) = spawn_server().await;
     let signer_name = format!("e2e-idem-{}", uuid::Uuid::new_v4().simple());
 
     for _ in 0..2 {
@@ -4922,7 +4846,7 @@ async fn test_plugin_signer_upsert_idempotent() {
 /// Empty list/matrix/events return empty arrays, not errors
 #[tokio::test]
 async fn test_plugin_empty_queries() {
-    let (base, c) = spawn_server().await;
+    let (base, c, _server) = spawn_server().await;
 
     let r = c.get(format!("{base}/admin/plugins")).send().await.unwrap();
     assert_eq!(r.status(), 200);
@@ -4960,7 +4884,7 @@ async fn test_plugin_empty_queries() {
 #[tokio::test]
 async fn test_plugin_admin_routes_require_master_key() {
     let mk = "test-mk-plugin-admin";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
     let uid = uid();
     let user_key = create_api_key_for_user(&client, &base, &auth, &uid, "plugin-user").await;
@@ -4994,46 +4918,36 @@ async fn test_plugin_admin_routes_require_master_key() {
 // ── Distributed coordination tests ────────────────────────────────────────────
 
 /// Spawn a server with a specific instance_id, returning (base_url, client, instance_id).
-async fn spawn_server_with_instance(instance_id: &str) -> (String, reqwest::Client, String) {
-    use memoria_git::GitForDataService;
-    use memoria_service::{Config, MemoryService};
-    use memoria_storage::SqlMemoryStore;
-    use sqlx::mysql::MySqlPool;
-
-    let cfg = Config::from_env();
-    let db = db_url();
-
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let pool = MySqlPool::connect(&db).await.expect("pool");
-    let git = Arc::new(GitForDataService::new(pool, &cfg.db_name));
-    let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    let state = memoria_api::AppState::new(service, git, String::new())
-        .with_instance_id(instance_id.to_string());
-
-    let app = memoria_api::build_router(state);
-
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind");
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move { axum::serve(listener, app).await });
-    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .expect("client");
-    let base = format!("http://127.0.0.1:{port}");
-    (base, client, instance_id.to_string())
+async fn spawn_server_with_instance(
+    instance_id: &str,
+) -> (
+    String,
+    reqwest::Client,
+    String,
+    support::multi_db::ApiTestServer,
+) {
+    let server = support::multi_db::spawn_api_server(
+        "api_e2e_instance",
+        test_dim(),
+        String::new(),
+        None,
+        None,
+        Some(instance_id.to_string()),
+        false,
+    )
+    .await;
+    (
+        server.base.clone(),
+        server.client.clone(),
+        instance_id.to_string(),
+        server,
+    )
 }
 
 #[tokio::test]
 async fn test_distributed_health_instance_returns_id() {
     let iid = format!("inst_{}", uuid::Uuid::new_v4().simple());
-    let (base, c, _) = spawn_server_with_instance(&iid).await;
+    let (base, c, _, _server) = spawn_server_with_instance(&iid).await;
 
     let r = c
         .get(format!("{base}/health/instance"))
@@ -5052,8 +4966,8 @@ async fn test_distributed_two_instances_different_ids() {
     let id_a = format!("inst_a_{}", uuid::Uuid::new_v4().simple());
     let id_b = format!("inst_b_{}", uuid::Uuid::new_v4().simple());
 
-    let (base_a, c, _) = spawn_server_with_instance(&id_a).await;
-    let (base_b, c2, _) = spawn_server_with_instance(&id_b).await;
+    let (base_a, c, _, _server_a) = spawn_server_with_instance(&id_a).await;
+    let (base_b, c2, _, _server_b) = spawn_server_with_instance(&id_b).await;
 
     let ra: Value = c
         .get(format!("{base_a}/health/instance"))
@@ -5084,8 +4998,8 @@ async fn test_distributed_cross_instance_memory_visibility() {
     let id_b = format!("inst_b_{}", uuid::Uuid::new_v4().simple());
     let user = uid();
 
-    let (base_a, c, _) = spawn_server_with_instance(&id_a).await;
-    let (base_b, c2, _) = spawn_server_with_instance(&id_b).await;
+    let (base_a, c, _, _server_a) = spawn_server_with_instance(&id_a).await;
+    let (base_b, c2, _, _server_b) = spawn_server_with_instance(&id_b).await;
 
     // Store on instance A
     let r = c
@@ -5126,14 +5040,12 @@ async fn test_distributed_cross_instance_memory_visibility() {
 async fn test_distributed_lock_acquire_release() {
     // Direct test of the distributed lock via SqlMemoryStore
     use memoria_service::DistributedLock;
-    use memoria_storage::SqlMemoryStore;
     use std::time::Duration;
 
-    let db = db_url();
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
+    let ctx =
+        memoria_test_utils::MultiDbTestContext::new(&db_url(), "api_e2e_lock", test_dim(), None, None)
+            .await;
+    let store = ctx.shared_store();
 
     let lock_key = format!("test_lock_{}", uuid::Uuid::new_v4().simple());
 
@@ -5179,14 +5091,17 @@ async fn test_distributed_lock_acquire_release() {
 #[tokio::test]
 async fn test_distributed_lock_expiry() {
     use memoria_service::DistributedLock;
-    use memoria_storage::SqlMemoryStore;
     use std::time::Duration;
 
-    let db = db_url();
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
+    let ctx = memoria_test_utils::MultiDbTestContext::new(
+        &db_url(),
+        "api_e2e_lock_expiry",
+        test_dim(),
+        None,
+        None,
+    )
+    .await;
+    let store = ctx.shared_store();
 
     let lock_key = format!("test_lock_exp_{}", uuid::Uuid::new_v4().simple());
 
@@ -5217,14 +5132,17 @@ async fn test_distributed_lock_expiry() {
 #[tokio::test]
 async fn test_distributed_lock_renew() {
     use memoria_service::DistributedLock;
-    use memoria_storage::SqlMemoryStore;
     use std::time::Duration;
 
-    let db = db_url();
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
+    let ctx = memoria_test_utils::MultiDbTestContext::new(
+        &db_url(),
+        "api_e2e_lock_renew",
+        test_dim(),
+        None,
+        None,
+    )
+    .await;
+    let store = ctx.shared_store();
 
     let lock_key = format!("test_lock_renew_{}", uuid::Uuid::new_v4().simple());
 
@@ -5255,13 +5173,16 @@ async fn test_distributed_lock_renew() {
 #[tokio::test]
 async fn test_distributed_async_task_cross_instance() {
     use memoria_service::AsyncTaskStore;
-    use memoria_storage::SqlMemoryStore;
 
-    let db = db_url();
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
+    let ctx = memoria_test_utils::MultiDbTestContext::new(
+        &db_url(),
+        "api_e2e_async_task",
+        test_dim(),
+        None,
+        None,
+    )
+    .await;
+    let store = ctx.shared_store();
 
     let task_id = format!("task_{}", uuid::Uuid::new_v4().simple());
 
@@ -5300,13 +5221,16 @@ async fn test_distributed_async_task_cross_instance() {
 #[tokio::test]
 async fn test_distributed_async_task_fail() {
     use memoria_service::AsyncTaskStore;
-    use memoria_storage::SqlMemoryStore;
 
-    let db = db_url();
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
+    let ctx = memoria_test_utils::MultiDbTestContext::new(
+        &db_url(),
+        "api_e2e_async_task_fail",
+        test_dim(),
+        None,
+        None,
+    )
+    .await;
+    let store = ctx.shared_store();
 
     let task_id = format!("task_{}", uuid::Uuid::new_v4().simple());
     store
@@ -5333,7 +5257,7 @@ async fn test_distributed_async_task_fail() {
 
 #[tokio::test]
 async fn test_api_feedback_record() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store a memory first
@@ -5367,7 +5291,7 @@ async fn test_api_feedback_record() {
 
 #[tokio::test]
 async fn test_api_feedback_invalid_signal() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store a memory
@@ -5395,7 +5319,7 @@ async fn test_api_feedback_invalid_signal() {
 
 #[tokio::test]
 async fn test_api_feedback_nonexistent_memory() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -5411,7 +5335,7 @@ async fn test_api_feedback_nonexistent_memory() {
 
 #[tokio::test]
 async fn test_api_feedback_stats() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store memories and give feedback
@@ -5460,7 +5384,7 @@ async fn test_api_feedback_stats() {
 
 #[tokio::test]
 async fn test_api_feedback_by_tier() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store memories with different tiers and give feedback
@@ -5507,7 +5431,7 @@ async fn test_api_feedback_by_tier() {
 
 #[tokio::test]
 async fn test_api_get_retrieval_params() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let r = client
@@ -5529,7 +5453,7 @@ async fn test_api_get_retrieval_params() {
 
 #[tokio::test]
 async fn test_api_set_retrieval_params() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Set custom params
@@ -5564,7 +5488,7 @@ async fn test_api_set_retrieval_params() {
 
 #[tokio::test]
 async fn test_api_tune_retrieval_params() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Without enough feedback, should not tune
@@ -5583,7 +5507,7 @@ async fn test_api_tune_retrieval_params() {
 
 #[tokio::test]
 async fn test_api_tune_with_feedback() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Create a memory
@@ -5639,7 +5563,7 @@ async fn test_api_tune_with_feedback() {
 
 #[tokio::test]
 async fn test_api_metrics() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let r = client.get(format!("{base}/metrics")).send().await.unwrap();
     assert_eq!(r.status(), 200);
     let body = r.text().await.unwrap();
@@ -5662,7 +5586,7 @@ async fn test_api_metrics() {
 
 #[tokio::test]
 async fn test_api_snapshot_rollback() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store a memory
@@ -5718,7 +5642,7 @@ async fn test_api_snapshot_rollback() {
 
 #[tokio::test]
 async fn test_api_branch_list_returns_structured_json() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
     let branch = format!(
         "api_branch_{}",
@@ -5780,7 +5704,7 @@ async fn test_api_branch_list_returns_structured_json() {
 
 #[tokio::test]
 async fn test_api_entities() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Store a memory to trigger entity extraction
@@ -5813,7 +5737,7 @@ async fn test_api_entities() {
 #[tokio::test]
 async fn test_api_admin_config() {
     let mk = format!("mk_{}", uuid::Uuid::new_v4().simple());
-    let (base, client) = spawn_server_with_master_key(&mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(&mk).await;
 
     // Without master key → 401
     let r = client
@@ -5846,7 +5770,7 @@ async fn test_api_admin_config() {
 #[tokio::test]
 async fn test_api_admin_config_forbidden() {
     let mk = format!("mk_{}", uuid::Uuid::new_v4().simple());
-    let (base, client) = spawn_server_with_master_key(&mk).await;
+    let (base, client, _server) = spawn_server_with_master_key(&mk).await;
 
     // Create an API key (non-master)
     let auth = format!("Bearer {mk}");
@@ -5878,7 +5802,7 @@ async fn test_api_admin_config_forbidden() {
 
 #[tokio::test]
 async fn test_concurrent_stores() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
     let client = Arc::new(client);
     let n = 20;
@@ -5926,7 +5850,7 @@ async fn test_concurrent_stores() {
 
 #[tokio::test]
 async fn test_concurrent_entity_upsert() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
     let client = Arc::new(client);
 
@@ -5965,7 +5889,7 @@ async fn test_concurrent_entity_upsert() {
 
 #[tokio::test]
 async fn test_batch_store_at_limit() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let memories: Vec<_> = (0..100)
@@ -6002,7 +5926,7 @@ async fn test_batch_store_at_limit() {
 
 #[tokio::test]
 async fn test_concurrent_feedback() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
     let client = Arc::new(client);
 
@@ -6062,7 +5986,7 @@ async fn test_concurrent_feedback() {
 
 #[tokio::test]
 async fn test_graceful_degradation() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     // Rollback to nonexistent snapshot → error, not crash
@@ -6127,11 +6051,10 @@ async fn test_graceful_degradation() {
 #[tokio::test]
 async fn test_last_used_batcher_coalesces_and_flushes() {
     use memoria_api::auth::LastUsedBatcher;
-    use memoria_storage::SqlMemoryStore;
     use sha2::{Digest, Sha256};
 
     let mk = "test-master-batcher";
-    let (base, client) = spawn_server_with_master_key(mk).await;
+    let (base, client, server) = spawn_server_with_master_key(mk).await;
     let auth = format!("Bearer {mk}");
 
     // Create 3 API keys
@@ -6161,16 +6084,17 @@ async fn test_last_used_batcher_coalesces_and_flushes() {
     // Verify all 3 are pending
     // (We can't inspect the internal set directly, but we can flush and verify DB)
 
-    // Connect to DB and flush
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
+    // Flush against the same shared DB that stored the keys.
+    let store = server.shared_store();
     batcher.flush(store.pool()).await;
 
     // Verify last_used_at was updated for all 3 keys
     for hash in &hashes {
         let row: Option<(Option<chrono::NaiveDateTime>,)> =
-            sqlx::query_as("SELECT last_used_at FROM mem_api_keys WHERE key_hash = ?")
+            sqlx::query_as(&format!(
+                "SELECT last_used_at FROM {} WHERE key_hash = ?",
+                store.t("mem_api_keys")
+            ))
                 .bind(hash)
                 .fetch_optional(store.pool())
                 .await
@@ -6198,24 +6122,17 @@ async fn test_last_used_batcher_coalesces_and_flushes() {
 #[tokio::test]
 async fn test_api_key_auth_uses_batcher_not_fire_and_forget() {
     let mk = "test-master-batcher-auth";
-    let db = db_url();
+    let ctx = memoria_test_utils::MultiDbTestContext::new(
+        &db_url(),
+        "api_e2e_auth_batcher",
+        test_dim(),
+        None,
+        None,
+    )
+    .await;
 
-    // Spawn server WITH init_auth_pool
-    use memoria_git::GitForDataService;
-    use memoria_service::{Config, MemoryService};
-    use memoria_storage::SqlMemoryStore;
-    use sqlx::mysql::MySqlPool;
-
-    let cfg = Config::from_env();
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let pool = MySqlPool::connect(&db).await.expect("pool");
-    let git = Arc::new(GitForDataService::new(pool, &cfg.db_name));
-    let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    let state = memoria_api::AppState::new(service, git, mk.to_string())
-        .init_auth_pool(&db, false)
+    let state = memoria_api::AppState::new(ctx.service(), ctx.git(), mk.to_string())
+        .init_auth_pool(ctx.shared_db_url(), false)
         .await
         .expect("auth pool");
 
@@ -6252,9 +6169,7 @@ async fn test_api_key_auth_uses_batcher_not_fire_and_forget() {
     assert_eq!(r.status(), 200, "Cached API key auth should succeed");
 
     // Manually flush the batcher to verify last_used_at is updated
-    let verify_store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
+    let verify_store = ctx.shared_store();
     batcher.flush(verify_store.pool()).await;
 
     let key_hash = format!(
@@ -6262,7 +6177,10 @@ async fn test_api_key_auth_uses_batcher_not_fire_and_forget() {
         <sha2::Sha256 as sha2::Digest>::digest(raw_key.as_bytes())
     );
     let row: Option<(Option<chrono::NaiveDateTime>,)> =
-        sqlx::query_as("SELECT last_used_at FROM mem_api_keys WHERE key_hash = ?")
+        sqlx::query_as(&format!(
+            "SELECT last_used_at FROM {} WHERE key_hash = ?",
+            verify_store.t("mem_api_keys")
+        ))
             .bind(&key_hash)
             .fetch_optional(verify_store.pool())
             .await
@@ -6280,7 +6198,7 @@ async fn test_api_key_auth_uses_batcher_not_fire_and_forget() {
 
 #[tokio::test]
 async fn test_tool_usage_tracking() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let user = format!("tool_test_{}", uuid::Uuid::new_v4().simple());
 
     // 1. No tool header → usage should be empty
@@ -6389,7 +6307,7 @@ async fn test_tool_usage_tracking() {
 /// Helper: store via remote, create graph node + entity links manually, return memory_id.
 async fn remote_store_with_links(
     remote: &memoria_mcp::remote::RemoteClient,
-    pool: &sqlx::MySqlPool,
+    user_store: &memoria_storage::SqlMemoryStore,
     uid: &str,
     content: &str,
 ) -> String {
@@ -6410,71 +6328,59 @@ async fn remote_store_with_links(
 
     // Create graph node (remote path goes through REST API which doesn't create graph nodes)
     let node_id = uuid::Uuid::new_v4().simple().to_string()[..32].to_string();
-    sqlx::query(
-        "INSERT INTO memory_graph_nodes \
+    sqlx::query(&format!(
+        "INSERT INTO {} \
          (node_id, user_id, node_type, content, memory_id, confidence, trust_tier, importance, \
-          access_count, cross_session_count, is_active, created_at) \
+           access_count, cross_session_count, is_active, created_at) \
          VALUES (?, ?, 'semantic', ?, ?, 0.95, 'T1', 0.5, 0, 0, 1, NOW())",
-    )
+        user_store.t("memory_graph_nodes")
+    ))
     .bind(&node_id)
     .bind(uid)
     .bind(content)
     .bind(&mid)
-    .execute(pool)
+    .execute(user_store.pool())
     .await
     .unwrap();
 
     // Insert into legacy mem_entity_links
     let id = uuid::Uuid::new_v4().to_string().replace('-', "");
-    sqlx::query(
-        "INSERT INTO mem_entity_links (id, user_id, memory_id, entity_name, entity_type, source, created_at) \
+    sqlx::query(&format!(
+        "INSERT INTO {} (id, user_id, memory_id, entity_name, entity_type, source, created_at) \
          VALUES (?, ?, ?, 'remote_entity', 'concept', 'manual', NOW())",
-    )
+        user_store.t("mem_entity_links")
+    ))
     .bind(&id)
     .bind(uid)
     .bind(&mid)
-    .execute(pool)
+    .execute(user_store.pool())
     .await
     .unwrap();
 
     mid
 }
 
-async fn spawn_server_with_pool() -> (String, reqwest::Client, sqlx::MySqlPool) {
-    use memoria_git::GitForDataService;
-    use memoria_service::{Config, MemoryService};
-    use memoria_storage::SqlMemoryStore;
-
-    let cfg = Config::from_env();
-    let db = db_url();
-
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let pool = sqlx::MySqlPool::connect(&db).await.expect("pool");
-    let git = Arc::new(GitForDataService::new(pool.clone(), &cfg.db_name));
-    let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    let state = memoria_api::AppState::new(service, git, String::new());
-
-    let app = memoria_api::build_router(state);
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind");
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move { axum::serve(listener, app).await });
-    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-    let client = reqwest::Client::builder().no_proxy().build().unwrap();
-    let base = format!("http://127.0.0.1:{port}");
-    (base, client, pool)
+async fn spawn_server_with_pool() -> (String, reqwest::Client, support::multi_db::ApiTestServer) {
+    let server = support::multi_db::spawn_api_server(
+        "api_e2e_pool",
+        test_dim(),
+        String::new(),
+        None,
+        None,
+        None,
+        false,
+    )
+    .await;
+    (server.base.clone(), server.client.clone(), server)
 }
 
-async fn graph_node_active_count(pool: &sqlx::MySqlPool, mid: &str) -> i64 {
-    sqlx::query_scalar(
-        "SELECT COUNT(*) FROM memory_graph_nodes WHERE memory_id = ? AND is_active = 1",
-    )
+async fn graph_node_active_count(user_store: &memoria_storage::SqlMemoryStore, mid: &str) -> i64 {
+    sqlx::query_scalar(&format!(
+        "SELECT COUNT(*) FROM {} WHERE memory_id = ? AND is_active = 1",
+        user_store.t("memory_graph_nodes")
+    ))
     .bind(mid)
-    .fetch_one(pool)
+    .fetch_one(user_store.pool())
     .await
     .unwrap()
 }
@@ -6485,14 +6391,15 @@ async fn graph_node_active_count(pool: &sqlx::MySqlPool, mid: &str) -> i64 {
 async fn test_remote_purge_cleans_graph_and_entity_links() {
     use memoria_mcp::remote::RemoteClient;
 
-    let (base, _client, pool) = spawn_server_with_pool().await;
+    let (base, _client, server) = spawn_server_with_pool().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
+    let user_store = server.user_store(&uid).await;
 
-    let mid = remote_store_with_links(&remote, &pool, &uid, "Remote purge graph test").await;
+    let mid = remote_store_with_links(&remote, &user_store, &uid, "Remote purge graph test").await;
 
     // Verify graph node exists
-    let cnt: i64 = graph_node_active_count(&pool, &mid).await;
+    let cnt: i64 = graph_node_active_count(&user_store, &mid).await;
     assert!(cnt > 0, "graph node should exist before purge");
 
     // Purge via remote
@@ -6504,16 +6411,19 @@ async fn test_remote_purge_cleans_graph_and_entity_links() {
     assert!(text.contains("Purged"), "got: {text}");
 
     // Verify graph node deactivated
-    let cnt: i64 = graph_node_active_count(&pool, &mid).await;
+    let cnt: i64 = graph_node_active_count(&user_store, &mid).await;
     assert_eq!(
         cnt, 0,
         "graph node should be deactivated after remote purge"
     );
 
     // Verify entity links cleaned
-    let cnt: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mem_entity_links WHERE memory_id = ?")
+    let cnt: i64 = sqlx::query_scalar(&format!(
+        "SELECT COUNT(*) FROM {} WHERE memory_id = ?",
+        user_store.t("mem_entity_links")
+    ))
         .bind(&mid)
-        .fetch_one(&pool)
+        .fetch_one(user_store.pool())
         .await
         .unwrap();
     assert_eq!(
@@ -6530,12 +6440,13 @@ async fn test_remote_purge_cleans_graph_and_entity_links() {
 async fn test_remote_purge_batch_cleans_graph_and_entity_links() {
     use memoria_mcp::remote::RemoteClient;
 
-    let (base, _client, pool) = spawn_server_with_pool().await;
+    let (base, _client, server) = spawn_server_with_pool().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
+    let user_store = server.user_store(&uid).await;
 
-    let mid1 = remote_store_with_links(&remote, &pool, &uid, "Remote batch purge A").await;
-    let mid2 = remote_store_with_links(&remote, &pool, &uid, "Remote batch purge B").await;
+    let mid1 = remote_store_with_links(&remote, &user_store, &uid, "Remote batch purge A").await;
+    let mid2 = remote_store_with_links(&remote, &user_store, &uid, "Remote batch purge B").await;
 
     // Purge batch via remote (comma-separated)
     let r = remote
@@ -6549,7 +6460,7 @@ async fn test_remote_purge_batch_cleans_graph_and_entity_links() {
     assert!(text.contains("Purged"), "got: {text}");
 
     for mid in [&mid1, &mid2] {
-        let cnt: i64 = graph_node_active_count(&pool, mid).await;
+        let cnt: i64 = graph_node_active_count(&user_store, mid).await;
         assert_eq!(cnt, 0, "graph node should be deactivated for {mid}");
     }
     println!("✅ remote purge batch: graph + entity links cleaned");
@@ -6561,13 +6472,14 @@ async fn test_remote_purge_batch_cleans_graph_and_entity_links() {
 async fn test_remote_purge_topic_cleans_graph_and_entity_links() {
     use memoria_mcp::remote::RemoteClient;
 
-    let (base, _client, pool) = spawn_server_with_pool().await;
+    let (base, _client, server) = spawn_server_with_pool().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
+    let user_store = server.user_store(&uid).await;
 
     let mid = remote_store_with_links(
         &remote,
-        &pool,
+        &user_store,
         &uid,
         "remote_topic_graph_cleanup_xyz unique",
     )
@@ -6583,12 +6495,15 @@ async fn test_remote_purge_topic_cleans_graph_and_entity_links() {
     let text = r["content"][0]["text"].as_str().unwrap_or("");
     assert!(text.contains("Purged"), "got: {text}");
 
-    let cnt: i64 = graph_node_active_count(&pool, &mid).await;
+    let cnt: i64 = graph_node_active_count(&user_store, &mid).await;
     assert_eq!(cnt, 0, "graph node should be deactivated after topic purge");
 
-    let cnt: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mem_entity_links WHERE memory_id = ?")
+    let cnt: i64 = sqlx::query_scalar(&format!(
+        "SELECT COUNT(*) FROM {} WHERE memory_id = ?",
+        user_store.t("mem_entity_links")
+    ))
         .bind(&mid)
-        .fetch_one(&pool)
+        .fetch_one(user_store.pool())
         .await
         .unwrap();
     assert_eq!(cnt, 0, "entity links should be cleaned after topic purge");
@@ -6602,12 +6517,14 @@ async fn test_remote_purge_topic_cleans_graph_and_entity_links() {
 async fn test_remote_correct_cleans_graph_and_entity_links() {
     use memoria_mcp::remote::RemoteClient;
 
-    let (base, _client, pool) = spawn_server_with_pool().await;
+    let (base, _client, server) = spawn_server_with_pool().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
+    let user_store = server.user_store(&uid).await;
 
     let old_mid =
-        remote_store_with_links(&remote, &pool, &uid, "Remote correct graph old content").await;
+        remote_store_with_links(&remote, &user_store, &uid, "Remote correct graph old content")
+            .await;
 
     // Correct
     let r = remote
@@ -6624,16 +6541,19 @@ async fn test_remote_correct_cleans_graph_and_entity_links() {
     assert!(text.contains("Corrected"), "got: {text}");
 
     // Old graph node deactivated
-    let cnt: i64 = graph_node_active_count(&pool, &old_mid).await;
+    let cnt: i64 = graph_node_active_count(&user_store, &old_mid).await;
     assert_eq!(
         cnt, 0,
         "old graph node should be deactivated after remote correct"
     );
 
     // Old entity links cleaned
-    let cnt: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mem_entity_links WHERE memory_id = ?")
+    let cnt: i64 = sqlx::query_scalar(&format!(
+        "SELECT COUNT(*) FROM {} WHERE memory_id = ?",
+        user_store.t("mem_entity_links")
+    ))
         .bind(&old_mid)
-        .fetch_one(&pool)
+        .fetch_one(user_store.pool())
         .await
         .unwrap();
     assert_eq!(
@@ -6650,13 +6570,14 @@ async fn test_remote_correct_cleans_graph_and_entity_links() {
 async fn test_remote_correct_by_query_cleans_graph_and_entity_links() {
     use memoria_mcp::remote::RemoteClient;
 
-    let (base, _client, pool) = spawn_server_with_pool().await;
+    let (base, _client, server) = spawn_server_with_pool().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
+    let user_store = server.user_store(&uid).await;
 
     let old_mid = remote_store_with_links(
         &remote,
-        &pool,
+        &user_store,
         &uid,
         "remote_correct_query_graph_xyz unique content",
     )
@@ -6680,15 +6601,18 @@ async fn test_remote_correct_by_query_cleans_graph_and_entity_links() {
 
     // If corrected, old graph should be cleaned
     if text.contains("Corrected") {
-        let cnt: i64 = graph_node_active_count(&pool, &old_mid).await;
+        let cnt: i64 = graph_node_active_count(&user_store, &old_mid).await;
         assert_eq!(
             cnt, 0,
             "old graph node should be deactivated after remote correct by query"
         );
         let cnt: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM mem_entity_links WHERE memory_id = ?")
+            sqlx::query_scalar(&format!(
+                "SELECT COUNT(*) FROM {} WHERE memory_id = ?",
+                user_store.t("mem_entity_links")
+            ))
                 .bind(&old_mid)
-                .fetch_one(&pool)
+                .fetch_one(user_store.pool())
                 .await
                 .unwrap();
         assert_eq!(
@@ -6703,37 +6627,20 @@ async fn test_remote_correct_by_query_cleans_graph_and_entity_links() {
 // ── Streamable HTTP MCP endpoint (/mcp) ──────────────────────────────────────
 
 /// Spawn a server that requires a Bearer master key (for auth tests).
-async fn spawn_server_with_key(master_key: &str) -> (String, reqwest::Client) {
-    use memoria_git::GitForDataService;
-    use memoria_service::{Config, MemoryService};
-    use memoria_storage::SqlMemoryStore;
-    use sqlx::mysql::MySqlPool;
-
-    let cfg = Config::from_env();
-    let db = db_url();
-
-    let store = SqlMemoryStore::connect(&db, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let pool = MySqlPool::connect(&db).await.expect("pool");
-    let git = Arc::new(GitForDataService::new(pool, &cfg.db_name));
-    let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    let state = memoria_api::AppState::new(service, git, master_key.to_string());
-
-    let app = memoria_api::build_router(state);
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind");
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move { axum::serve(listener, app).await });
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .expect("client");
-    (format!("http://127.0.0.1:{port}"), client)
+async fn spawn_server_with_key(
+    master_key: &str,
+) -> (String, reqwest::Client, support::multi_db::ApiTestServer) {
+    let server = support::multi_db::spawn_api_server(
+        "api_e2e_mcp_key",
+        test_dim(),
+        master_key.to_string(),
+        None,
+        None,
+        None,
+        false,
+    )
+    .await;
+    (server.base.clone(), server.client.clone(), server)
 }
 
 /// POST /mcp helper: sends a JSON-RPC request and returns the parsed response.
@@ -6764,7 +6671,7 @@ fn mcp_result_text(resp: &Value) -> &str {
 
 #[tokio::test]
 async fn test_mcp_initialize() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let resp = mcp_post_with_headers(
@@ -6789,7 +6696,7 @@ async fn test_mcp_initialize() {
 
 #[tokio::test]
 async fn test_mcp_tools_list() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let resp = mcp_post_with_headers(
@@ -6818,7 +6725,7 @@ async fn test_mcp_tools_list() {
 
 #[tokio::test]
 async fn test_mcp_tools_call_memory_store() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let resp = mcp_post_with_headers(
@@ -6851,7 +6758,7 @@ async fn test_mcp_tools_call_memory_store() {
 
 #[tokio::test]
 async fn test_mcp_memory_retrieve_filter_session_end_to_end() {
-    let (base, client, _pool) =
+    let (base, client, _server) =
         spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
             .await;
     let uid = uid();
@@ -6987,7 +6894,7 @@ async fn test_mcp_memory_retrieve_filter_session_end_to_end() {
 
 #[tokio::test]
 async fn test_mcp_tools_call_records_tool_usage() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
     let uid = uid();
 
     let resp = mcp_post_with_headers(
@@ -7032,7 +6939,7 @@ async fn test_mcp_tools_call_records_tool_usage() {
 
 #[tokio::test]
 async fn test_mcp_invalid_json_returns_parse_error() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
 
     let resp: Value = client
         .post(format!("{base}/mcp"))
@@ -7054,7 +6961,7 @@ async fn test_mcp_invalid_json_returns_parse_error() {
 
 #[tokio::test]
 async fn test_mcp_invalid_request_non_object() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
 
     // A JSON array is valid JSON but not a JSON-RPC object → -32600
     let resp: Value = client
@@ -7080,7 +6987,7 @@ async fn test_mcp_invalid_request_non_object() {
 
 #[tokio::test]
 async fn test_mcp_invalid_request_wrong_version() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
 
     // jsonrpc != "2.0" → -32600
     let resp: Value = client
@@ -7105,7 +7012,7 @@ async fn test_mcp_invalid_request_wrong_version() {
 
 #[tokio::test]
 async fn test_mcp_invalid_request_missing_method() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
 
     // No method field → -32600 (not mistaken for a Notification)
     let resp: Value = client
@@ -7130,7 +7037,7 @@ async fn test_mcp_invalid_request_missing_method() {
 
 #[tokio::test]
 async fn test_mcp_auth_required_when_master_key_set() {
-    let (base, client) = spawn_server_with_key("test-master-secret").await;
+    let (base, client, _server) = spawn_server_with_key("test-master-secret").await;
 
     // No Authorization header → 401
     let status = client
@@ -7181,7 +7088,7 @@ async fn test_mcp_auth_required_when_master_key_set() {
 
 #[tokio::test]
 async fn test_mcp_notifications_initialized_no_error() {
-    let (base, client) = spawn_server().await;
+    let (base, client, _server) = spawn_server().await;
 
     // JSON-RPC 2.0: a Notification has no "id" field.
     // The server MUST NOT reply — expected HTTP 204 No Content with no body.

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -1113,7 +1113,15 @@ async fn test_api_key_cannot_get_other_users_memory() {
         .send()
         .await
         .unwrap();
-    assert_eq!(r.status(), 403, "non-owner API key must get 403");
+    assert_eq!(
+        r.status(),
+        200,
+        "non-owner API key must see the same response as a missing memory"
+    );
+    assert!(
+        r.json::<Value>().await.unwrap().is_null(),
+        "foreign memory reads must not reveal existence"
+    );
 }
 
 #[tokio::test]
@@ -1148,7 +1156,11 @@ async fn test_api_key_cannot_correct_other_users_memory() {
         .send()
         .await
         .unwrap();
-    assert_eq!(r.status(), 403, "non-owner API key must get 403");
+    assert_eq!(
+        r.status(),
+        404,
+        "non-owner API key must see the same response as a missing memory"
+    );
 }
 
 #[tokio::test]
@@ -1215,7 +1227,11 @@ async fn test_api_key_cannot_delete_other_users_memory() {
         .send()
         .await
         .unwrap();
-    assert_eq!(r.status(), 403, "non-owner API key must get 403 on delete");
+    assert_eq!(
+        r.status(),
+        404,
+        "non-owner API key must see the same response as a missing memory on delete"
+    );
 }
 
 // ── 10b-5. cross-user list isolation ─────────────────────────────────────────

--- a/memoria/crates/memoria-api/tests/pool_isolation.rs
+++ b/memoria/crates/memoria-api/tests/pool_isolation.rs
@@ -6,75 +6,36 @@
 //!
 //! Run: DATABASE_URL="mysql://root:111@localhost:6001/memoria" cargo test --test pool_isolation -- --nocapture
 
-use serde_json::json;
-use std::sync::Arc;
+mod support;
 
-fn db_url() -> String {
-    std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string())
-}
+use serde_json::json;
 
 fn uid() -> String {
     format!("pool_test_{}", uuid::Uuid::new_v4().simple())
 }
 
-/// Spawn server with a tiny main pool (2 connections) to make saturation easy.
-async fn spawn_tiny_pool_server() -> (String, reqwest::Client, sqlx::MySqlPool) {
-    use memoria_git::GitForDataService;
-    use memoria_service::MemoryService;
-    use memoria_storage::SqlMemoryStore;
-    use sqlx::mysql::MySqlPool;
+/// Spawn server with a tiny routed user pool (2 connections) to make saturation easy.
+async fn spawn_tiny_pool_server() -> (
+    String,
+    reqwest::Client,
+    sqlx::MySqlPool,
+    support::multi_db::ApiTestServer,
+) {
+    unsafe {
+        std::env::set_var("MEMORIA_GLOBAL_USER_POOL_MAX", "2");
+        std::env::set_var("MEMORIA_USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS", "1");
+    }
 
-    let db = db_url();
-    memoria_test_utils::wait_for_mysql_ready(&db, std::time::Duration::from_secs(30)).await;
-
-    // Create store with only 2 main pool connections
-    let pool = sqlx::mysql::MySqlPoolOptions::new()
-        .max_connections(2)
-        .acquire_timeout(std::time::Duration::from_secs(3))
-        .connect(&db)
-        .await
-        .expect("pool");
-
-    let store = SqlMemoryStore::from_existing_pool(
-        pool.clone(),
-        1024,
-        uuid::Uuid::new_v4().to_string(),
-        Some(db.clone()),
-        Some(2),
-        "pool_isolation_test_pool",
-    );
-    store.migrate().await.expect("migrate");
-
-    let raw_pool = MySqlPool::connect(&db).await.expect("git pool");
-    let suffix_start = db.find(['?', '#']).unwrap_or(db.len());
-    let db_name = db[..suffix_start]
-        .rsplit_once('/')
-        .map(|(_, n)| n)
-        .unwrap_or("memoria");
-    let git = Arc::new(GitForDataService::new(raw_pool, db_name));
-    let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    let state = memoria_api::AppState::new(service, git, String::new());
-    let app = memoria_api::build_router(state);
-
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind");
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move { axum::serve(listener, app).await });
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .expect("client");
-    let base = format!("http://127.0.0.1:{port}");
-    (base, client, pool)
+    let server =
+        support::multi_db::spawn_api_server("pool_isolation", 1024, String::new(), None, None, None, false)
+            .await;
+    let pool = server.router().global_user_pool().clone();
+    (server.base.clone(), server.client.clone(), pool, server)
 }
 
 #[tokio::test]
 async fn test_api_survives_main_pool_saturation() {
-    let (base, client, pool) = spawn_tiny_pool_server().await;
+    let (base, client, pool, _server) = spawn_tiny_pool_server().await;
     let user = uid();
 
     // 1. First, store a memory while pool is healthy — should succeed
@@ -94,12 +55,13 @@ async fn test_api_survives_main_pool_saturation() {
         res.status()
     );
 
-    // 2. Saturate the main pool: hold all 2 connections with SLEEP queries
+    // 2. Saturate the routed user pool: hold all 2 connections long enough to exceed
+    // the pool's 15s acquire timeout.
     let mut blockers = Vec::new();
     for _ in 0..2 {
         let p = pool.clone();
         blockers.push(tokio::spawn(async move {
-            let _ = sqlx::query("SELECT SLEEP(4)").execute(&p).await;
+            let _ = sqlx::query("SELECT SLEEP(20)").execute(&p).await;
         }));
     }
     // Give blockers time to acquire connections

--- a/memoria/crates/memoria-api/tests/pool_isolation.rs
+++ b/memoria/crates/memoria-api/tests/pool_isolation.rs
@@ -9,9 +9,54 @@
 mod support;
 
 use serde_json::json;
+use std::{
+    future::Future,
+    sync::{Mutex, OnceLock},
+};
 
 fn uid() -> String {
     format!("pool_test_{}", uuid::Uuid::new_v4().simple())
+}
+
+async fn with_env_async<F, Fut, T>(vars: &[(&str, Option<&str>)], f: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = T>,
+{
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    let _lock = ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
+    struct EnvGuard(Vec<(String, Option<std::ffi::OsString>)>);
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, old) in &self.0 {
+                match old {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+            }
+        }
+    }
+
+    let _restore = EnvGuard(
+        vars.iter()
+            .map(|(key, value)| {
+                let old = std::env::var_os(key);
+                match value {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+                (key.to_string(), old)
+            })
+            .collect(),
+    );
+
+    f().await
 }
 
 /// Spawn server with a tiny routed user pool (2 connections) to make saturation easy.
@@ -21,16 +66,27 @@ async fn spawn_tiny_pool_server() -> (
     sqlx::MySqlPool,
     support::multi_db::ApiTestServer,
 ) {
-    unsafe {
-        std::env::set_var("MEMORIA_GLOBAL_USER_POOL_MAX", "2");
-        std::env::set_var("MEMORIA_USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS", "1");
-    }
-
-    let server =
-        support::multi_db::spawn_api_server("pool_isolation", 1024, String::new(), None, None, None, false)
+    with_env_async(
+        &[
+            ("MEMORIA_GLOBAL_USER_POOL_MAX", Some("2")),
+            ("MEMORIA_USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS", Some("1")),
+        ],
+        || async {
+            let server = support::multi_db::spawn_api_server(
+                "pool_isolation",
+                1024,
+                String::new(),
+                None,
+                None,
+                None,
+                false,
+            )
             .await;
-    let pool = server.router().global_user_pool().clone();
-    (server.base.clone(), server.client.clone(), pool, server)
+            let pool = server.router().global_user_pool().clone();
+            (server.base.clone(), server.client.clone(), pool, server)
+        },
+    )
+    .await
 }
 
 #[tokio::test]

--- a/memoria/crates/memoria-api/tests/support/mod.rs
+++ b/memoria/crates/memoria-api/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub mod multi_db;

--- a/memoria/crates/memoria-api/tests/support/multi_db.rs
+++ b/memoria/crates/memoria-api/tests/support/multi_db.rs
@@ -1,0 +1,159 @@
+use std::sync::Arc;
+
+use memoria_core::interfaces::EmbeddingProvider;
+use memoria_embedding::LlmClient;
+use memoria_git::GitForDataService;
+use memoria_service::MemoryService;
+use memoria_storage::{DbRouter, SqlMemoryStore};
+use memoria_test_utils::MultiDbTestContext;
+use sqlx::MySqlPool;
+
+pub struct ApiTestServer {
+    pub base: String,
+    pub client: reqwest::Client,
+    context: Option<MultiDbTestContext>,
+    shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    server_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl ApiTestServer {
+    pub fn service(&self) -> Arc<MemoryService> {
+        self.context.as_ref().expect("context").service()
+    }
+
+    pub fn git(&self) -> Arc<GitForDataService> {
+        self.context.as_ref().expect("context").git()
+    }
+
+    pub fn router(&self) -> Arc<DbRouter> {
+        self.context.as_ref().expect("context").router()
+    }
+
+    pub fn shared_pool(&self) -> MySqlPool {
+        self.context.as_ref().expect("context").shared_pool()
+    }
+
+    pub fn shared_store(&self) -> Arc<SqlMemoryStore> {
+        self.context.as_ref().expect("context").shared_store()
+    }
+
+    pub fn shared_table(&self, table: &str) -> String {
+        self.context.as_ref().expect("context").shared_table(table)
+    }
+
+    pub fn shared_db_url(&self) -> &str {
+        self.context.as_ref().expect("context").shared_db_url()
+    }
+
+    pub async fn user_store(&self, user_id: &str) -> Arc<SqlMemoryStore> {
+        self.context.as_ref().expect("context").user_store(user_id).await
+    }
+
+    pub async fn user_table(&self, user_id: &str, table: &str) -> String {
+        self.context.as_ref().expect("context").user_table(user_id, table).await
+    }
+
+    pub async fn user_db_name(&self, user_id: &str) -> String {
+        self.context.as_ref().expect("context").user_db_name(user_id).await
+    }
+
+    pub async fn user_db_pool(&self, user_id: &str) -> MySqlPool {
+        self.context.as_ref().expect("context").user_db_pool(user_id).await
+    }
+}
+
+impl Drop for ApiTestServer {
+    fn drop(&mut self) {
+        let shutdown_tx = self.shutdown_tx.take();
+        let server_handle = self.server_handle.take();
+        let context = self.context.take();
+
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                if let Some(tx) = shutdown_tx {
+                    let _ = tx.send(());
+                }
+                if let Some(server_handle) = server_handle {
+                    let _ = server_handle.await;
+                }
+                drop(context);
+            });
+        }
+    }
+}
+
+pub async fn spawn_api_server(
+    db_name_prefix: &str,
+    embedding_dim: usize,
+    master_key: String,
+    embedder: Option<Arc<dyn EmbeddingProvider>>,
+    llm: Option<Arc<LlmClient>>,
+    instance_id: Option<String>,
+    init_auth_pool: bool,
+) -> ApiTestServer {
+    let context =
+        MultiDbTestContext::new(&db_url(), db_name_prefix, embedding_dim, embedder, llm).await;
+    let mut state = memoria_api::AppState::new(context.service(), context.git(), master_key);
+    if let Some(instance_id) = instance_id {
+        state = state.with_instance_id(instance_id);
+    }
+    if init_auth_pool {
+        state = state
+            .init_auth_pool(context.shared_db_url(), false)
+            .await
+            .expect("init auth pool");
+    }
+
+    let app = memoria_api::build_router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let port = listener.local_addr().expect("local addr").port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("serve api test app");
+    });
+
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("client");
+    let base = format!("http://127.0.0.1:{port}");
+    wait_for_server(&client, &base, &context.shared_pool()).await;
+
+    ApiTestServer {
+        base,
+        client,
+        context: Some(context),
+        shutdown_tx: Some(shutdown_tx),
+        server_handle: Some(server_handle),
+    }
+}
+
+pub async fn wait_for_server(client: &reqwest::Client, base: &str, pool: &MySqlPool) {
+    for _ in 0..20 {
+        if client.get(format!("{base}/health")).send().await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+
+    for _ in 0..20 {
+        if sqlx::query("SELECT 1").execute(pool).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+
+    panic!("DB not ready after 1s");
+}
+
+fn db_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string())
+}

--- a/memoria/crates/memoria-mcp/tests/branch_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/branch_e2e.rs
@@ -9,9 +9,10 @@ use memoria_embedding::MockEmbedder;
 ///
 /// Run: DATABASE_URL=mysql://root:111@localhost:6001/memoria \
 ///      cargo test -p memoria-mcp --test branch_e2e -- --test-threads=1 --nocapture
+mod support;
+
 use memoria_git::GitForDataService;
 use memoria_service::MemoryService;
-use memoria_storage::SqlMemoryStore;
 use serde_json::{json, Value};
 use sqlx::{mysql::MySqlPool, Row};
 use std::sync::Arc;
@@ -24,10 +25,6 @@ fn test_dim() -> usize {
         .unwrap_or(1024)
 }
 
-fn db_url() -> String {
-    std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string())
-}
 fn uid() -> String {
     format!("br_{}", &Uuid::new_v4().simple().to_string()[..8])
 }
@@ -35,16 +32,14 @@ fn bname(suffix: &str) -> String {
     format!("b{}_{suffix}", &Uuid::new_v4().simple().to_string()[..6])
 }
 
-async fn setup() -> (Arc<MemoryService>, Arc<GitForDataService>, String) {
-    let pool = MySqlPool::connect(&db_url()).await.expect("pool");
-    let db_name = db_url().rsplit('/').next().unwrap_or("memoria").to_string();
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("store");
-    store.migrate().await.expect("migrate");
-    let git = Arc::new(GitForDataService::new(pool, &db_name));
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    (svc, git, uid())
+async fn setup() -> (
+    Arc<MemoryService>,
+    Arc<GitForDataService>,
+    String,
+    support::multi_db::McpTestContext,
+) {
+    let ctx = support::multi_db::setup_mcp_context("branch_e2e", test_dim(), None, None).await;
+    (ctx.service(), ctx.git(), uid(), ctx)
 }
 
 async fn setup_with_mock_embedder() -> (
@@ -52,18 +47,15 @@ async fn setup_with_mock_embedder() -> (
     Arc<GitForDataService>,
     MySqlPool,
     String,
+    support::multi_db::McpTestContext,
 ) {
-    let pool = MySqlPool::connect(&db_url()).await.expect("pool");
-    let db_name = db_url().rsplit('/').next().unwrap_or("memoria").to_string();
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("store");
-    store.migrate().await.expect("migrate");
-    let git = Arc::new(GitForDataService::new(pool.clone(), &db_name));
     let embedder: Option<Arc<dyn EmbeddingProvider>> =
         Some(Arc::new(MockEmbedder::new(test_dim())));
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), embedder, None).await);
-    (svc, git, pool, uid())
+    let ctx =
+        support::multi_db::setup_mcp_context("branch_e2e_mock", test_dim(), embedder, None).await;
+    let uid = uid();
+    let pool = ctx.user_db_pool(&uid).await;
+    (ctx.service(), ctx.git(), pool, uid, ctx)
 }
 
 async fn gc(
@@ -90,7 +82,7 @@ fn text(v: &Value) -> &str {
 
 #[tokio::test]
 async fn test_basic_branch_workflow() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("basic");
 
     store_mem("main memory", &svc, &uid).await;
@@ -131,7 +123,7 @@ async fn test_basic_branch_workflow() {
 
 #[tokio::test]
 async fn test_merge_accept_alias() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("accept");
 
     store_mem("main memory", &svc, &uid).await;
@@ -168,7 +160,7 @@ async fn test_merge_accept_alias() {
 
 #[tokio::test]
 async fn test_merge_replace_updates_conflicting_memory() {
-    let (svc, git, pool, uid) = setup_with_mock_embedder().await;
+    let (svc, git, pool, uid, ctx) = setup_with_mock_embedder().await;
     let branch = bname("replace");
     let replacement = "branch replacement memory";
 
@@ -182,10 +174,9 @@ async fn test_merge_replace_updates_conflicting_memory() {
         .expect("original memory");
 
     gc("memory_branch", json!({"name": branch}), &git, &svc, &uid).await;
-    let branch_table = svc
-        .sql_store
-        .as_ref()
-        .expect("sql store")
+    let branch_table = ctx
+        .user_store(&uid)
+        .await
         .list_branches(&uid)
         .await
         .unwrap()
@@ -257,7 +248,7 @@ async fn test_merge_replace_updates_conflicting_memory() {
 
 #[tokio::test]
 async fn test_diff_before_merge() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("diff");
 
     store_mem("shared memory", &svc, &uid).await;
@@ -290,7 +281,7 @@ async fn test_diff_before_merge() {
 
 #[tokio::test]
 async fn test_diff_no_changes() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("nochange");
 
     store_mem("existing memory", &svc, &uid).await;
@@ -315,7 +306,7 @@ async fn test_diff_no_changes() {
 
 #[tokio::test]
 async fn test_cannot_delete_main() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let r = gc(
         "memory_branch_delete",
         json!({"name": "main"}),
@@ -332,7 +323,7 @@ async fn test_cannot_delete_main() {
 
 #[tokio::test]
 async fn test_delete_nonexistent_branch() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let r = gc(
         "memory_branch_delete",
         json!({"name": "no_such_branch_xyz"}),
@@ -349,7 +340,7 @@ async fn test_delete_nonexistent_branch() {
 
 #[tokio::test]
 async fn test_checkout_nonexistent_branch() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let result = memoria_mcp::git_tools::call(
         "memory_checkout",
         json!({"name": "ghost_branch"}),
@@ -364,7 +355,7 @@ async fn test_checkout_nonexistent_branch() {
 
 #[tokio::test]
 async fn test_merge_unknown_strategy_rejected() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("badmerge");
 
     store_mem("main memory", &svc, &uid).await;
@@ -395,7 +386,7 @@ async fn test_merge_unknown_strategy_rejected() {
 
 #[tokio::test]
 async fn test_duplicate_branch_name_rejected() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("dup");
 
     gc("memory_branch", json!({"name": branch}), &git, &svc, &uid).await;
@@ -427,7 +418,7 @@ async fn test_duplicate_branch_name_rejected() {
 
 #[tokio::test]
 async fn test_branch_from_snapshot_and_timestamp_exclusive() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let r = gc(
         "memory_branch",
         json!({"name": "x", "from_snapshot": "snap1", "from_timestamp": "2026-01-01 00:00:00"}),
@@ -444,7 +435,7 @@ async fn test_branch_from_snapshot_and_timestamp_exclusive() {
 
 #[tokio::test]
 async fn test_branch_from_timestamp_future_rejected() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let r = gc(
         "memory_branch",
         json!({"name": bname("fut"), "from_timestamp": "2099-01-01 00:00:00"}),
@@ -461,7 +452,7 @@ async fn test_branch_from_timestamp_future_rejected() {
 
 #[tokio::test]
 async fn test_branch_from_timestamp_too_old_rejected() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let r = gc(
         "memory_branch",
         json!({"name": bname("old"), "from_timestamp": "2020-01-01 00:00:00"}),
@@ -478,7 +469,7 @@ async fn test_branch_from_timestamp_too_old_rejected() {
 
 #[tokio::test]
 async fn test_branch_from_timestamp_invalid_format() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let result = memoria_mcp::git_tools::call(
         "memory_branch",
         json!({"name": bname("fmt"), "from_timestamp": "not-a-date"}),
@@ -495,16 +486,16 @@ async fn test_branch_from_timestamp_invalid_format() {
 
 #[tokio::test]
 async fn test_active_branch_resets_on_delete() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, ctx) = setup().await;
     let branch = bname("reset");
 
     gc("memory_branch", json!({"name": branch}), &git, &svc, &uid).await;
     gc("memory_checkout", json!({"name": branch}), &git, &svc, &uid).await;
 
     // Verify we're on branch
-    let sql = svc.sql_store.as_ref().unwrap();
+    let sql = ctx.user_store(&uid).await;
     let active = sql.active_table(&uid).await.unwrap();
-    assert_ne!(active, "mem_memories", "should be on branch table");
+    assert_ne!(active, sql.t("mem_memories"), "should be on branch table");
 
     // Delete branch while checked out
     gc(
@@ -525,7 +516,8 @@ async fn test_active_branch_resets_on_delete() {
     // Should auto-reset to main
     let active = sql.active_table(&uid).await.unwrap();
     assert_eq!(
-        active, "mem_memories",
+        active,
+        sql.t("mem_memories"),
         "should reset to main after branch delete"
     );
     println!("✅ active branch reset to main after delete");
@@ -535,7 +527,7 @@ async fn test_active_branch_resets_on_delete() {
 
 #[tokio::test]
 async fn test_multiuser_branch_isolation() {
-    let (svc, git, _) = setup().await;
+    let (svc, git, _, _ctx) = setup().await;
     let uid_a = uid();
     let uid_b = uid();
     let branch_a = bname("ua");
@@ -636,7 +628,7 @@ async fn test_multiuser_branch_isolation() {
 
 #[tokio::test]
 async fn test_branches_list_shows_active_marker() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let b1 = bname("list1");
     let b2 = bname("list2");
 
@@ -680,7 +672,7 @@ async fn test_branches_list_shows_active_marker() {
 
 #[tokio::test]
 async fn test_merge_idempotent() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("idem");
 
     gc("memory_branch", json!({"name": branch}), &git, &svc, &uid).await;
@@ -713,7 +705,7 @@ async fn test_merge_idempotent() {
 
 #[tokio::test]
 async fn test_merge_nonexistent_branch_errors() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let result = memoria_mcp::git_tools::call(
         "memory_merge",
         json!({"source": "ghost_branch_xyz"}),
@@ -730,7 +722,7 @@ async fn test_merge_nonexistent_branch_errors() {
 
 #[tokio::test]
 async fn test_diff_nonexistent_branch_errors() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let result = memoria_mcp::git_tools::call(
         "memory_diff",
         json!({"source": "ghost_xyz"}),
@@ -747,7 +739,7 @@ async fn test_diff_nonexistent_branch_errors() {
 
 #[tokio::test]
 async fn test_branch_name_sanitization() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     // Name with spaces/dashes — should be sanitized and created successfully
     let r = gc(
         "memory_branch",
@@ -774,7 +766,7 @@ async fn test_branch_name_sanitization() {
 
 #[tokio::test]
 async fn test_diff_fields_complete() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, ctx) = setup().await;
     let branch = bname("fields");
 
     store_mem("existing on main", &svc, &uid).await;
@@ -794,15 +786,21 @@ async fn test_diff_fields_complete() {
     gc("memory_checkout", json!({"name": "main"}), &git, &svc, &uid).await;
 
     // Use GitForDataService directly to check DiffRow fields
-    let sql = svc.sql_store.as_ref().unwrap();
+    let sql = ctx.user_store(&uid).await;
     let branches = sql.list_branches(&uid).await.unwrap();
     let table = branches
         .iter()
         .find(|(n, _)| n == &branch)
         .map(|(_, t)| t.clone())
         .unwrap();
+    let user_git = GitForDataService::new(
+        sql.pool().clone(),
+        sql.database_name()
+            .expect("user db name")
+            .to_string(),
+    );
 
-    let rows = git
+    let rows = user_git
         .diff_branch_rows(&table, "mem_memories", &uid, 50)
         .await
         .unwrap();
@@ -820,7 +818,7 @@ async fn test_diff_fields_complete() {
     );
 
     // Native count >= 1 (may include other users' changes)
-    let count = git
+    let count = user_git
         .diff_branch_count(&table, "mem_memories", &uid)
         .await
         .unwrap();
@@ -841,7 +839,7 @@ async fn test_diff_fields_complete() {
 
 #[tokio::test]
 async fn test_diff_limit_truncation() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("trunc");
 
     gc("memory_branch", json!({"name": branch}), &git, &svc, &uid).await;
@@ -884,7 +882,7 @@ async fn test_diff_limit_truncation() {
 
 #[tokio::test]
 async fn test_diff_native_count_vs_join_rows() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, ctx) = setup().await;
     let branch = bname("countvsrows");
 
     // Store 2 memories on main
@@ -900,23 +898,29 @@ async fn test_diff_native_count_vs_join_rows() {
 
     gc("memory_checkout", json!({"name": "main"}), &git, &svc, &uid).await;
 
-    let sql = svc.sql_store.as_ref().unwrap();
+    let sql = ctx.user_store(&uid).await;
     let branches = sql.list_branches(&uid).await.unwrap();
     let table = branches
         .iter()
         .find(|(n, _)| n == &branch)
         .map(|(_, t)| t.clone())
         .unwrap();
+    let user_git = GitForDataService::new(
+        sql.pool().clone(),
+        sql.database_name()
+            .expect("user db name")
+            .to_string(),
+    );
 
     // Native count: >= 1 (account-level, may include other users)
-    let count = git
+    let count = user_git
         .diff_branch_count(&table, "mem_memories", &uid)
         .await
         .unwrap();
     assert!(count >= 1, "native LCA diff count should be at least 1");
 
     // Find our specific row
-    let rows = git
+    let rows = user_git
         .diff_branch_rows(&table, "mem_memories", &uid, 50)
         .await
         .unwrap();
@@ -943,7 +947,7 @@ async fn test_diff_native_count_vs_join_rows() {
 
 #[tokio::test]
 async fn test_correct_on_branch_isolated_from_main() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("correctiso");
 
     // Store on main
@@ -1012,7 +1016,7 @@ async fn test_correct_on_branch_isolated_from_main() {
 
 #[tokio::test]
 async fn test_purge_on_branch_isolated_from_main() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("purgeiso");
 
     // Store on main
@@ -1061,7 +1065,7 @@ async fn test_purge_on_branch_isolated_from_main() {
 
 #[tokio::test]
 async fn test_purge_by_topic_on_branch_isolated_from_main() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("topiciso");
 
     // Store on main
@@ -1115,7 +1119,7 @@ async fn test_purge_by_topic_on_branch_isolated_from_main() {
 
 #[tokio::test]
 async fn test_purge_batch_on_branch_isolated_from_main() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("batchiso");
 
     // Store two memories on main
@@ -1168,7 +1172,7 @@ async fn test_purge_batch_on_branch_isolated_from_main() {
 
 #[tokio::test]
 async fn test_correct_blocks_sensitive_content() {
-    let (svc, _git, uid) = setup().await;
+    let (svc, _git, uid, _ctx) = setup().await;
 
     // Store a normal memory
     store_mem("database config info", &svc, &uid).await;
@@ -1206,7 +1210,7 @@ async fn test_correct_blocks_sensitive_content() {
 
 #[tokio::test]
 async fn test_correct_triggers_entity_extraction() {
-    let (svc, _git, uid) = setup().await;
+    let (svc, _git, uid, _ctx) = setup().await;
 
     // Store a memory with an entity
     store_mem("Project uses PostgreSQL database", &svc, &uid).await;
@@ -1264,7 +1268,7 @@ async fn test_correct_triggers_entity_extraction() {
 
 #[tokio::test]
 async fn test_get_for_user_finds_branch_only_memory() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("getuser");
 
     // Create branch, checkout, store a branch-only memory
@@ -1289,10 +1293,10 @@ async fn test_get_for_user_finds_branch_only_memory() {
     assert_eq!(found.unwrap().content, "branch-only secret");
 
     // plain get() should NOT find it (hardcoded to mem_memories)
-    let not_found = svc.get(&branch_mid).await.unwrap();
+    let plain_get = svc.get(&branch_mid).await;
     assert!(
-        not_found.is_none(),
-        "plain get() should not find branch-only memory"
+        plain_get.is_err() || plain_get.unwrap().is_none(),
+        "plain get() should not resolve branch-only memory in multi-db"
     );
 
     println!("✅ get_for_user finds branch-only memory, get() does not");
@@ -1312,7 +1316,7 @@ async fn test_get_for_user_finds_branch_only_memory() {
 
 #[tokio::test]
 async fn test_micro_batch_entity_extraction() {
-    let (svc, _git, uid) = setup().await;
+    let (svc, _git, uid, _ctx) = setup().await;
 
     // Burst-write 10 memories with distinct entities — should trigger micro-batching
     let contents = [
@@ -1361,7 +1365,7 @@ async fn test_micro_batch_entity_extraction() {
 
 #[tokio::test]
 async fn test_batch_entity_deduplication_across_memories() {
-    let (svc, _git, uid) = setup().await;
+    let (svc, _git, uid, ctx) = setup().await;
 
     // Multiple memories mention the same entity — should deduplicate in batch
     store_mem("Rust is great for systems programming", &svc, &uid).await;
@@ -1371,7 +1375,7 @@ async fn test_batch_entity_deduplication_across_memories() {
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
     // Check that "rust" entity exists only once
-    let sql = svc.sql_store.as_ref().expect("sql_store");
+    let sql = ctx.user_store(&uid).await;
     let graph = sql.graph_store();
     let entities = graph.get_user_entities(&uid).await.unwrap();
 

--- a/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
@@ -5,8 +5,9 @@
 ///
 /// Run: DATABASE_URL=mysql://root:111@localhost:6001/memoria \
 ///      cargo test -p memoria-mcp --test core_tools_e2e -- --nocapture
+mod support;
+
 use memoria_service::MemoryService;
-use memoria_storage::SqlMemoryStore;
 use serde_json::{json, Value};
 use sqlx::Row;
 use std::sync::Arc;
@@ -17,10 +18,6 @@ fn test_dim() -> usize {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(1024)
-}
-fn db_url() -> String {
-    std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string())
 }
 fn uid() -> String {
     format!("ct_{}", &Uuid::new_v4().simple().to_string()[..8])
@@ -33,13 +30,9 @@ async fn spawn_fake_llm() -> (
     memoria_test_utils::spawn_fake_llm(vec![]).await
 }
 
-async fn setup() -> (Arc<MemoryService>, String) {
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    (svc, uid())
+async fn setup() -> (Arc<MemoryService>, String, support::multi_db::McpTestContext) {
+    let ctx = support::multi_db::setup_mcp_context("core_tools_e2e", test_dim(), None, None).await;
+    (ctx.service(), uid(), ctx)
 }
 
 async fn call(name: &str, args: Value, svc: &Arc<MemoryService>, uid: &str) -> Value {
@@ -55,7 +48,7 @@ fn text(v: &Value) -> &str {
 
 #[tokio::test]
 async fn test_store_all_memory_types() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     for mt in &[
         "semantic",
         "profile",
@@ -86,7 +79,7 @@ async fn test_store_all_memory_types() {
 
 #[tokio::test]
 async fn test_store_session_and_trust_tier() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let r = call(
         "memory_store",
         json!({"content": "session memory", "session_id": "sess-abc", "trust_tier": "T1"}),
@@ -97,7 +90,7 @@ async fn test_store_session_and_trust_tier() {
     let t = text(&r);
     assert!(t.contains("Stored"), "{t}");
     let mid = t.split_whitespace().nth(2).unwrap().trim_end_matches(':');
-    let m = svc.get(mid).await.unwrap().unwrap();
+    let m = svc.get_for_user(&uid, mid).await.unwrap().unwrap();
     assert_eq!(m.session_id.as_deref(), Some("sess-abc"));
     assert_eq!(m.trust_tier.to_string(), "T1");
     println!(
@@ -108,7 +101,7 @@ async fn test_store_session_and_trust_tier() {
 
 #[tokio::test]
 async fn test_store_rejects_invalid_trust_tier() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let err = memoria_mcp::tools::call(
         "memory_store",
         json!({"content": "bad tier memory", "trust_tier": "verified"}),
@@ -130,7 +123,7 @@ async fn test_store_rejects_invalid_trust_tier() {
 
 #[tokio::test]
 async fn test_retrieve_finds_relevant() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     call(
         "memory_store",
         json!({"content": "rust ownership model"}),
@@ -161,7 +154,7 @@ async fn test_retrieve_finds_relevant() {
 
 #[tokio::test]
 async fn test_retrieve_empty() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let r = call(
         "memory_retrieve",
         json!({"query": "nothing here"}),
@@ -177,7 +170,7 @@ async fn test_retrieve_empty() {
 
 #[tokio::test]
 async fn test_search_top_k() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     for i in 0..5 {
         call(
             "memory_store",
@@ -204,7 +197,7 @@ async fn test_search_top_k() {
 
 #[tokio::test]
 async fn test_correct_by_id() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let stored = call(
         "memory_store",
         json!({"content": "old content"}),
@@ -239,12 +232,12 @@ async fn test_correct_by_id() {
     assert_ne!(new_mid, mid, "new memory should have different id");
 
     // New memory should have corrected content
-    let new = svc.get(new_mid).await.unwrap().unwrap();
+    let new = svc.get_for_user(&uid, new_mid).await.unwrap().unwrap();
     assert_eq!(new.content, "corrected content");
     assert!(new.is_active, "new memory should be active");
 
     // Old memory should be deactivated (get returns None for inactive)
-    let old = svc.get(&mid).await.unwrap();
+    let old = svc.get_for_user(&uid, &mid).await.unwrap();
     assert!(
         old.is_none(),
         "old memory should not be returned by get (deactivated)"
@@ -256,7 +249,7 @@ async fn test_correct_by_id() {
 
 #[tokio::test]
 async fn test_correct_by_query() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     call(
         "memory_store",
         json!({"content": "uses black for formatting"}),
@@ -276,7 +269,7 @@ async fn test_correct_by_query() {
 
 #[tokio::test]
 async fn test_correct_no_target() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let r = call(
         "memory_correct",
         json!({"new_content": "something"}),
@@ -296,7 +289,7 @@ async fn test_correct_no_target() {
 
 #[tokio::test]
 async fn test_correct_no_content() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let r = call(
         "memory_correct",
         json!({"memory_id": "some-id"}),
@@ -312,7 +305,7 @@ async fn test_correct_no_content() {
 
 #[tokio::test]
 async fn test_purge_single() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let stored = call("memory_store", json!({"content": "to delete"}), &svc, &uid).await;
     let mid = text(&stored)
         .split_whitespace()
@@ -323,7 +316,7 @@ async fn test_purge_single() {
 
     let r = call("memory_purge", json!({"memory_id": mid}), &svc, &uid).await;
     assert!(text(&r).contains("1"), "{}", text(&r));
-    assert!(svc.get(&mid).await.unwrap().is_none());
+    assert!(svc.get_for_user(&uid, &mid).await.unwrap().is_none());
     println!("✅ purge single: {}", text(&r));
 }
 
@@ -331,7 +324,7 @@ async fn test_purge_single() {
 
 #[tokio::test]
 async fn test_purge_batch() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let mut ids = vec![];
     for i in 0..3 {
         let r = call(
@@ -360,7 +353,7 @@ async fn test_purge_batch() {
 
 #[tokio::test]
 async fn test_purge_topic() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     call(
         "memory_store",
         json!({"content": "rust ownership rules"}),
@@ -400,7 +393,7 @@ async fn test_purge_topic() {
 
 #[tokio::test]
 async fn test_purge_session_id_with_memory_types() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let target_session = format!("session:test-smp-{}", Uuid::new_v4().simple());
     let other_session = format!("session:test-smp-{}", Uuid::new_v4().simple());
 
@@ -457,7 +450,7 @@ async fn test_purge_session_id_with_memory_types() {
 
 #[tokio::test]
 async fn test_purge_no_target() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let r = call("memory_purge", json!({}), &svc, &uid).await;
     assert!(
         text(&r).contains("memory_id") || text(&r).contains("topic"),
@@ -471,7 +464,7 @@ async fn test_purge_no_target() {
 
 #[tokio::test]
 async fn test_purge_short_topic() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     // 直接调用不会 panic 的版本
     let result = memoria_mcp::tools::call("memory_purge", json!({"topic": "ab"}), &svc, &uid).await;
     assert!(result.is_err(), "Should return error for short topic");
@@ -487,7 +480,7 @@ async fn test_purge_short_topic() {
 
 #[tokio::test]
 async fn test_profile() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     call(
         "memory_store",
         json!({"content": "prefers tabs", "memory_type": "profile"}),
@@ -525,7 +518,7 @@ async fn test_profile() {
 
 #[tokio::test]
 async fn test_profile_empty() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let r = call("memory_profile", json!({}), &svc, &uid).await;
     assert!(text(&r).contains("No profile"), "{}", text(&r));
     println!("✅ profile empty: {}", text(&r));
@@ -535,7 +528,7 @@ async fn test_profile_empty() {
 
 #[tokio::test]
 async fn test_list_limit_and_fields() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     for i in 0..5 {
         call(
             "memory_store",
@@ -561,7 +554,7 @@ async fn test_list_limit_and_fields() {
 
 #[tokio::test]
 async fn test_capabilities() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let r = call("memory_capabilities", json!({}), &svc, &uid).await;
     let t = text(&r);
     for tool in &[
@@ -606,7 +599,7 @@ async fn test_capabilities() {
 
 #[tokio::test]
 async fn test_unknown_tool_errors() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let result = memoria_mcp::tools::call("nonexistent", json!({}), &svc, &uid).await;
     assert!(result.is_err());
     println!("✅ unknown tool → error");
@@ -616,11 +609,12 @@ async fn test_unknown_tool_errors() {
 
 #[tokio::test]
 async fn test_governance_quarantine_and_cooldown() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, ctx) = setup().await;
 
     // Store a memory with very low initial_confidence (T4 = 0.4) and old observed_at
     // so effective_confidence = 0.4 * exp(-365/30) ≈ 0 < 0.2 threshold
-    let sql = svc.sql_store.as_ref().unwrap();
+    let _sql = ctx.user_store(&uid).await;
+    let pool = ctx.user_db_pool(&uid).await;
     let mid = format!("gov_{}", uuid::Uuid::new_v4().simple());
     sqlx::query(
         "INSERT INTO mem_memories (memory_id, user_id, memory_type, content, source_event_ids, \
@@ -630,7 +624,7 @@ async fn test_governance_quarantine_and_cooldown() {
     )
     .bind(&mid)
     .bind(&uid)
-    .execute(sql.pool())
+    .execute(&pool)
     .await
     .expect("insert old memory");
 
@@ -657,7 +651,7 @@ async fn test_governance_quarantine_and_cooldown() {
     let remaining: Vec<(String,)> =
         sqlx::query_as("SELECT memory_id FROM mem_memories WHERE memory_id = ?")
             .bind(&mid)
-            .fetch_all(sql.pool())
+            .fetch_all(&pool)
             .await
             .unwrap();
     assert!(
@@ -690,8 +684,9 @@ async fn test_governance_quarantine_and_cooldown() {
 
 #[tokio::test]
 async fn test_governance_cleanup_stale() {
-    let (svc, uid) = setup().await;
-    let sql = svc.sql_store.as_ref().unwrap();
+    let (svc, uid, ctx) = setup().await;
+    let _sql = ctx.user_store(&uid).await;
+    let pool = ctx.user_db_pool(&uid).await;
 
     // Insert a soft-deleted memory with very low confidence
     let mid = format!("stale_{}", uuid::Uuid::new_v4().simple());
@@ -703,7 +698,7 @@ async fn test_governance_cleanup_stale() {
     )
     .bind(&mid)
     .bind(&uid)
-    .execute(sql.pool())
+    .execute(&pool)
     .await
     .expect("insert stale");
 
@@ -718,7 +713,7 @@ async fn test_governance_cleanup_stale() {
     // Verify physically deleted
     let row = sqlx::query("SELECT COUNT(*) as cnt FROM mem_memories WHERE memory_id = ?")
         .bind(&mid)
-        .fetch_one(sql.pool())
+        .fetch_one(&pool)
         .await
         .expect("fetch");
     let cnt: i64 = row.try_get("cnt").unwrap_or(1);
@@ -730,7 +725,7 @@ async fn test_governance_cleanup_stale() {
 
 #[tokio::test]
 async fn test_consolidate_basic() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
 
     // First run should succeed
     let r = call("memory_consolidate", json!({"force": true}), &svc, &uid).await;
@@ -750,7 +745,7 @@ async fn test_consolidate_basic() {
 
 #[tokio::test]
 async fn test_reflect_candidates() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
 
     // Store a few memories first
     call(
@@ -781,7 +776,7 @@ async fn test_reflect_candidates() {
 
 #[tokio::test]
 async fn test_reflect_internal_unavailable() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let r = call("memory_reflect", json!({"mode": "internal"}), &svc, &uid).await;
     let t = text(&r);
     assert!(
@@ -795,7 +790,7 @@ async fn test_reflect_internal_unavailable() {
 
 #[tokio::test]
 async fn test_extract_and_link_entities() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
 
     // Store a memory
     let store_r = call(
@@ -878,7 +873,7 @@ async fn test_extract_and_link_entities() {
 
 #[tokio::test]
 async fn test_link_entities_invalid_json() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let r = call(
         "memory_link_entities",
         json!({"entities": "not json"}),
@@ -897,20 +892,17 @@ async fn test_link_entities_invalid_json() {
 /// Helper: create service with explicit LLM client (for testing LLM paths).
 async fn setup_with_llm(
     llm: Option<Arc<memoria_embedding::LlmClient>>,
-) -> (Arc<MemoryService>, String) {
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, llm).await);
-    (svc, uid())
+) -> (Arc<MemoryService>, String, support::multi_db::McpTestContext) {
+    let ctx =
+        support::multi_db::setup_mcp_context("core_tools_e2e_llm", test_dim(), None, llm).await;
+    (ctx.service(), uid(), ctx)
 }
 
 // ── 26. reflect without LLM returns candidates (not error) ───────────────────
 
 #[tokio::test]
 async fn test_reflect_no_llm_returns_candidates() {
-    let (svc, uid) = setup_with_llm(None).await;
+    let (svc, uid, _ctx) = setup_with_llm(None).await;
 
     // Store memories in two different "sessions" to create clusters
     call(
@@ -970,7 +962,7 @@ async fn test_reflect_no_llm_returns_candidates() {
 
 #[tokio::test]
 async fn test_reflect_candidates_mode_no_llm_needed() {
-    let (svc, uid) = setup_with_llm(None).await;
+    let (svc, uid, _ctx) = setup_with_llm(None).await;
     call(
         "memory_store",
         json!({"content": "Test memory for candidates mode"}),
@@ -1005,7 +997,7 @@ async fn test_reflect_candidates_mode_no_llm_needed() {
 
 #[tokio::test]
 async fn test_reflect_internal_no_llm_returns_error() {
-    let (svc, uid) = setup_with_llm(None).await;
+    let (svc, uid, _ctx) = setup_with_llm(None).await;
     let r = call("memory_reflect", json!({"mode": "internal"}), &svc, &uid).await;
     let t = text(&r);
     assert!(
@@ -1019,7 +1011,7 @@ async fn test_reflect_internal_no_llm_returns_error() {
 
 #[tokio::test]
 async fn test_extract_entities_no_llm_returns_candidates() {
-    let (svc, uid) = setup_with_llm(None).await;
+    let (svc, uid, _ctx) = setup_with_llm(None).await;
     call(
         "memory_store",
         json!({"content": "Project uses Rust and MatrixOne"}),
@@ -1052,7 +1044,7 @@ async fn test_extract_entities_no_llm_returns_candidates() {
 
 #[tokio::test]
 async fn test_extract_entities_internal_no_llm_returns_error() {
-    let (svc, uid) = setup_with_llm(None).await;
+    let (svc, uid, _ctx) = setup_with_llm(None).await;
     let r = call(
         "memory_extract_entities",
         json!({"mode": "internal"}),
@@ -1073,9 +1065,10 @@ async fn test_extract_entities_internal_no_llm_returns_error() {
 #[tokio::test]
 async fn test_reflect_with_llm_if_configured() {
     let (llm, _shutdown) = spawn_fake_llm().await;
-    let (svc, uid) = setup_with_llm(Some(llm)).await;
+    let (svc, uid, ctx) = setup_with_llm(Some(llm)).await;
+    let pool = ctx.user_db_pool(&uid).await;
 
-    let sql = svc.sql_store.as_ref().expect("sql store");
+    let sql = ctx.user_store(&uid).await;
     let graph = sql.graph_store();
     for (idx, content) in [
         "Uses Rust for backend",
@@ -1129,7 +1122,7 @@ async fn test_reflect_with_llm_if_configured() {
 
     let rows = sqlx::query("SELECT content FROM mem_memories WHERE user_id = ? AND is_active = 1")
         .bind(&uid)
-        .fetch_all(sql.pool())
+        .fetch_all(&pool)
         .await
         .unwrap();
     let contents: Vec<String> = rows
@@ -1150,7 +1143,7 @@ async fn test_reflect_with_llm_if_configured() {
 #[tokio::test]
 async fn test_extract_entities_with_llm_if_configured() {
     let (llm, _shutdown) = spawn_fake_llm().await;
-    let (svc, uid) = setup_with_llm(Some(llm)).await;
+    let (svc, uid, ctx) = setup_with_llm(Some(llm)).await;
 
     call(
         "memory_store",
@@ -1178,7 +1171,7 @@ async fn test_extract_entities_with_llm_if_configured() {
         "fake LLM should create entities: {t}"
     );
 
-    let sql = svc.sql_store.as_ref().expect("sql store");
+    let sql = ctx.user_store(&uid).await;
     let graph = sql.graph_store();
     let entities = graph.get_user_entities(&uid).await.unwrap();
     let names: Vec<String> = entities.iter().map(|(name, _)| name.clone()).collect();
@@ -1194,7 +1187,7 @@ async fn test_extract_entities_with_llm_if_configured() {
 
 #[tokio::test]
 async fn test_retrieve_fulltext_fallback() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     // Store a memory with a unique keyword
     call(
         "memory_store",
@@ -1223,7 +1216,7 @@ async fn test_retrieve_fulltext_fallback() {
 
 #[tokio::test]
 async fn test_search_top_k_zero() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     call(
         "memory_store",
         json!({"content": "topk zero test"}),
@@ -1251,7 +1244,7 @@ async fn test_search_top_k_zero() {
 
 #[tokio::test]
 async fn test_store_with_session_id_retrievable() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let sid = format!(
         "sess_{}",
         uuid::Uuid::new_v4().simple().to_string()[..8].to_string()
@@ -1282,7 +1275,7 @@ async fn test_store_with_session_id_retrievable() {
 
 #[tokio::test]
 async fn test_purge_topic_then_search_empty() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let tag = format!(
         "purgetopic_{}",
         uuid::Uuid::new_v4().simple().to_string()[..6].to_string()
@@ -1325,7 +1318,7 @@ async fn test_purge_topic_then_search_empty() {
 
 #[tokio::test]
 async fn test_retrieve_explain_mode() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     call(
         "memory_store",
         json!({"content": "explain test memory alpha"}),
@@ -1356,7 +1349,7 @@ async fn test_retrieve_explain_mode() {
 
 #[tokio::test]
 async fn test_retrieve_explain_empty() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     let r = call(
         "memory_retrieve",
         json!({"query": "nonexistent_xyz_123", "top_k": 5, "explain": true}),
@@ -1378,7 +1371,7 @@ async fn test_retrieve_explain_empty() {
 
 #[tokio::test]
 async fn test_search_explain_mode() {
-    let (svc, uid) = setup().await;
+    let (svc, uid, _ctx) = setup().await;
     call(
         "memory_store",
         json!({"content": "search explain test beta"}),

--- a/memoria/crates/memoria-mcp/tests/edit_log_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/edit_log_e2e.rs
@@ -4,9 +4,10 @@
 ///
 /// Run: DATABASE_URL=mysql://root:111@localhost:6001/memoria \
 ///      cargo test -p memoria-mcp --test edit_log_e2e -- --nocapture
+mod support;
+
 use memoria_git::GitForDataService;
 use memoria_service::{GovernanceStrategy, MemoryService};
-use memoria_storage::SqlMemoryStore;
 use serde_json::{json, Value};
 use serial_test::serial;
 use sqlx::mysql::MySqlPool;
@@ -22,27 +23,14 @@ fn test_dim() -> usize {
         .and_then(|s| s.parse().ok())
         .unwrap_or(1024)
 }
-fn db_url() -> String {
-    std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string())
-}
-fn test_db_name() -> String {
-    let db = db_url();
-    let suffix_start = db.find(['?', '#']).unwrap_or(db.len());
-    db[..suffix_start]
-        .rsplit('/')
-        .next()
-        .unwrap_or("memoria")
-        .to_string()
-}
 fn uid() -> String {
     format!("elog_{}", &Uuid::new_v4().simple().to_string()[..8])
 }
 
-fn safety_snapshot_prefix() -> String {
+fn safety_snapshot_prefix(db_name: &str) -> String {
     format!(
         "mem_snap_{}_pre_",
-        compact_identifier_fragment(&test_db_name(), 21)
+        compact_identifier_fragment(db_name, 21)
     )
 }
 
@@ -84,8 +72,8 @@ fn compact_identifier_fragment(value: &str, max_len: usize) -> String {
     format!("{head}_{tail}")
 }
 
-fn is_purge_safety_snapshot(name: &str) -> bool {
-    name.starts_with(&format!("{}purge_", safety_snapshot_prefix()))
+fn is_purge_safety_snapshot(db_name: &str, name: &str) -> bool {
+    name.starts_with(&format!("{}purge_", safety_snapshot_prefix(db_name)))
 }
 
 // ── Full edit-log row with ALL columns ────────────────────────────────────────
@@ -110,18 +98,15 @@ async fn setup() -> (
     Arc<GitForDataService>,
     MySqlPool,
     String,
+    String,
+    support::multi_db::McpTestContext,
 ) {
-    let pool = MySqlPool::connect(&db_url()).await.expect("pool");
-    let db_name = db_url().rsplit('/').next().unwrap_or("memoria").to_string();
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), Uuid::new_v4().to_string())
-        .await
-        .expect("store");
-    store.migrate().await.expect("migrate");
-    let git = Arc::new(GitForDataService::new(pool.clone(), &db_name));
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
+    let ctx = support::multi_db::setup_mcp_context("edit_log", test_dim(), None, None).await;
     let user_id = uid();
-    cleanup(&pool, &user_id).await;
-    (svc, git, pool, user_id)
+    let db_name = ctx.user_db_name(&user_id).await;
+    let pool = ctx.user_db_pool(&user_id).await;
+    cleanup(&pool, &user_id, &db_name).await;
+    (ctx.service(), ctx.git(), pool, user_id, db_name, ctx)
 }
 
 /// Setup with real embedder. Returns None if EMBEDDING_* env vars not set.
@@ -130,6 +115,8 @@ async fn setup_with_embedder() -> Option<(
     Arc<GitForDataService>,
     MySqlPool,
     String,
+    String,
+    support::multi_db::McpTestContext,
 )> {
     let base_url = std::env::var("EMBEDDING_BASE_URL").unwrap_or_default();
     let api_key = std::env::var("EMBEDDING_API_KEY").unwrap_or_default();
@@ -141,21 +128,16 @@ async fn setup_with_embedder() -> Option<(
     let embedder: Arc<dyn EmbeddingProvider> =
         Arc::new(HttpEmbedder::new(&base_url, &api_key, &model, dim));
 
-    let pool = MySqlPool::connect(&db_url()).await.expect("pool");
-    let db_name = db_url().rsplit('/').next().unwrap_or("memoria").to_string();
-    let store = SqlMemoryStore::connect(&db_url(), dim, Uuid::new_v4().to_string())
-        .await
-        .expect("store");
-    store.migrate().await.expect("migrate");
-    let git = Arc::new(GitForDataService::new(pool.clone(), &db_name));
-    let svc =
-        Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), Some(embedder), None).await);
+    let ctx =
+        support::multi_db::setup_mcp_context("edit_log_embedder", dim, Some(embedder), None).await;
     let user_id = uid();
-    cleanup(&pool, &user_id).await;
-    Some((svc, git, pool, user_id))
+    let db_name = ctx.user_db_name(&user_id).await;
+    let pool = ctx.user_db_pool(&user_id).await;
+    cleanup(&pool, &user_id, &db_name).await;
+    Some((ctx.service(), ctx.git(), pool, user_id, db_name, ctx))
 }
 
-async fn cleanup(pool: &MySqlPool, user_id: &str) {
+async fn cleanup(pool: &MySqlPool, user_id: &str, db_name: &str) {
     let _ = sqlx::query("DELETE FROM mem_edit_log WHERE user_id = ?")
         .bind(user_id)
         .execute(pool)
@@ -164,7 +146,7 @@ async fn cleanup(pool: &MySqlPool, user_id: &str) {
         .bind(user_id)
         .execute(pool)
         .await;
-    let prefix = safety_snapshot_prefix();
+    let prefix = safety_snapshot_prefix(db_name);
     let rows: Vec<(String,)> =
         sqlx::query_as("SELECT sname FROM mo_catalog.mo_snapshots WHERE prefix_eq(sname, ?)")
             .bind(prefix)
@@ -271,7 +253,7 @@ fn extract_mid(response: &Value) -> String {
 #[tokio::test]
 #[serial]
 async fn test_inject_all_fields() {
-    let (svc, _git, pool, uid) = setup().await;
+    let (svc, _git, pool, uid, db_name, _ctx) = setup().await;
 
     let r = call(
         "memory_store",
@@ -294,7 +276,7 @@ async fn test_inject_all_fields() {
     assert_eq!(row.reason.as_deref(), Some("store_memory"));
     assert!(row.snapshot_before.is_none());
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ inject: all fields verified");
 }
 
@@ -305,7 +287,7 @@ async fn test_inject_all_fields() {
 #[tokio::test]
 #[serial]
 async fn test_correct_all_fields() {
-    let (svc, _git, pool, uid) = setup().await;
+    let (svc, _git, pool, uid, db_name, _ctx) = setup().await;
 
     let r = call("memory_store", json!({"content": "uses black"}), &svc, &uid).await;
     let old_mid = extract_mid(&r);
@@ -333,7 +315,7 @@ async fn test_correct_all_fields() {
     assert_eq!(row.reason.as_deref(), Some(""));
     assert!(row.snapshot_before.is_none());
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ correct: all fields verified");
 }
 
@@ -344,7 +326,7 @@ async fn test_correct_all_fields() {
 #[tokio::test]
 #[serial]
 async fn test_purge_single_all_fields() {
-    let (svc, _git, pool, uid) = setup().await;
+    let (svc, _git, pool, uid, db_name, _ctx) = setup().await;
     ensure_snapshot_quota(&pool).await;
 
     let r = call("memory_store", json!({"content": "to delete"}), &svc, &uid).await;
@@ -372,7 +354,7 @@ async fn test_purge_single_all_fields() {
         .as_ref()
         .expect("snapshot_before should be set");
     assert!(
-        is_purge_safety_snapshot(snap),
+        is_purge_safety_snapshot(&db_name, snap),
         "unexpected snapshot name: {snap}"
     );
     let exists: Vec<(String,)> =
@@ -383,7 +365,7 @@ async fn test_purge_single_all_fields() {
             .unwrap();
     assert_eq!(exists.len(), 1, "safety snapshot should exist in DB");
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ purge single: all fields verified + snapshot exists");
 }
 
@@ -394,7 +376,7 @@ async fn test_purge_single_all_fields() {
 #[tokio::test]
 #[serial]
 async fn test_purge_batch_all_fields() {
-    let (svc, _git, pool, uid) = setup().await;
+    let (svc, _git, pool, uid, db_name, _ctx) = setup().await;
     ensure_snapshot_quota(&pool).await;
 
     let mut mids = vec![];
@@ -437,7 +419,7 @@ async fn test_purge_batch_all_fields() {
     }
     assert_eq!(edit_ids.len(), 3, "edit_ids should be unique");
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ purge batch: all fields verified");
 }
 
@@ -448,7 +430,7 @@ async fn test_purge_batch_all_fields() {
 #[tokio::test]
 #[serial]
 async fn test_purge_topic_all_fields() {
-    let (svc, _git, pool, uid) = setup().await;
+    let (svc, _git, pool, uid, db_name, _ctx) = setup().await;
     ensure_snapshot_quota(&pool).await;
 
     call(
@@ -492,7 +474,7 @@ async fn test_purge_topic_all_fields() {
         );
     }
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ purge topic: all fields verified");
 }
 
@@ -503,7 +485,7 @@ async fn test_purge_topic_all_fields() {
 #[tokio::test]
 #[serial]
 async fn test_store_batch_all_fields() {
-    let (svc, _git, pool, uid) = setup().await;
+    let (svc, _git, pool, uid, db_name, _ctx) = setup().await;
 
     let items = vec![
         (
@@ -547,7 +529,7 @@ async fn test_store_batch_all_fields() {
     assert!(log_types.contains(&"semantic".to_string()));
     assert!(log_types.contains(&"procedural".to_string()));
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ store_batch: all fields verified");
 }
 
@@ -558,7 +540,7 @@ async fn test_store_batch_all_fields() {
 #[tokio::test]
 #[serial]
 async fn test_full_audit_trail_chronological() {
-    let (svc, _git, pool, uid) = setup().await;
+    let (svc, _git, pool, uid, db_name, _ctx) = setup().await;
     ensure_snapshot_quota(&pool).await;
 
     let r = call(
@@ -618,7 +600,7 @@ async fn test_full_audit_trail_chronological() {
     let purge = logs.iter().find(|r| r.operation == "purge").unwrap();
     assert!(purge.snapshot_before.is_some());
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ full audit trail: chronological, all fields consistent");
 }
 
@@ -629,7 +611,7 @@ async fn test_full_audit_trail_chronological() {
 #[tokio::test]
 #[serial]
 async fn test_purge_rollback_restores_memory() {
-    let (svc, git, pool, uid) = setup().await;
+    let (svc, git, pool, uid, db_name, _ctx) = setup().await;
     ensure_snapshot_quota(&pool).await;
 
     let r = call(
@@ -679,7 +661,7 @@ async fn test_purge_rollback_restores_memory() {
     // correctly recorded by checking BEFORE rollback (already verified above
     // via the purge response containing the snapshot name).
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ rollback: memory restored, snapshot name verified");
 }
 
@@ -690,9 +672,11 @@ async fn test_purge_rollback_restores_memory() {
 #[tokio::test]
 #[serial]
 async fn test_user_isolation() {
-    let (svc, _git, pool, uid1) = setup().await;
+    let (svc, _git, pool, uid1, db_name, ctx) = setup().await;
     let uid2 = uid();
-    cleanup(&pool, &uid2).await;
+    let pool2 = ctx.user_db_pool(&uid2).await;
+    let db_name2 = ctx.user_db_name(&uid2).await;
+    cleanup(&pool2, &uid2, &db_name2).await;
 
     call(
         "memory_store",
@@ -711,7 +695,7 @@ async fn test_user_isolation() {
     svc.flush_edit_log().await;
 
     let logs1 = get_logs(&pool, &uid1).await;
-    let logs2 = get_logs(&pool, &uid2).await;
+    let logs2 = get_logs(&pool2, &uid2).await;
     assert_eq!(logs1.len(), 1);
     assert_eq!(logs2.len(), 1);
     for row in &logs1 {
@@ -723,8 +707,8 @@ async fn test_user_isolation() {
         assert_eq!(row.created_by, uid2);
     }
 
-    cleanup(&pool, &uid1).await;
-    cleanup(&pool, &uid2).await;
+    cleanup(&pool, &uid1, &db_name).await;
+    cleanup(&pool2, &uid2, &db_name2).await;
     println!("✅ isolation: users see only their own logs");
 }
 
@@ -735,7 +719,7 @@ async fn test_user_isolation() {
 #[tokio::test]
 #[serial]
 async fn test_governance_quarantine_edit_log() {
-    let (svc, _git, pool, uid) = setup().await;
+    let (svc, _git, pool, uid, db_name, _ctx) = setup().await;
 
     // T4 tier with initial_confidence=0.5, aged 60 days → confidence decays below 0.2 threshold
     let r = call(
@@ -791,7 +775,7 @@ async fn test_governance_quarantine_edit_log() {
         "memory should be physically deleted by quarantine"
     );
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ governance quarantine: all fields verified + DB state checked");
 }
 
@@ -802,7 +786,7 @@ async fn test_governance_quarantine_edit_log() {
 #[tokio::test]
 #[serial]
 async fn test_governance_cleanup_stale_edit_log() {
-    let (svc, _git, pool, uid) = setup().await;
+    let (svc, _git, pool, uid, db_name, _ctx) = setup().await;
 
     // Insert a memory and mark it inactive → cleanup_stale target
     let r = call("memory_store", json!({"content": "stale fact"}), &svc, &uid).await;
@@ -845,7 +829,7 @@ async fn test_governance_cleanup_stale_edit_log() {
         "stale memory should be deleted from DB"
     );
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ governance cleanup_stale: all fields verified + DB state checked");
 }
 
@@ -853,17 +837,15 @@ async fn test_governance_cleanup_stale_edit_log() {
 // 12. GOVERNANCE via REST API
 // ═══════════════════════════════════════════════════════════════════════════════
 
-async fn spawn_server() -> (String, reqwest::Client, MySqlPool, Arc<MemoryService>) {
-    let db = db_url();
-    let store = SqlMemoryStore::connect(&db, test_dim(), Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let pool = MySqlPool::connect(&db).await.expect("pool");
-    let db_name = db.rsplit('/').next().unwrap_or("memoria").to_string();
-    let git = Arc::new(GitForDataService::new(pool.clone(), &db_name));
-    let service = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    let state = memoria_api::AppState::new(Arc::clone(&service), git, String::new());
+async fn spawn_server() -> (
+    String,
+    reqwest::Client,
+    Arc<MemoryService>,
+    support::multi_db::McpTestContext,
+) {
+    let ctx = support::multi_db::setup_mcp_context("edit_log_api", test_dim(), None, None).await;
+    let service = ctx.service();
+    let state = memoria_api::AppState::new(Arc::clone(&service), ctx.git(), String::new());
     let app = memoria_api::build_router(state);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -874,15 +856,17 @@ async fn spawn_server() -> (String, reqwest::Client, MySqlPool, Arc<MemoryServic
     tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
 
     let client = reqwest::Client::builder().no_proxy().build().unwrap();
-    (format!("http://127.0.0.1:{port}"), client, pool, service)
+    (format!("http://127.0.0.1:{port}"), client, service, ctx)
 }
 
 #[tokio::test]
 #[serial]
 async fn test_api_governance_quarantine_edit_log() {
-    let (base, client, pool, svc) = spawn_server().await;
+    let (base, client, svc, ctx) = spawn_server().await;
     let uid = uid();
-    cleanup(&pool, &uid).await;
+    let pool = ctx.user_db_pool(&uid).await;
+    let db_name = ctx.user_db_name(&uid).await;
+    cleanup(&pool, &uid, &db_name).await;
 
     // Store via API
     let r = client
@@ -927,7 +911,7 @@ async fn test_api_governance_quarantine_edit_log() {
     let payload: Value = serde_json::from_str(row.payload.as_ref().unwrap()).unwrap();
     assert!(payload["quarantined"].as_i64().unwrap() >= 1);
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ API governance quarantine: edit log verified");
 }
 
@@ -938,9 +922,11 @@ async fn test_api_governance_quarantine_edit_log() {
 #[tokio::test]
 #[serial]
 async fn test_api_purge_edit_log_all_fields() {
-    let (base, client, pool, svc) = spawn_server().await;
+    let (base, client, svc, ctx) = spawn_server().await;
     let uid = uid();
-    cleanup(&pool, &uid).await;
+    let pool = ctx.user_db_pool(&uid).await;
+    let db_name = ctx.user_db_name(&uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     ensure_snapshot_quota(&pool).await;
 
     let r = client
@@ -967,7 +953,7 @@ async fn test_api_purge_edit_log_all_fields() {
     assert_eq!(body["purged"], 1);
     let snap = body["snapshot_name"].as_str().unwrap();
     assert!(
-        is_purge_safety_snapshot(snap),
+        is_purge_safety_snapshot(&db_name, snap),
         "unexpected snapshot name: {snap}"
     );
 
@@ -992,7 +978,7 @@ async fn test_api_purge_edit_log_all_fields() {
             .unwrap();
     assert_eq!(exists.len(), 1);
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ API purge: all edit log fields verified + snapshot exists");
 }
 
@@ -1003,9 +989,11 @@ async fn test_api_purge_edit_log_all_fields() {
 #[tokio::test]
 #[serial]
 async fn test_api_purge_topic_edit_log_all_fields() {
-    let (base, client, pool, svc) = spawn_server().await;
+    let (base, client, svc, ctx) = spawn_server().await;
     let uid = uid();
-    cleanup(&pool, &uid).await;
+    let pool = ctx.user_db_pool(&uid).await;
+    let db_name = ctx.user_db_name(&uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     ensure_snapshot_quota(&pool).await;
 
     for c in ["topicZ alpha", "topicZ beta", "unrelated"] {
@@ -1045,7 +1033,7 @@ async fn test_api_purge_topic_edit_log_all_fields() {
         );
     }
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ API purge topic: all edit log fields verified");
 }
 
@@ -1056,7 +1044,7 @@ async fn test_api_purge_topic_edit_log_all_fields() {
 #[tokio::test]
 #[serial]
 async fn test_edit_id_globally_unique() {
-    let (svc, _git, pool, uid) = setup().await;
+    let (svc, _git, pool, uid, db_name, _ctx) = setup().await;
     ensure_snapshot_quota(&pool).await;
 
     // inject
@@ -1108,7 +1096,7 @@ async fn test_edit_id_globally_unique() {
         assert!(row.edit_id.chars().all(|c| c.is_ascii_hexdigit()));
     }
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ edit_id globally unique across all operation types");
 }
 
@@ -1119,7 +1107,7 @@ async fn test_edit_id_globally_unique() {
 #[tokio::test]
 #[serial]
 async fn test_inject_supersede_all_fields() {
-    let Some((svc, _git, pool, uid)) = setup_with_embedder().await else {
+    let Some((svc, _git, pool, uid, db_name, _ctx)) = setup_with_embedder().await else {
         println!("⚠️  skipped: EMBEDDING_BASE_URL / EMBEDDING_API_KEY not set");
         return;
     };
@@ -1158,7 +1146,7 @@ async fn test_inject_supersede_all_fields() {
             "⚠️  supersede not triggered (embeddings not close enough), verifying normal inject"
         );
         assert!(logs.len() >= 2);
-        cleanup(&pool, &uid).await;
+        cleanup(&pool, &uid, &db_name).await;
         return;
     }
 
@@ -1186,7 +1174,7 @@ async fn test_inject_supersede_all_fields() {
         "superseded_by should point to new"
     );
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ inject supersede: all fields verified + old memory superseded in DB");
 }
 
@@ -1197,7 +1185,7 @@ async fn test_inject_supersede_all_fields() {
 #[tokio::test]
 #[serial]
 async fn test_governance_archive_working_edit_log() {
-    let (svc, _git, pool, uid) = setup().await;
+    let (svc, _git, pool, uid, db_name, ctx) = setup().await;
 
     // Store a working memory and age it beyond the 72h threshold
     let r = call(
@@ -1221,13 +1209,12 @@ async fn test_governance_archive_working_edit_log() {
         .unwrap();
 
     // Run full governance via the scheduler strategy
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), Uuid::new_v4().to_string())
-        .await
-        .expect("store");
+    let store = ctx.shared_store();
     let strategy = memoria_service::DefaultGovernanceStrategy;
     let _ = strategy
-        .run(&store, memoria_service::GovernanceTask::Hourly)
+        .run(store.as_ref(), memoria_service::GovernanceTask::Hourly)
         .await;
+    svc.flush_edit_log().await;
 
     let logs = get_logs_by_op(&pool, &uid, "governance:archive_working").await;
     assert!(!logs.is_empty(), "should have archive_working edit log");
@@ -1247,7 +1234,7 @@ async fn test_governance_archive_working_edit_log() {
             .unwrap();
     assert_eq!(active[0].0, 0, "working memory should be archived");
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
     println!("✅ governance archive_working: all fields verified + DB state checked");
 }
 
@@ -1258,7 +1245,7 @@ async fn test_governance_archive_working_edit_log() {
 #[tokio::test]
 #[serial]
 async fn test_governance_cleanup_orphaned_edit_log() {
-    let (svc, _git, pool, uid) = setup().await;
+    let (svc, _git, pool, uid, db_name, ctx) = setup().await;
 
     // Store a memory, then supersede it manually to create an orphan
     let r = call("memory_store", json!({"content": "original"}), &svc, &uid).await;
@@ -1281,12 +1268,10 @@ async fn test_governance_cleanup_orphaned_edit_log() {
         .await
         .unwrap();
 
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), Uuid::new_v4().to_string())
-        .await
-        .expect("store");
+    let store = ctx.user_store(&uid).await;
     let strategy = memoria_service::DefaultGovernanceStrategy;
     let _ = strategy
-        .run(&store, memoria_service::GovernanceTask::Daily)
+        .run(store.as_ref(), memoria_service::GovernanceTask::Daily)
         .await;
 
     let logs = get_logs_by_op(&pool, &uid, "governance:cleanup_orphaned_incrementals").await;
@@ -1302,5 +1287,5 @@ async fn test_governance_cleanup_orphaned_edit_log() {
         println!("⚠️  governance cleanup_orphaned: not triggered (orphan criteria not met)");
     }
 
-    cleanup(&pool, &uid).await;
+    cleanup(&pool, &uid, &db_name).await;
 }

--- a/memoria/crates/memoria-mcp/tests/feedback_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/feedback_e2e.rs
@@ -3,6 +3,10 @@
 ///
 /// Run: DATABASE_URL=mysql://root:111@localhost:6001/memoria \
 ///      cargo test -p memoria-mcp --test feedback_e2e -- --nocapture
+mod support;
+
+use memoria_core::interfaces::EmbeddingProvider;
+use memoria_embedding::MockEmbedder;
 use memoria_service::MemoryService;
 use memoria_storage::SqlMemoryStore;
 use serde_json::{json, Value};
@@ -15,22 +19,35 @@ fn test_dim() -> usize {
         .and_then(|s| s.parse().ok())
         .unwrap_or(1024)
 }
-fn db_url() -> String {
-    std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string())
-}
 fn uid() -> String {
     format!("fb_{}", &Uuid::new_v4().simple().to_string()[..8])
 }
 
-async fn setup() -> (Arc<MemoryService>, Arc<SqlMemoryStore>, String) {
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let store = Arc::new(store);
-    let svc = Arc::new(MemoryService::new_sql_with_llm(store.clone(), None, None).await);
-    (svc, store, uid())
+async fn setup() -> (
+    Arc<MemoryService>,
+    Arc<SqlMemoryStore>,
+    String,
+    support::multi_db::McpTestContext,
+) {
+    let ctx = support::multi_db::setup_mcp_context("feedback_e2e", test_dim(), None, None).await;
+    let uid = uid();
+    let store = ctx.user_store(&uid).await;
+    (ctx.service(), store, uid, ctx)
+}
+
+async fn setup_with_mock_embedder() -> (
+    Arc<MemoryService>,
+    Arc<SqlMemoryStore>,
+    String,
+    support::multi_db::McpTestContext,
+) {
+    let embedder: Option<Arc<dyn EmbeddingProvider>> =
+        Some(Arc::new(MockEmbedder::new(test_dim())));
+    let ctx =
+        support::multi_db::setup_mcp_context("feedback_e2e_mock", test_dim(), embedder, None).await;
+    let uid = uid();
+    let store = ctx.user_store(&uid).await;
+    (ctx.service(), store, uid, ctx)
 }
 
 async fn call(name: &str, args: Value, svc: &Arc<MemoryService>, uid: &str) -> Value {
@@ -46,7 +63,7 @@ fn text(v: &Value) -> &str {
 
 #[tokio::test]
 async fn test_feedback_basic_flow() {
-    let (svc, _store, uid) = setup().await;
+    let (svc, _store, uid, _ctx) = setup().await;
 
     // Store a memory first
     let r = call(
@@ -86,7 +103,7 @@ async fn test_feedback_basic_flow() {
 
 #[tokio::test]
 async fn test_feedback_all_signals() {
-    let (svc, _store, uid) = setup().await;
+    let (svc, _store, uid, _ctx) = setup().await;
 
     // Store memories for each signal type
     let signals = ["useful", "irrelevant", "outdated", "wrong"];
@@ -132,7 +149,7 @@ async fn test_feedback_all_signals() {
 
 #[tokio::test]
 async fn test_feedback_with_context() {
-    let (svc, _store, uid) = setup().await;
+    let (svc, _store, uid, _ctx) = setup().await;
 
     // Store a memory
     let r = call(
@@ -170,7 +187,7 @@ async fn test_feedback_with_context() {
 
 #[tokio::test]
 async fn test_feedback_invalid_signal() {
-    let (svc, _store, uid) = setup().await;
+    let (svc, _store, uid, _ctx) = setup().await;
 
     // Store a memory
     let r = call(
@@ -209,7 +226,7 @@ async fn test_feedback_invalid_signal() {
 
 #[tokio::test]
 async fn test_feedback_nonexistent_memory() {
-    let (svc, _store, uid) = setup().await;
+    let (svc, _store, uid, _ctx) = setup().await;
 
     let result = memoria_mcp::tools::call(
         "memory_feedback",
@@ -233,7 +250,7 @@ async fn test_feedback_nonexistent_memory() {
 
 #[tokio::test]
 async fn test_feedback_other_users_memory() {
-    let (svc, _store, uid1) = setup().await;
+    let (svc, _store, uid1, _ctx) = setup().await;
     let uid2 = uid(); // Different user
 
     // User 1 stores a memory
@@ -273,7 +290,7 @@ async fn test_feedback_other_users_memory() {
 
 #[tokio::test]
 async fn test_feedback_stats() {
-    let (svc, store, uid) = setup().await;
+    let (svc, store, uid, _ctx) = setup().await;
 
     // Store multiple memories and give feedback
     let mut memory_ids = Vec::new();
@@ -330,7 +347,7 @@ async fn test_feedback_stats() {
 
 #[tokio::test]
 async fn test_feedback_by_tier() {
-    let (svc, store, uid) = setup().await;
+    let (svc, store, uid, _ctx) = setup().await;
 
     // Store memories with different trust tiers
     let tiers = ["T1", "T2", "T3", "T4"];
@@ -398,7 +415,7 @@ async fn test_feedback_by_tier() {
 
 #[tokio::test]
 async fn test_service_record_feedback() {
-    let (svc, _store, uid) = setup().await;
+    let (svc, _store, uid, _ctx) = setup().await;
 
     // Store a memory
     let r = call(
@@ -433,7 +450,7 @@ async fn test_service_record_feedback() {
 
 #[tokio::test]
 async fn test_multiple_feedback_same_memory() {
-    let (svc, store, uid) = setup().await;
+    let (svc, store, uid, _ctx) = setup().await;
 
     // Store a memory
     let r = call(
@@ -470,7 +487,7 @@ async fn test_multiple_feedback_same_memory() {
 
 #[tokio::test]
 async fn test_feedback_db_verification() {
-    let (svc, store, uid) = setup().await;
+    let (svc, store, uid, _ctx) = setup().await;
 
     // Store a memory
     let r = call(
@@ -510,9 +527,10 @@ async fn test_feedback_db_verification() {
     // ── Direct DB verification ────────────────────────────────────────────────
 
     // 1. Verify feedback record exists in mem_retrieval_feedback
-    let row: Option<(String, String, String, String, Option<String>)> = sqlx::query_as(
-        "SELECT id, user_id, memory_id, signal, context FROM mem_retrieval_feedback WHERE id = ?",
-    )
+    let feedback_table = store.t("mem_retrieval_feedback");
+    let row: Option<(String, String, String, String, Option<String>)> = sqlx::query_as(&format!(
+        "SELECT id, user_id, memory_id, signal, context FROM {feedback_table} WHERE id = ?"
+    ))
     .bind(feedback_id)
     .fetch_optional(store.pool())
     .await
@@ -532,12 +550,14 @@ async fn test_feedback_db_verification() {
     );
 
     // 2. Verify memory exists and has correct trust_tier
-    let mem_row: Option<(String, String)> =
-        sqlx::query_as("SELECT memory_id, trust_tier FROM mem_memories WHERE memory_id = ?")
-            .bind(memory_id)
-            .fetch_optional(store.pool())
-            .await
-            .expect("query memory");
+    let memories_table = store.t("mem_memories");
+    let mem_row: Option<(String, String)> = sqlx::query_as(&format!(
+        "SELECT memory_id, trust_tier FROM {memories_table} WHERE memory_id = ?"
+    ))
+    .bind(memory_id)
+    .fetch_optional(store.pool())
+    .await
+    .expect("query memory");
 
     let (_, db_tier) = mem_row.expect("memory should exist");
     assert_eq!(db_tier, "T2", "trust_tier mismatch");
@@ -565,18 +585,19 @@ async fn test_feedback_db_verification() {
     store
         .record_feedback(&uid, memory_id_2, "irrelevant", None)
         .await
-        .unwrap();
+    .unwrap();
 
     // 4. Verify aggregated stats via direct SQL
-    let stats_row: (i64, i64, i64, i64, i64) = sqlx::query_as(
+    let feedback_table = store.t("mem_retrieval_feedback");
+    let stats_row: (i64, i64, i64, i64, i64) = sqlx::query_as(&format!(
         "SELECT \
            COUNT(*) as total, \
            SUM(CASE WHEN signal = 'useful' THEN 1 ELSE 0 END) as useful, \
            SUM(CASE WHEN signal = 'irrelevant' THEN 1 ELSE 0 END) as irrelevant, \
            SUM(CASE WHEN signal = 'outdated' THEN 1 ELSE 0 END) as outdated, \
            SUM(CASE WHEN signal = 'wrong' THEN 1 ELSE 0 END) as wrong \
-         FROM mem_retrieval_feedback WHERE user_id = ?",
-    )
+         FROM {feedback_table} WHERE user_id = ?"
+    ))
     .bind(&uid)
     .fetch_one(store.pool())
     .await
@@ -589,14 +610,15 @@ async fn test_feedback_db_verification() {
     assert_eq!(stats_row.4, 0, "wrong count");
 
     // 5. Verify feedback by tier via direct SQL
-    let tier_rows: Vec<(String, String, i64)> = sqlx::query_as(
+    let memories_table = store.t("mem_memories");
+    let tier_rows: Vec<(String, String, i64)> = sqlx::query_as(&format!(
         "SELECT m.trust_tier, f.signal, COUNT(*) as cnt \
-         FROM mem_retrieval_feedback f \
-         JOIN mem_memories m ON f.memory_id = m.memory_id \
+         FROM {feedback_table} f \
+         JOIN {memories_table} m ON f.memory_id = m.memory_id \
          WHERE f.user_id = ? \
          GROUP BY m.trust_tier, f.signal \
-         ORDER BY m.trust_tier, f.signal",
-    )
+         ORDER BY m.trust_tier, f.signal"
+    ))
     .bind(&uid)
     .fetch_all(store.pool())
     .await
@@ -639,7 +661,7 @@ async fn test_feedback_db_verification() {
 
 #[tokio::test]
 async fn test_feedback_closed_loop() {
-    let (svc, store, uid) = setup().await;
+    let (svc, store, uid, _ctx) = setup().await;
 
     // 1. Store multiple memories with different tiers
     let memories = vec![
@@ -730,7 +752,7 @@ async fn test_feedback_closed_loop() {
 
 #[tokio::test]
 async fn test_feedback_denormalized_counters() {
-    let (svc, store, uid) = setup().await;
+    let (svc, store, uid, _ctx) = setup().await;
 
     // Store a memory
     let r = call(
@@ -774,10 +796,11 @@ async fn test_feedback_denormalized_counters() {
     assert_eq!(fb.wrong, 0, "wrong count");
 
     // Verify via direct SQL (no JOIN needed)
-    let row: (i32, i32, i32, i32) = sqlx::query_as(
+    let stats_table = store.t("mem_memories_stats");
+    let row: (i32, i32, i32, i32) = sqlx::query_as(&format!(
         "SELECT feedback_useful, feedback_irrelevant, feedback_outdated, feedback_wrong \
-         FROM mem_memories_stats WHERE memory_id = ?",
-    )
+         FROM {stats_table} WHERE memory_id = ?"
+    ))
     .bind(memory_id)
     .fetch_one(store.pool())
     .await
@@ -799,7 +822,7 @@ async fn test_feedback_denormalized_counters() {
 
 #[tokio::test]
 async fn test_feedback_affects_retrieval_ranking() {
-    let (svc, store, uid) = setup().await;
+    let (svc, store, uid, _ctx) = setup_with_mock_embedder().await;
 
     // Store 3 memories with similar content but different trust tiers
     let memories = vec![
@@ -908,7 +931,7 @@ async fn test_feedback_affects_retrieval_ranking() {
 
 #[tokio::test]
 async fn test_feedback_score_multiplier_db_verification() {
-    let (svc, store, uid) = setup().await;
+    let (svc, store, uid, _ctx) = setup_with_mock_embedder().await;
 
     // Store a memory
     let r = call(
@@ -1020,7 +1043,7 @@ async fn test_feedback_score_multiplier_db_verification() {
 
 #[tokio::test]
 async fn test_get_retrieval_params_default() {
-    let (svc, _store, uid) = setup().await;
+    let (svc, _store, uid, _ctx) = setup().await;
 
     let result = call("memory_get_retrieval_params", json!({}), &svc, &uid).await;
     let text = text(&result);
@@ -1050,7 +1073,7 @@ async fn test_get_retrieval_params_default() {
 
 #[tokio::test]
 async fn test_tune_params_insufficient_feedback() {
-    let (svc, _store, uid) = setup().await;
+    let (svc, _store, uid, _ctx) = setup().await;
 
     // No feedback yet, should not tune
     let result = call("memory_tune_params", json!({}), &svc, &uid).await;
@@ -1069,7 +1092,7 @@ async fn test_tune_params_insufficient_feedback() {
 
 #[tokio::test]
 async fn test_tune_params_with_feedback() {
-    let (svc, store, uid) = setup().await;
+    let (svc, store, uid, _ctx) = setup().await;
 
     // Create a memory via MCP tool
     let result = call(
@@ -1131,7 +1154,7 @@ async fn test_tune_params_with_feedback() {
 
 #[tokio::test]
 async fn test_tuning_db_verification() {
-    let (_svc, store, uid) = setup().await;
+    let (_svc, store, uid, _ctx) = setup().await;
 
     // Set custom params
     let custom = memoria_storage::UserRetrievalParams {
@@ -1168,7 +1191,7 @@ async fn test_tuning_db_verification() {
 
 #[tokio::test]
 async fn test_tuning_affects_scoring() {
-    let (svc, store, uid) = setup().await;
+    let (svc, store, uid, _ctx) = setup_with_mock_embedder().await;
 
     // Use highly unique content to avoid cross-test interference
     let unique = format!("xyzzy_tuning_test_{}", uid);
@@ -1268,7 +1291,7 @@ async fn test_governance_daily_tunes_params_in_db() {
         GovernanceStrategy,
     };
 
-    let (_svc, store, uid) = setup().await;
+    let (_svc, store, uid, ctx) = setup().await;
 
     // Store a memory and add 12 useful feedback signals (above MIN_FEEDBACK_FOR_TUNING=10)
     let result = call(
@@ -1297,7 +1320,7 @@ async fn test_governance_daily_tunes_params_in_db() {
     // Run governance daily task directly (no scheduler needed)
     let strategy: Arc<dyn GovernanceStrategy> = Arc::new(DefaultGovernanceStrategy);
     let execution = strategy
-        .run(store.as_ref(), GovernanceTask::Daily)
+        .run(ctx.shared_store().as_ref(), GovernanceTask::Daily)
         .await
         .unwrap();
 
@@ -1336,11 +1359,9 @@ async fn test_duplicate_instance_id_lock_is_exclusive() {
     use memoria_service::distributed::DistributedLock;
     use std::time::Duration;
 
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let store = Arc::new(store);
+    let ctx =
+        support::multi_db::setup_mcp_context("feedback_lock", test_dim(), None, None).await;
+    let store = ctx.shared_store();
 
     let lock_key = format!("test:dup_instance:{}", uid());
 

--- a/memoria/crates/memoria-mcp/tests/graph_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/graph_e2e.rs
@@ -1,7 +1,15 @@
+mod support;
+
+use memoria_service::MemoryService;
 use memoria_storage::graph::types::{edge_type, GraphEdge, GraphNode, NodeType};
 /// Graph E2E tests: GraphStore CRUD, consolidation, entity extraction/linking.
 /// Requires real DB. Run with --test-threads=1 (rollback is account-level).
-use memoria_storage::{GraphConsolidator, GraphStore};
+use memoria_storage::{GraphConsolidator, GraphStore, SqlMemoryStore};
+use sqlx::mysql::MySqlPool;
+use std::sync::Arc;
+use uuid::Uuid;
+
+const TEST_DB_PREFIX: &str = "graph_e2e";
 
 fn test_dim() -> usize {
     std::env::var("EMBEDDING_DIM")
@@ -10,14 +18,57 @@ fn test_dim() -> usize {
         .unwrap_or(1024)
 }
 
-async fn setup_graph() -> (GraphStore, String) {
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
-    let pool = sqlx::MySqlPool::connect(&db_url).await.expect("connect");
-    let store = GraphStore::new(pool, test_dim()); // dim=4 for tests
-    store.migrate().await.expect("migrate");
-    let uid = format!("graph_test_{}", uuid::Uuid::new_v4().simple());
-    (store, uid)
+async fn setup_user(
+    uid_prefix: &str,
+) -> (
+    support::multi_db::McpTestContext,
+    Arc<SqlMemoryStore>,
+    MySqlPool,
+    String,
+) {
+    let ctx = support::multi_db::setup_mcp_context(TEST_DB_PREFIX, test_dim(), None, None).await;
+    let uid = format!("{uid_prefix}_{}", Uuid::new_v4().simple());
+    let sql = ctx.user_store(&uid).await;
+    let pool = ctx.user_db_pool(&uid).await;
+    (ctx, sql, pool, uid)
+}
+
+async fn setup_graph() -> (GraphStore, String, support::multi_db::McpTestContext) {
+    let (ctx, sql, _pool, uid) = setup_user("graph_test").await;
+    (sql.graph_store(), uid, ctx)
+}
+
+async fn setup_sql(
+    uid_prefix: &str,
+) -> (
+    Arc<SqlMemoryStore>,
+    MySqlPool,
+    String,
+    support::multi_db::McpTestContext,
+) {
+    let (ctx, sql, pool, uid) = setup_user(uid_prefix).await;
+    (sql, pool, uid, ctx)
+}
+
+async fn setup_service(
+    uid_prefix: &str,
+) -> (
+    Arc<MemoryService>,
+    Arc<SqlMemoryStore>,
+    MySqlPool,
+    String,
+    support::multi_db::McpTestContext,
+) {
+    let (ctx, sql, pool, uid) = setup_user(uid_prefix).await;
+    (ctx.service(), sql, pool, uid, ctx)
+}
+
+fn extract_memory_id(text: &str) -> String {
+    text.split_whitespace()
+        .nth(2)
+        .unwrap_or("")
+        .trim_end_matches(':')
+        .to_string()
 }
 
 fn make_node(
@@ -53,7 +104,7 @@ fn make_node(
 
 #[tokio::test]
 async fn test_graph_create_and_get_node() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let node = make_node(
         &uid,
         NodeType::Semantic,
@@ -79,7 +130,7 @@ async fn test_graph_create_and_get_node() {
 
 #[tokio::test]
 async fn test_graph_get_by_memory_id() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let mid = format!("mem_{}", uuid::Uuid::new_v4().simple());
     let node = make_node(&uid, NodeType::Semantic, "test content", Some(&mid));
     store.create_node(&node).await.expect("create");
@@ -97,7 +148,7 @@ async fn test_graph_get_by_memory_id() {
 
 #[tokio::test]
 async fn test_graph_get_user_nodes_by_type() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
 
     let semantic = make_node(&uid, NodeType::Semantic, "semantic node", None);
     let scene = make_node(&uid, NodeType::Scene, "scene node", None);
@@ -130,7 +181,7 @@ async fn test_graph_get_user_nodes_by_type() {
 
 #[tokio::test]
 async fn test_graph_deactivate_node() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let node = make_node(&uid, NodeType::Scene, "to be deactivated", None);
     let node_id = node.node_id.clone();
     store.create_node(&node).await.expect("create");
@@ -152,7 +203,7 @@ async fn test_graph_deactivate_node() {
 
 #[tokio::test]
 async fn test_graph_update_tier() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let mut node = make_node(&uid, NodeType::Scene, "tier test", None);
     node.trust_tier = "T4".to_string();
     node.confidence = 0.6;
@@ -178,7 +229,7 @@ async fn test_graph_update_tier() {
 
 #[tokio::test]
 async fn test_graph_edge_and_conflict() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let n1 = make_node(&uid, NodeType::Semantic, "node A", None);
     let n2 = make_node(&uid, NodeType::Semantic, "node B", None);
     let (id1, id2) = (n1.node_id.clone(), n2.node_id.clone());
@@ -216,7 +267,7 @@ async fn test_graph_edge_and_conflict() {
 
 #[tokio::test]
 async fn test_graph_entity_upsert() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
 
     let (id1, is_new1) = store
         .upsert_entity(&uid, "rust", "Rust", "tech")
@@ -237,7 +288,7 @@ async fn test_graph_entity_upsert() {
 
 #[tokio::test]
 async fn test_graph_entity_link_idempotent() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let (entity_id, _) = store
         .upsert_entity(&uid, "matrixone", "MatrixOne", "tech")
         .await
@@ -262,12 +313,10 @@ async fn test_graph_entity_link_idempotent() {
 
 #[tokio::test]
 async fn test_graph_unlinked_memories() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, ctx) = setup_graph().await;
 
     // Insert a memory directly into mem_memories
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
-    let pool = sqlx::MySqlPool::connect(&db_url).await.expect("connect");
+    let pool = ctx.user_db_pool(&uid).await;
     let mid = format!("mem_{}", uuid::Uuid::new_v4().simple());
     sqlx::query(
         "INSERT INTO mem_memories (memory_id, user_id, memory_type, content, source_event_ids, \
@@ -318,7 +367,7 @@ async fn test_graph_unlinked_memories() {
 
 #[tokio::test]
 async fn test_consolidator_trust_tier_lifecycle() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
 
     // T4 scene with high confidence and old age (simulate by setting created_at far back)
     let mut scene = make_node(&uid, NodeType::Scene, "old high-confidence scene", None);
@@ -360,7 +409,7 @@ async fn test_consolidator_trust_tier_lifecycle() {
 
 #[tokio::test]
 async fn test_consolidator_orphaned_scene() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
 
     // Scene with source_nodes pointing to non-existent nodes
     let mut scene = make_node(&uid, NodeType::Scene, "orphaned scene", None);
@@ -392,7 +441,7 @@ async fn test_consolidator_orphaned_scene() {
 
 #[tokio::test]
 async fn test_consolidator_t3_demotion() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
 
     // T3 scene with low confidence and very old age
     let mut scene = make_node(&uid, NodeType::Scene, "stale T3 scene", None);
@@ -422,12 +471,10 @@ async fn test_consolidator_t3_demotion() {
 
 #[tokio::test]
 async fn test_graph_full_entity_workflow() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, ctx) = setup_graph().await;
 
     // Insert memory
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
-    let pool = sqlx::MySqlPool::connect(&db_url).await.expect("connect");
+    let pool = ctx.user_db_pool(&uid).await;
     let mid = format!("mem_{}", uuid::Uuid::new_v4().simple());
     sqlx::query(
         "INSERT INTO mem_memories (memory_id, user_id, memory_type, content, source_event_ids, \
@@ -494,18 +541,7 @@ async fn test_graph_full_entity_workflow() {
 
 #[tokio::test]
 async fn test_store_creates_graph_node() {
-    use memoria_service::MemoryService;
-    use memoria_storage::SqlMemoryStore;
-    use std::sync::Arc;
-
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
-    let sql = SqlMemoryStore::connect(&db_url, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    sql.migrate().await.expect("migrate");
-    let uid = format!("gsync_{}", uuid::Uuid::new_v4().simple());
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(sql.clone()), None, None).await);
+    let (svc, sql, _pool, uid, _ctx) = setup_service("gsync").await;
 
     // Call memory_store via tools
     let r = memoria_mcp::tools::call(
@@ -517,15 +553,11 @@ async fn test_store_creates_graph_node() {
     assert!(text.contains("Stored memory"), "got: {text}");
 
     // Extract memory_id from response
-    let mid = text
-        .split_whitespace()
-        .nth(2)
-        .unwrap_or("")
-        .trim_end_matches(':');
+    let mid = extract_memory_id(text);
 
     // Verify graph node was created
     let graph = sql.graph_store();
-    let node = graph.get_node_by_memory_id(mid).await.expect("query");
+    let node = graph.get_node_by_memory_id(&mid).await.expect("query");
     assert!(
         node.is_some(),
         "graph node should be created for memory {mid}"
@@ -552,18 +584,7 @@ async fn test_store_creates_graph_node() {
 
 #[tokio::test]
 async fn test_correct_updates_graph_node() {
-    use memoria_service::MemoryService;
-    use memoria_storage::SqlMemoryStore;
-    use std::sync::Arc;
-
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
-    let sql = SqlMemoryStore::connect(&db_url, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    sql.migrate().await.expect("migrate");
-    let uid = format!("gcorr_{}", uuid::Uuid::new_v4().simple());
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(sql.clone()), None, None).await);
+    let (svc, sql, _pool, uid, _ctx) = setup_service("gcorr").await;
 
     // Store
     let r = memoria_mcp::tools::call(
@@ -575,12 +596,7 @@ async fn test_correct_updates_graph_node() {
     .await
     .expect("store");
     let text = r["content"][0]["text"].as_str().unwrap_or("");
-    let mid = text
-        .split_whitespace()
-        .nth(2)
-        .unwrap_or("")
-        .trim_end_matches(':')
-        .to_string();
+    let mid = extract_memory_id(text);
 
     // Correct — creates new memory, deactivates old
     let cr = memoria_mcp::tools::call(
@@ -589,12 +605,7 @@ async fn test_correct_updates_graph_node() {
         &svc, &uid,
     ).await.expect("correct");
     let ct = cr["content"][0]["text"].as_str().unwrap_or("");
-    let new_mid = ct
-        .split_whitespace()
-        .nth(2)
-        .unwrap_or("")
-        .trim_end_matches(':')
-        .to_string();
+    let new_mid = extract_memory_id(ct);
 
     // Verify old graph node deactivated, new graph node has updated content
     let graph = sql.graph_store();
@@ -613,18 +624,7 @@ async fn test_correct_updates_graph_node() {
 
 #[tokio::test]
 async fn test_purge_deactivates_graph_node() {
-    use memoria_service::MemoryService;
-    use memoria_storage::SqlMemoryStore;
-    use std::sync::Arc;
-
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
-    let sql = SqlMemoryStore::connect(&db_url, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    sql.migrate().await.expect("migrate");
-    let uid = format!("gpurge_{}", uuid::Uuid::new_v4().simple());
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(sql.clone()), None, None).await);
+    let (svc, sql, _pool, uid, _ctx) = setup_service("gpurge").await;
 
     // Store
     let r = memoria_mcp::tools::call(
@@ -636,12 +636,7 @@ async fn test_purge_deactivates_graph_node() {
     .await
     .expect("store");
     let text = r["content"][0]["text"].as_str().unwrap_or("");
-    let mid = text
-        .split_whitespace()
-        .nth(2)
-        .unwrap_or("")
-        .trim_end_matches(':')
-        .to_string();
+    let mid = extract_memory_id(text);
 
     // Verify graph node exists
     let graph = sql.graph_store();
@@ -698,15 +693,7 @@ fn test_ner_extract_entities() {
 
 #[tokio::test]
 async fn test_entity_link_weights_by_source() {
-    use memoria_storage::SqlMemoryStore;
-
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
-    let sql = SqlMemoryStore::connect(&db_url, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    sql.migrate().await.expect("migrate");
-    let uid = format!("elw_{}", uuid::Uuid::new_v4().simple());
+    let (sql, _pool, uid, _ctx) = setup_sql("elw").await;
     let graph = sql.graph_store();
 
     // Create entity
@@ -734,11 +721,15 @@ async fn test_entity_link_weights_by_source() {
         .expect("link manual");
 
     // Verify weights
-    let rows = sqlx::query(
-        "SELECT memory_id, weight FROM mem_memory_entity_links WHERE entity_id = ? AND user_id = ? ORDER BY weight"
-    )
-    .bind(&eid).bind(&uid)
-    .fetch_all(sql.pool()).await.expect("query");
+    let links_table = graph.t("mem_memory_entity_links");
+    let rows = sqlx::query(&format!(
+        "SELECT memory_id, weight FROM {links_table} WHERE entity_id = ? AND user_id = ? ORDER BY weight"
+    ))
+    .bind(&eid)
+    .bind(&uid)
+    .fetch_all(graph.pool())
+    .await
+    .expect("query");
 
     use sqlx::Row;
     assert_eq!(rows.len(), 3);
@@ -776,7 +767,7 @@ async fn test_entity_link_weights_by_source() {
 
 #[tokio::test]
 async fn test_batch_upsert_entity_links_empty() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     store
         .batch_upsert_memory_entity_links(&uid, &[])
         .await
@@ -786,7 +777,7 @@ async fn test_batch_upsert_entity_links_empty() {
 
 #[tokio::test]
 async fn test_batch_upsert_entity_links_basic() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let (eid1, _) = store
         .upsert_entity(&uid, "rust", "Rust", "tech")
         .await
@@ -801,11 +792,15 @@ async fn test_batch_upsert_entity_links_basic() {
         .expect("batch upsert");
 
     // Verify both links exist
-    let rows = sqlx::query(
-        "SELECT entity_id, source, weight FROM mem_memory_entity_links WHERE user_id = ? AND memory_id = ? ORDER BY weight"
-    )
-    .bind(&uid).bind(&mid)
-    .fetch_all(store.pool()).await.unwrap();
+    let links_table = store.t("mem_memory_entity_links");
+    let rows = sqlx::query(&format!(
+        "SELECT entity_id, source, weight FROM {links_table} WHERE user_id = ? AND memory_id = ? ORDER BY weight"
+    ))
+    .bind(&uid)
+    .bind(&mid)
+    .fetch_all(store.pool())
+    .await
+    .unwrap();
 
     use sqlx::Row;
     assert_eq!(rows.len(), 2);
@@ -818,7 +813,7 @@ async fn test_batch_upsert_entity_links_basic() {
 
 #[tokio::test]
 async fn test_batch_upsert_entity_links_idempotent() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let (eid, _) = store
         .upsert_entity(&uid, "matrixone", "MatrixOne", "tech")
         .await
@@ -836,11 +831,16 @@ async fn test_batch_upsert_entity_links_idempotent() {
         .await
         .unwrap();
 
-    let rows = sqlx::query(
-        "SELECT COUNT(*) as cnt FROM mem_memory_entity_links WHERE user_id = ? AND memory_id = ? AND entity_id = ?"
-    )
-    .bind(&uid).bind(&mid).bind(&eid)
-    .fetch_one(store.pool()).await.unwrap();
+    let links_table = store.t("mem_memory_entity_links");
+    let rows = sqlx::query(&format!(
+        "SELECT COUNT(*) as cnt FROM {links_table} WHERE user_id = ? AND memory_id = ? AND entity_id = ?"
+    ))
+    .bind(&uid)
+    .bind(&mid)
+    .bind(&eid)
+    .fetch_one(store.pool())
+    .await
+    .unwrap();
     use sqlx::Row;
     let cnt: i64 = rows.get("cnt");
     assert_eq!(cnt, 1, "should still be exactly 1 link");
@@ -849,7 +849,7 @@ async fn test_batch_upsert_entity_links_idempotent() {
 
 #[tokio::test]
 async fn test_batch_upsert_entity_links_source_upgrade() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let (eid, _) = store
         .upsert_entity(&uid, "tokio", "Tokio", "tech")
         .await
@@ -871,9 +871,10 @@ async fn test_batch_upsert_entity_links_source_upgrade() {
         .unwrap();
 
     use sqlx::Row;
-    let row = sqlx::query(
-        "SELECT source, weight FROM mem_memory_entity_links WHERE memory_id = ? AND entity_id = ?",
-    )
+    let links_table = store.t("mem_memory_entity_links");
+    let row = sqlx::query(&format!(
+        "SELECT source, weight FROM {links_table} WHERE memory_id = ? AND entity_id = ?"
+    ))
     .bind(&mid)
     .bind(&eid)
     .fetch_one(store.pool())
@@ -891,7 +892,7 @@ async fn test_batch_upsert_entity_links_source_upgrade() {
 
 #[tokio::test]
 async fn test_batch_upsert_entity_links_large_batch() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     // Create 80 entities and link them all to one memory
     let mut entity_ids = Vec::new();
     for i in 0..80 {
@@ -912,9 +913,10 @@ async fn test_batch_upsert_entity_links_large_batch() {
         .expect("large batch should succeed (chunked into 50+30)");
 
     use sqlx::Row;
-    let row = sqlx::query(
-        "SELECT COUNT(*) as cnt FROM mem_memory_entity_links WHERE user_id = ? AND memory_id = ?",
-    )
+    let links_table = store.t("mem_memory_entity_links");
+    let row = sqlx::query(&format!(
+        "SELECT COUNT(*) as cnt FROM {links_table} WHERE user_id = ? AND memory_id = ?"
+    ))
     .bind(&uid)
     .bind(&mid)
     .fetch_one(store.pool())
@@ -927,7 +929,7 @@ async fn test_batch_upsert_entity_links_large_batch() {
 
 #[tokio::test]
 async fn test_batch_upsert_entity_links_mixed_sources() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let (eid1, _) = store.upsert_entity(&uid, "a", "A", "tech").await.unwrap();
     let (eid2, _) = store.upsert_entity(&uid, "b", "B", "tech").await.unwrap();
     let (eid3, _) = store.upsert_entity(&uid, "c", "C", "tech").await.unwrap();
@@ -944,11 +946,15 @@ async fn test_batch_upsert_entity_links_mixed_sources() {
         .unwrap();
 
     use sqlx::Row;
-    let rows = sqlx::query(
-        "SELECT source, weight FROM mem_memory_entity_links WHERE user_id = ? AND memory_id = ? ORDER BY weight"
-    )
-    .bind(&uid).bind(&mid)
-    .fetch_all(store.pool()).await.unwrap();
+    let links_table = store.t("mem_memory_entity_links");
+    let rows = sqlx::query(&format!(
+        "SELECT source, weight FROM {links_table} WHERE user_id = ? AND memory_id = ? ORDER BY weight"
+    ))
+    .bind(&uid)
+    .bind(&mid)
+    .fetch_all(store.pool())
+    .await
+    .unwrap();
     assert_eq!(rows.len(), 3);
     let sources: Vec<String> = rows.iter().map(|r| r.get("source")).collect();
     assert_eq!(sources, vec!["regex", "llm", "manual"]);
@@ -957,7 +963,7 @@ async fn test_batch_upsert_entity_links_mixed_sources() {
 
 #[tokio::test]
 async fn test_batch_upsert_entity_links_multiple_memories() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let (eid, _) = store
         .upsert_entity(&uid, "shared_entity", "SharedEntity", "concept")
         .await
@@ -972,11 +978,15 @@ async fn test_batch_upsert_entity_links_multiple_memories() {
         .await
         .unwrap();
 
-    let rows = sqlx::query(
-        "SELECT memory_id, source FROM mem_memory_entity_links WHERE user_id = ? AND entity_id = ? ORDER BY memory_id"
-    )
-    .bind(&uid).bind(&eid)
-    .fetch_all(store.pool()).await.unwrap();
+    let links_table = store.t("mem_memory_entity_links");
+    let rows = sqlx::query(&format!(
+        "SELECT memory_id, source FROM {links_table} WHERE user_id = ? AND entity_id = ? ORDER BY memory_id"
+    ))
+    .bind(&uid)
+    .bind(&eid)
+    .fetch_all(store.pool())
+    .await
+    .unwrap();
     assert_eq!(rows.len(), 2, "entity should be linked to 2 memories");
     println!("✅ batch_upsert_memory_entity_links: one entity linked to multiple memories");
 }
@@ -985,7 +995,7 @@ async fn test_batch_upsert_entity_links_multiple_memories() {
 
 #[tokio::test]
 async fn test_batch_upsert_entities_empty() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let result = store.batch_upsert_entities(&uid, &[]).await.unwrap();
     assert!(result.is_empty());
     println!("✅ batch_upsert_entities: empty input OK");
@@ -993,7 +1003,7 @@ async fn test_batch_upsert_entities_empty() {
 
 #[tokio::test]
 async fn test_batch_upsert_entities_basic() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let entities: Vec<(&str, &str, &str)> = vec![
         ("rust", "Rust", "tech"),
         ("go", "Go", "tech"),
@@ -1017,7 +1027,7 @@ async fn test_batch_upsert_entities_basic() {
 
 #[tokio::test]
 async fn test_batch_upsert_entities_idempotent() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let entities: Vec<(&str, &str, &str)> = vec![("rust", "Rust", "tech"), ("go", "Go", "tech")];
 
     let first = store.batch_upsert_entities(&uid, &entities).await.unwrap();
@@ -1039,7 +1049,7 @@ async fn test_batch_upsert_entities_idempotent() {
 
 #[tokio::test]
 async fn test_batch_upsert_entities_mixed_new_and_existing() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
 
     // Pre-create one entity via single upsert
     let (existing_id, _) = store
@@ -1068,7 +1078,7 @@ async fn test_batch_upsert_entities_mixed_new_and_existing() {
 
 #[tokio::test]
 async fn test_batch_upsert_entities_duplicates_in_input() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
 
     // Same entity name appears twice in one batch
     let entities: Vec<(&str, &str, &str)> =
@@ -1089,7 +1099,7 @@ async fn test_batch_upsert_entities_duplicates_in_input() {
 
 #[tokio::test]
 async fn test_batch_upsert_entities_large_batch() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
 
     // 120 entities — exceeds chunk size of 50, tests multi-chunk INSERT
     let names: Vec<String> = (0..120).map(|i| format!("entity_{i}")).collect();
@@ -1109,12 +1119,13 @@ async fn test_batch_upsert_entities_large_batch() {
 
 #[tokio::test]
 async fn test_batch_upsert_entities_user_isolation() {
-    let (store, uid1) = setup_graph().await;
+    let (store, uid1, ctx) = setup_graph().await;
     let uid2 = format!("graph_test_{}", uuid::Uuid::new_v4().simple());
+    let store2 = ctx.user_store(&uid2).await.graph_store();
 
     let entities: Vec<(&str, &str, &str)> = vec![("rust", "Rust", "tech")];
     let r1 = store.batch_upsert_entities(&uid1, &entities).await.unwrap();
-    let r2 = store.batch_upsert_entities(&uid2, &entities).await.unwrap();
+    let r2 = store2.batch_upsert_entities(&uid2, &entities).await.unwrap();
 
     // Same name, different users → different entity_ids
     assert_ne!(
@@ -1126,7 +1137,7 @@ async fn test_batch_upsert_entities_user_isolation() {
 
 #[tokio::test]
 async fn test_batch_upsert_entities_end_to_end_with_links() {
-    let (store, uid) = setup_graph().await;
+    let (store, uid, _ctx) = setup_graph().await;
     let mid = format!("mem_{}", uuid::Uuid::new_v4().simple());
 
     // Simulate the full process_entity_batch flow
@@ -1149,9 +1160,10 @@ async fn test_batch_upsert_entities_end_to_end_with_links() {
         .unwrap();
 
     // Verify links exist
-    let rows = sqlx::query(
-        "SELECT entity_id FROM mem_memory_entity_links WHERE user_id = ? AND memory_id = ?",
-    )
+    let links_table = store.t("mem_memory_entity_links");
+    let rows = sqlx::query(&format!(
+        "SELECT entity_id FROM {links_table} WHERE user_id = ? AND memory_id = ?"
+    ))
     .bind(&uid)
     .bind(&mid)
     .fetch_all(store.pool())
@@ -1165,18 +1177,7 @@ async fn test_batch_upsert_entities_end_to_end_with_links() {
 
 #[tokio::test]
 async fn test_purge_cleans_entity_links() {
-    use memoria_service::MemoryService;
-    use memoria_storage::SqlMemoryStore;
-    use std::sync::Arc;
-
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
-    let sql = SqlMemoryStore::connect(&db_url, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    sql.migrate().await.expect("migrate");
-    let uid = format!("gpurge_el_{}", uuid::Uuid::new_v4().simple());
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(sql.clone()), None, None).await);
+    let (svc, sql, pool, uid, _ctx) = setup_service("gpurge_el").await;
 
     // Store a memory
     let r = memoria_mcp::tools::call(
@@ -1188,12 +1189,7 @@ async fn test_purge_cleans_entity_links() {
     .await
     .expect("store");
     let text = r["content"][0]["text"].as_str().unwrap_or("");
-    let mid = text
-        .split_whitespace()
-        .nth(2)
-        .unwrap_or("")
-        .trim_end_matches(':')
-        .to_string();
+    let mid = extract_memory_id(text);
     assert!(!mid.is_empty(), "should extract memory_id from response");
 
     // Wait for async entity extraction
@@ -1210,7 +1206,7 @@ async fn test_purge_cleans_entity_links() {
     )
     .bind(&uid)
     .bind(&mid)
-    .fetch_all(sql.pool())
+    .fetch_all(&pool)
     .await
     .unwrap();
     assert!(!rows.is_empty(), "entity links should exist before purge");
@@ -1238,7 +1234,7 @@ async fn test_purge_cleans_entity_links() {
     )
     .bind(&uid)
     .bind(&mid)
-    .fetch_all(sql.pool())
+    .fetch_all(&pool)
     .await
     .unwrap();
     assert!(
@@ -1247,12 +1243,14 @@ async fn test_purge_cleans_entity_links() {
     );
 
     // Verify mem_memory_entity_links cleaned
-    let rows: Vec<(String,)> =
-        sqlx::query_as("SELECT entity_id FROM mem_memory_entity_links WHERE memory_id = ?")
-            .bind(&mid)
-            .fetch_all(sql.pool())
-            .await
-            .unwrap();
+    let memory_entity_links_table = sql.graph_store().t("mem_memory_entity_links");
+    let rows: Vec<(String,)> = sqlx::query_as(&format!(
+        "SELECT entity_id FROM {memory_entity_links_table} WHERE memory_id = ?"
+    ))
+    .bind(&mid)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
     assert!(
         rows.is_empty(),
         "mem_memory_entity_links should be cleaned after purge"
@@ -1265,18 +1263,7 @@ async fn test_purge_cleans_entity_links() {
 
 #[tokio::test]
 async fn test_purge_batch_cleans_graph_and_entity_links() {
-    use memoria_service::MemoryService;
-    use memoria_storage::SqlMemoryStore;
-    use std::sync::Arc;
-
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
-    let sql = SqlMemoryStore::connect(&db_url, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    sql.migrate().await.expect("migrate");
-    let uid = format!("gbatch_{}", uuid::Uuid::new_v4().simple());
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(sql.clone()), None, None).await);
+    let (svc, sql, _pool, uid, _ctx) = setup_service("gbatch").await;
 
     // Store two memories
     let mut mids = Vec::new();
@@ -1290,12 +1277,7 @@ async fn test_purge_batch_cleans_graph_and_entity_links() {
         .await
         .expect("store");
         let text = r["content"][0]["text"].as_str().unwrap_or("");
-        let mid = text
-            .split_whitespace()
-            .nth(2)
-            .unwrap_or("")
-            .trim_end_matches(':')
-            .to_string();
+        let mid = extract_memory_id(text);
         mids.push(mid);
     }
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -1334,18 +1316,7 @@ async fn test_purge_batch_cleans_graph_and_entity_links() {
 
 #[tokio::test]
 async fn test_correct_cleans_old_graph_node_via_service() {
-    use memoria_service::MemoryService;
-    use memoria_storage::SqlMemoryStore;
-    use std::sync::Arc;
-
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
-    let sql = SqlMemoryStore::connect(&db_url, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    sql.migrate().await.expect("migrate");
-    let uid = format!("gcorrect_svc_{}", uuid::Uuid::new_v4().simple());
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(sql.clone()), None, None).await);
+    let (svc, sql, pool, uid, _ctx) = setup_service("gcorrect_svc").await;
 
     // Store
     let r = memoria_mcp::tools::call(
@@ -1357,12 +1328,7 @@ async fn test_correct_cleans_old_graph_node_via_service() {
     .await
     .expect("store");
     let text = r["content"][0]["text"].as_str().unwrap_or("");
-    let old_mid = text
-        .split_whitespace()
-        .nth(2)
-        .unwrap_or("")
-        .trim_end_matches(':')
-        .to_string();
+    let old_mid = extract_memory_id(text);
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     // Verify old graph node exists
@@ -1393,7 +1359,7 @@ async fn test_correct_cleans_old_graph_node_via_service() {
     let rows: Vec<(String,)> =
         sqlx::query_as("SELECT entity_name FROM mem_entity_links WHERE memory_id = ?")
             .bind(&old_mid)
-            .fetch_all(sql.pool())
+            .fetch_all(&pool)
             .await
             .unwrap();
     assert!(
@@ -1411,15 +1377,7 @@ async fn test_correct_cleans_old_graph_node_via_service() {
 
 #[tokio::test]
 async fn test_governance_cleans_orphan_graph_data() {
-    use memoria_storage::SqlMemoryStore;
-
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
-    let sql = SqlMemoryStore::connect(&db_url, test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    sql.migrate().await.expect("migrate");
-    let uid = format!("gorphan_{}", uuid::Uuid::new_v4().simple());
+    let (sql, pool, uid, _ctx) = setup_sql("gorphan").await;
 
     // Insert a memory, then soft-delete it (simulating a crash mid-purge)
     let mid = uuid::Uuid::new_v4().simple().to_string();
@@ -1442,7 +1400,8 @@ async fn test_governance_cleans_orphan_graph_data() {
         access_count: 0,
         retrieval_score: None,
     };
-    sql.insert_into("mem_memories", &mem).await.expect("insert");
+    let memories_table = sql.t("mem_memories");
+    sql.insert_into(&memories_table, &mem).await.expect("insert");
 
     // Create graph node + entity links pointing to this memory
     let graph = sql.graph_store();
@@ -1471,7 +1430,7 @@ async fn test_governance_cleans_orphan_graph_data() {
     let el_rows: Vec<(String,)> =
         sqlx::query_as("SELECT entity_name FROM mem_entity_links WHERE memory_id = ?")
             .bind(&mid)
-            .fetch_all(sql.pool())
+            .fetch_all(&pool)
             .await
             .unwrap();
     assert!(!el_rows.is_empty(), "orphan entity links should exist");
@@ -1492,7 +1451,7 @@ async fn test_governance_cleans_orphan_graph_data() {
     let el_rows: Vec<(String,)> =
         sqlx::query_as("SELECT entity_name FROM mem_entity_links WHERE memory_id = ?")
             .bind(&mid)
-            .fetch_all(sql.pool())
+            .fetch_all(&pool)
             .await
             .unwrap();
     assert!(el_rows.is_empty(), "orphan entity links should be cleaned");

--- a/memoria/crates/memoria-mcp/tests/integration_full.rs
+++ b/memoria/crates/memoria-mcp/tests/integration_full.rs
@@ -6,10 +6,11 @@
 ///
 /// Run: DATABASE_URL=mysql://root:111@localhost:6001/memoria \
 ///      cargo test -p memoria-mcp --test integration_full -- --test-threads=1 --nocapture
+mod support;
+
 use chrono::Utc;
 use memoria_git::GitForDataService;
 use memoria_service::MemoryService;
-use memoria_storage::SqlMemoryStore;
 use serde_json::{json, Value};
 use sqlx::mysql::MySqlPool;
 use sqlx::Row;
@@ -23,22 +24,15 @@ fn test_dim() -> usize {
         .unwrap_or(1024)
 }
 
-fn db_url() -> String {
-    std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string())
-}
-
-async fn setup() -> (Arc<MemoryService>, Arc<GitForDataService>, String) {
-    let pool = MySqlPool::connect(&db_url()).await.expect("pool");
-    let db_name = db_url().rsplit('/').next().unwrap_or("memoria").to_string();
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("store");
-    store.migrate().await.expect("migrate");
-    let git = Arc::new(GitForDataService::new(pool, &db_name));
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
+async fn setup() -> (
+    Arc<MemoryService>,
+    Arc<GitForDataService>,
+    String,
+    support::multi_db::McpTestContext,
+) {
+    let ctx = support::multi_db::setup_mcp_context("integration_full", test_dim(), None, None).await;
     let uid = format!("integ_{}", &Uuid::new_v4().simple().to_string()[..8]);
-    (svc, git, uid)
+    (ctx.service(), ctx.git(), uid, ctx)
 }
 
 async fn tc(name: &str, args: Value, svc: &Arc<MemoryService>, uid: &str) -> Value {
@@ -133,8 +127,8 @@ fn extract_mid(store_response: &str) -> String {
 
 #[tokio::test]
 async fn test_full_stack_all_fields() {
-    let (svc, git, uid) = setup().await;
-    let pool = MySqlPool::connect(&db_url()).await.expect("pool");
+    let (svc, git, uid, ctx) = setup().await;
+    let pool = ctx.user_db_pool(&uid).await;
     let before = Utc::now();
 
     // ── Phase 1: Store memories with all variants ─────────────────────────────
@@ -374,7 +368,7 @@ async fn test_full_stack_all_fields() {
     let mid_branch = extract_mid(text(&r));
 
     // Verify branch memory is in branch table, not main
-    let sql_store = svc.sql_store.as_ref().unwrap();
+    let sql_store = ctx.user_store(&uid).await;
     let branches = sql_store.list_branches(&uid).await.unwrap();
     let branch_table = branches
         .iter()

--- a/memoria/crates/memoria-mcp/tests/mcp_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/mcp_e2e.rs
@@ -3,26 +3,20 @@
 ///
 /// Run: DATABASE_URL=... EMBEDDING_BASE_URL=... EMBEDDING_API_KEY=... \
 ///      SQLX_OFFLINE=true cargo test -p memoria-mcp --test mcp_e2e -- --nocapture
+mod support;
+
 use memoria_core::interfaces::EmbeddingProvider;
 use memoria_embedding::HttpEmbedder;
 use memoria_service::MemoryService;
-use memoria_storage::SqlMemoryStore;
 use serde_json::{json, Value};
 use std::sync::Arc;
 use uuid::Uuid;
 
-async fn make_service() -> (Arc<MemoryService>, String) {
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
+async fn make_service() -> (Arc<MemoryService>, String, support::multi_db::McpTestContext) {
     let dim: usize = std::env::var("EMBEDDING_DIM")
         .unwrap_or_else(|_| "1024".to_string())
         .parse()
         .unwrap_or(1024);
-
-    let store = SqlMemoryStore::connect(&db_url, dim, uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
 
     let embedder: Option<Arc<dyn EmbeddingProvider>> = {
         let base_url = std::env::var("EMBEDDING_BASE_URL").unwrap_or_default();
@@ -39,9 +33,8 @@ async fn make_service() -> (Arc<MemoryService>, String) {
     };
 
     let user_id = format!("e2e_{}", Uuid::new_v4().simple());
-    let store = Arc::new(store);
-    let svc = Arc::new(MemoryService::new(store.clone(), embedder, Some(store)));
-    (svc, user_id)
+    let ctx = support::multi_db::setup_mcp_context("mcp_e2e", dim, embedder, None).await;
+    (ctx.service(), user_id, ctx)
 }
 
 async fn call_tool(name: &str, args: Value, svc: &Arc<MemoryService>, uid: &str) -> Value {
@@ -56,7 +49,7 @@ fn text(v: &Value) -> &str {
 
 #[tokio::test]
 async fn test_e2e_store_retrieve() {
-    let (svc, uid) = make_service().await;
+    let (svc, uid, _ctx) = make_service().await;
 
     // Store
     let r = call_tool(
@@ -87,7 +80,7 @@ async fn test_e2e_store_retrieve() {
 
 #[tokio::test]
 async fn test_e2e_correct_purge() {
-    let (svc, uid) = make_service().await;
+    let (svc, uid, _ctx) = make_service().await;
 
     // Store
     let r = call_tool(
@@ -124,7 +117,7 @@ async fn test_e2e_correct_purge() {
 
 #[tokio::test]
 async fn test_e2e_list_profile() {
-    let (svc, uid) = make_service().await;
+    let (svc, uid, _ctx) = make_service().await;
 
     call_tool(
         "memory_store",
@@ -181,18 +174,12 @@ async fn make_git_service() -> (
     Arc<MemoryService>,
     Arc<memoria_git::GitForDataService>,
     String,
+    support::multi_db::McpTestContext,
 ) {
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string());
     let dim: usize = std::env::var("EMBEDDING_DIM")
         .unwrap_or_else(|_| "1024".to_string())
         .parse()
         .unwrap_or(1024);
-
-    let store = SqlMemoryStore::connect(&db_url, dim, uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
 
     let embedder: Option<Arc<dyn EmbeddingProvider>> = {
         let base_url = std::env::var("EMBEDDING_BASE_URL").unwrap_or_default();
@@ -207,19 +194,16 @@ async fn make_git_service() -> (
         }
     };
 
-    let pool = sqlx::mysql::MySqlPool::connect(&db_url)
-        .await
-        .expect("pool");
-    let db_name = db_url.rsplit('/').next().unwrap_or("memoria");
-    let git = Arc::new(memoria_git::GitForDataService::new(pool, db_name));
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), embedder, None).await);
+    let ctx = support::multi_db::setup_mcp_context("mcp_e2e_git", dim, embedder, None).await;
+    let git = ctx.git();
+    let svc = ctx.service();
     let uid = format!("e2e_{}", Uuid::new_v4().simple());
-    (svc, git, uid)
+    (svc, git, uid, ctx)
 }
 
 #[tokio::test]
 async fn test_e2e_branch_store_merge() {
-    let (svc, git, uid) = make_git_service().await;
+    let (svc, git, uid, _ctx) = make_git_service().await;
     let branch = format!("test_br_{}", &uid[5..13]);
 
     // 1. Store a memory on main

--- a/memoria/crates/memoria-mcp/tests/perf_optimizations_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/perf_optimizations_e2e.rs
@@ -5,8 +5,11 @@
 ///
 /// Run: DATABASE_URL=mysql://root:111@localhost:6001/memoria \
 ///      cargo test -p memoria-mcp --test perf_optimizations_e2e -- --test-threads=1 --nocapture
+mod support;
+
 use memoria_storage::SqlMemoryStore;
 use serde_json::json;
+use sqlx::mysql::MySqlPool;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -16,10 +19,6 @@ fn test_dim() -> usize {
         .and_then(|s| s.parse().ok())
         .unwrap_or(1024)
 }
-fn db_url() -> String {
-    std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string())
-}
 fn uid() -> String {
     format!("perf_{}", &Uuid::new_v4().simple().to_string()[..8])
 }
@@ -27,16 +26,15 @@ fn uid() -> String {
 async fn setup() -> (
     Arc<memoria_service::MemoryService>,
     Arc<SqlMemoryStore>,
+    MySqlPool,
     String,
+    support::multi_db::McpTestContext,
 ) {
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), Uuid::new_v4().to_string())
-        .await
-        .expect("connect");
-    store.migrate().await.expect("migrate");
-    let store = Arc::new(store);
-    let svc =
-        Arc::new(memoria_service::MemoryService::new_sql_with_llm(store.clone(), None, None).await);
-    (svc, store, uid())
+    let ctx = support::multi_db::setup_mcp_context("perf_optimizations", test_dim(), None, None).await;
+    let uid = uid();
+    let store = ctx.user_store(&uid).await;
+    let pool = ctx.user_db_pool(&uid).await;
+    (ctx.service(), store, pool, uid, ctx)
 }
 
 async fn call(
@@ -57,15 +55,15 @@ fn text(v: &serde_json::Value) -> &str {
 
 #[tokio::test]
 async fn test_active_table_cache_hit_and_invalidation() {
-    let (_svc, store, uid) = setup().await;
+    let (_svc, store, pool, uid, _ctx) = setup().await;
 
     // First call: cache miss → DB lookup → should return "mem_memories"
     let t1 = store.active_table(&uid).await.expect("active_table 1");
-    assert_eq!(t1, "mem_memories", "default should be mem_memories");
+    assert_eq!(t1, store.t("mem_memories"), "default should be mem_memories");
 
     // Second call: should be cache hit (same result)
     let t2 = store.active_table(&uid).await.expect("active_table 2");
-    assert_eq!(t2, "mem_memories", "cached value should match");
+    assert_eq!(t2, store.t("mem_memories"), "cached value should match");
 
     // Switch to a branch
     let branch_name = format!("b_{}", &Uuid::new_v4().simple().to_string()[..6]);
@@ -74,7 +72,7 @@ async fn test_active_table_cache_hit_and_invalidation() {
     sqlx::query(&format!(
         "CREATE TABLE IF NOT EXISTS {table_name} LIKE mem_memories"
     ))
-    .execute(store.pool())
+    .execute(&pool)
     .await
     .expect("create branch table");
     // Use register_branch which handles the schema correctly
@@ -91,7 +89,7 @@ async fn test_active_table_cache_hit_and_invalidation() {
 
     // Now active_table should return the branch table
     let t3 = store.active_table(&uid).await.expect("active_table 3");
-    assert_eq!(t3, table_name, "should return branch table after switch");
+    assert_eq!(t3, store.t(&table_name), "should return branch table after switch");
 
     // Switch back to main
     store
@@ -100,21 +98,22 @@ async fn test_active_table_cache_hit_and_invalidation() {
         .expect("set_active_branch main");
     let t4 = store.active_table(&uid).await.expect("active_table 4");
     assert_eq!(
-        t4, "mem_memories",
+        t4,
+        store.t("mem_memories"),
         "should return mem_memories after switch back"
     );
 
     // Cleanup
     let _ = sqlx::query(&format!("DROP TABLE IF EXISTS {table_name}"))
-        .execute(store.pool())
+        .execute(&pool)
         .await;
     let _ = sqlx::query("DELETE FROM mem_branches WHERE user_id = ?")
         .bind(&uid)
-        .execute(store.pool())
+        .execute(&pool)
         .await;
     let _ = sqlx::query("DELETE FROM mem_user_state WHERE user_id = ?")
         .bind(&uid)
-        .execute(store.pool())
+        .execute(&pool)
         .await;
 
     println!("✅ active_table cache: hit + invalidation on branch switch");
@@ -124,7 +123,7 @@ async fn test_active_table_cache_hit_and_invalidation() {
 
 #[tokio::test]
 async fn test_cooldown_cache_fast_path() {
-    let (_svc, store, uid) = setup().await;
+    let (_svc, store, pool, uid, _ctx) = setup().await;
     let op = "test_governance";
     let cooldown_secs = 3600; // 1 hour
 
@@ -157,7 +156,7 @@ async fn test_cooldown_cache_fast_path() {
     )
     .bind(&uid)
     .bind(op)
-    .fetch_optional(store.pool())
+    .fetch_optional(&pool)
     .await
     .expect("query cooldown");
     assert!(db_row.is_some(), "cooldown should exist in DB");
@@ -167,7 +166,7 @@ async fn test_cooldown_cache_fast_path() {
     // Cleanup
     let _ = sqlx::query("DELETE FROM mem_governance_cooldown WHERE user_id = ?")
         .bind(&uid)
-        .execute(store.pool())
+        .execute(&pool)
         .await;
 
     println!("✅ cooldown cache: fast path + DB consistency");
@@ -176,7 +175,7 @@ async fn test_cooldown_cache_fast_path() {
 #[tokio::test]
 async fn test_cooldown_cache_db_fallback_on_cold_start() {
     // Simulate cross-instance scenario: set cooldown via raw DB, then check via cache
-    let (_svc, store, uid) = setup().await;
+    let (_svc, store, pool, uid, _ctx) = setup().await;
     let op = "test_consolidate";
     let cooldown_secs = 1800;
 
@@ -187,7 +186,7 @@ async fn test_cooldown_cache_db_fallback_on_cold_start() {
     )
     .bind(&uid)
     .bind(op)
-    .execute(store.pool())
+    .execute(&pool)
     .await
     .expect("insert cooldown");
 
@@ -213,7 +212,7 @@ async fn test_cooldown_cache_db_fallback_on_cold_start() {
     // Cleanup
     let _ = sqlx::query("DELETE FROM mem_governance_cooldown WHERE user_id = ?")
         .bind(&uid)
-        .execute(store.pool())
+        .execute(&pool)
         .await;
 
     println!("✅ cooldown cache: DB fallback on cold start + backfill");
@@ -223,7 +222,7 @@ async fn test_cooldown_cache_db_fallback_on_cold_start() {
 
 #[tokio::test]
 async fn test_node_count_cache_shared_across_graph_store_instances() {
-    let (_svc, store, uid) = setup().await;
+    let (_svc, store, pool, uid, _ctx) = setup().await;
     use memoria_storage::graph::types::{GraphNode, NodeType};
 
     let graph1 = store.graph_store();
@@ -298,7 +297,7 @@ async fn test_node_count_cache_shared_across_graph_store_instances() {
         "SELECT COUNT(*) FROM memory_graph_nodes WHERE user_id = ? AND is_active = 1",
     )
     .bind(&uid)
-    .fetch_one(store.pool())
+    .fetch_one(&pool)
     .await
     .expect("db count");
     assert_eq!(db_count, 6, "DB should have 6 nodes");
@@ -306,7 +305,7 @@ async fn test_node_count_cache_shared_across_graph_store_instances() {
     // Cleanup
     let _ = sqlx::query("DELETE FROM memory_graph_nodes WHERE user_id = ?")
         .bind(&uid)
-        .execute(store.pool())
+        .execute(&pool)
         .await;
 
     println!("✅ node_count_cache: shared across GraphStore instances from same SqlMemoryStore");
@@ -316,7 +315,7 @@ async fn test_node_count_cache_shared_across_graph_store_instances() {
 
 #[tokio::test]
 async fn test_get_stats_batch_returns_correct_values() {
-    let (svc, store, uid) = setup().await;
+    let (svc, store, pool, uid, _ctx) = setup().await;
 
     // Store two memories
     let r1 = call(
@@ -427,7 +426,7 @@ async fn test_get_stats_batch_returns_correct_values() {
 
 #[tokio::test]
 async fn test_batch_entity_methods() {
-    let (_svc, store, uid) = setup().await;
+    let (_svc, store, pool, uid, _ctx) = setup().await;
     let graph = store.graph_store();
     graph.migrate().await.expect("migrate");
 
@@ -465,8 +464,9 @@ async fn test_batch_entity_methods() {
         created_at: Some(chrono::Utc::now()),
         updated_at: None,
     };
+    let memories_table = store.t("mem_memories");
     store
-        .insert_into("mem_memories", &mem)
+        .insert_into(&memories_table, &mem)
         .await
         .expect("insert memory");
 
@@ -537,15 +537,15 @@ async fn test_batch_entity_methods() {
     // Cleanup
     let _ = sqlx::query("DELETE FROM mem_memory_entity_links WHERE user_id = ?")
         .bind(&uid)
-        .execute(store.pool())
+        .execute(&pool)
         .await;
     let _ = sqlx::query("DELETE FROM mem_entities WHERE user_id = ?")
         .bind(&uid)
-        .execute(store.pool())
+        .execute(&pool)
         .await;
     let _ = sqlx::query("DELETE FROM mem_memories WHERE user_id = ?")
         .bind(&uid)
-        .execute(store.pool())
+        .execute(&pool)
         .await;
 
     println!("✅ batch entity methods: find_entities_by_names + get_memories_by_entities");
@@ -555,7 +555,7 @@ async fn test_batch_entity_methods() {
 
 #[tokio::test]
 async fn test_find_near_duplicate_single_query_same_type_preference() {
-    let (_svc, store, uid) = setup().await;
+    let (_svc, store, pool, uid, _ctx) = setup().await;
     let dim = test_dim();
 
     // Create a base embedding
@@ -582,8 +582,9 @@ async fn test_find_near_duplicate_single_query_same_type_preference() {
         created_at: Some(chrono::Utc::now()),
         updated_at: None,
     };
+    let memories_table = store.t("mem_memories");
     store
-        .insert_into("mem_memories", &mem_a)
+        .insert_into(&memories_table, &mem_a)
         .await
         .expect("insert A");
 
@@ -610,7 +611,7 @@ async fn test_find_near_duplicate_single_query_same_type_preference() {
         updated_at: None,
     };
     store
-        .insert_into("mem_memories", &mem_b)
+        .insert_into(&memories_table, &mem_b)
         .await
         .expect("insert B");
 
@@ -669,7 +670,7 @@ async fn test_find_near_duplicate_single_query_same_type_preference() {
     // Cleanup
     let _ = sqlx::query("DELETE FROM mem_memories WHERE user_id = ?")
         .bind(&uid)
-        .execute(store.pool())
+        .execute(&pool)
         .await;
 
     println!("✅ find_near_duplicate: single query with same-type preference");
@@ -679,7 +680,7 @@ async fn test_find_near_duplicate_single_query_same_type_preference() {
 
 #[tokio::test]
 async fn test_feedback_created_at_index_exists() {
-    let (_svc, store, _uid) = setup().await;
+    let (_svc, store, pool, _uid, _ctx) = setup().await;
 
     let count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM information_schema.statistics \
@@ -687,7 +688,7 @@ async fn test_feedback_created_at_index_exists() {
            AND table_name = 'mem_retrieval_feedback' \
            AND index_name = 'idx_feedback_created_at'",
     )
-    .fetch_one(store.pool())
+    .fetch_one(&pool)
     .await
     .expect("check index");
 
@@ -702,7 +703,7 @@ async fn test_feedback_created_at_index_exists() {
 
 #[tokio::test]
 async fn test_hybrid_search_concurrent_correctness() {
-    let (svc, _store, uid) = setup().await;
+    let (svc, _store, _pool, uid, _ctx) = setup().await;
 
     // Store several memories with distinct content
     for i in 0..5 {
@@ -740,11 +741,10 @@ async fn test_hybrid_search_concurrent_correctness() {
 
 #[tokio::test]
 async fn test_graph_store_new_standalone_still_works() {
-    let pool = sqlx::MySqlPool::connect(&db_url()).await.expect("pool");
+    let (_svc, _store, pool, uid, _ctx) = setup().await;
     let graph = memoria_storage::GraphStore::new(pool, test_dim());
     graph.migrate().await.expect("migrate");
 
-    let uid = uid();
     // count_user_nodes should work (own cache, not shared)
     let count = graph.count_user_nodes(&uid).await.expect("count");
     assert_eq!(count, 0, "new user should have 0 nodes");

--- a/memoria/crates/memoria-mcp/tests/snapshot_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/snapshot_e2e.rs
@@ -4,12 +4,12 @@
 /// IMPORTANT: These tests MUST run serially because:
 /// - MO#23860: concurrent DELETE + INSERT FROM SNAPSHOT causes w-w conflict
 /// - MO#23861: concurrent snapshot restore loses FULLTEXT INDEX secondary tables
+mod support;
+
 use memoria_git::GitForDataService;
 use memoria_service::MemoryService;
-use memoria_storage::{DbRouter, SqlMemoryStore};
 use serde_json::{json, Value};
 use serial_test::serial;
-use sqlx::mysql::MySqlPool;
 use std::sync::Arc;
 use tokio::sync::Barrier;
 use uuid::Uuid;
@@ -19,34 +19,6 @@ fn test_dim() -> usize {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(1024)
-}
-
-fn db_url() -> String {
-    std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string())
-}
-
-fn test_db_name() -> String {
-    parse_db_name(&db_url())
-}
-
-fn parse_db_name(database_url: &str) -> String {
-    let db = database_url;
-    let suffix_start = db.find(['?', '#']).unwrap_or(db.len());
-    db[..suffix_start]
-        .rsplit('/')
-        .next()
-        .unwrap_or("memoria")
-        .to_string()
-}
-
-fn replace_db_name(database_url: &str, db_name: &str) -> String {
-    let suffix_start = database_url.find(['?', '#']).unwrap_or(database_url.len());
-    let (without_suffix, suffix) = database_url.split_at(suffix_start);
-    let (base, _) = without_suffix
-        .rsplit_once('/')
-        .expect("database url must include db name");
-    format!("{base}/{db_name}{suffix}")
 }
 
 fn uid() -> String {
@@ -119,14 +91,14 @@ fn compact_identifier_fragment(value: &str, max_len: usize) -> String {
 }
 
 /// Mirror of git_tools::snap_internal so white-box assertions follow scoped names.
-fn internal_snapshot_name(name: &str) -> String {
+fn internal_snapshot_name(db_name: &str, name: &str) -> String {
     const SNAP_PREFIX: &str = "mem_snap_";
     const MILESTONE_PREFIX: &str = "mem_milestone_";
 
     if name.starts_with(SNAP_PREFIX) || name.starts_with(MILESTONE_PREFIX) {
         name.to_string()
     } else {
-        let scope = sanitize_snapshot_scope(&test_db_name());
+        let scope = sanitize_snapshot_scope(db_name);
         format!(
             "{SNAP_PREFIX}{}_{scope}_{}",
             scope.len(),
@@ -135,56 +107,35 @@ fn internal_snapshot_name(name: &str) -> String {
     }
 }
 
-async fn setup() -> (Arc<MemoryService>, Arc<GitForDataService>, String) {
-    let pool = MySqlPool::connect(&db_url()).await.expect("pool");
-    let db_name = test_db_name();
-    let store = SqlMemoryStore::connect(&db_url(), test_dim(), uuid::Uuid::new_v4().to_string())
-        .await
-        .expect("store");
-    store.migrate().await.expect("migrate");
-    let git = Arc::new(GitForDataService::new(pool, &db_name));
-    let svc = Arc::new(MemoryService::new_sql_with_llm(Arc::new(store), None, None).await);
-    (svc, git, uid())
+async fn setup() -> (
+    Arc<MemoryService>,
+    Arc<GitForDataService>,
+    String,
+    String,
+    support::multi_db::McpTestContext,
+) {
+    let ctx = support::multi_db::setup_mcp_context("snapshot_e2e", test_dim(), None, None).await;
+    let uid = uid();
+    let db_name = ctx.user_db_name(&uid).await;
+    (ctx.service(), ctx.git(), uid, db_name, ctx)
 }
 
 async fn setup_multi_db() -> (
     Arc<MemoryService>,
+    String,
+    String,
+    String,
+    String,
     Arc<GitForDataService>,
-    Arc<DbRouter>,
-    String,
-    String,
+    support::multi_db::McpTestContext,
 ) {
-    let shared_db_url = replace_db_name(
-        &db_url(),
-        &format!(
-            "memoria_snap_multi_{}",
-            &Uuid::new_v4().simple().to_string()[..8]
-        ),
-    );
-    let router = Arc::new(
-        DbRouter::connect(&shared_db_url, test_dim(), uuid::Uuid::new_v4().to_string())
-            .await
-            .expect("router"),
-    );
-    let mut store =
-        SqlMemoryStore::connect(&shared_db_url, test_dim(), uuid::Uuid::new_v4().to_string())
-            .await
-            .expect("store");
-    store.migrate_shared().await.expect("migrate_shared");
-    store.set_db_router(router.clone());
-
-    let pool = MySqlPool::connect(&shared_db_url).await.expect("pool");
-    let git = Arc::new(GitForDataService::new(pool, parse_db_name(&shared_db_url)));
-    let svc = Arc::new(
-        MemoryService::new_sql_with_llm_and_router(
-            Arc::new(store),
-            Some(router.clone()),
-            None,
-            None,
-        )
-        .await,
-    );
-    (svc, git, router, uid(), uid())
+    let ctx =
+        support::multi_db::setup_mcp_context("snapshot_e2e_multi", test_dim(), None, None).await;
+    let user_a = uid();
+    let user_b = uid();
+    let db_a = ctx.user_db_name(&user_a).await;
+    let db_b = ctx.user_db_name(&user_b).await;
+    (ctx.service(), user_a, user_b, db_a, db_b, ctx.git(), ctx)
 }
 
 async fn git_call(
@@ -205,6 +156,14 @@ async fn store(content: &str, svc: &Arc<MemoryService>, uid: &str) {
         .expect("store");
 }
 
+async fn git_for_user(svc: &Arc<MemoryService>, uid: &str) -> GitForDataService {
+    let sql = svc.user_sql_store(uid).await.expect("user sql store");
+    GitForDataService::new(
+        sql.pool().clone(),
+        sql.database_name().expect("user db name").to_string(),
+    )
+}
+
 fn text(v: &Value) -> &str {
     v["content"][0]["text"].as_str().unwrap_or("")
 }
@@ -214,7 +173,7 @@ fn text(v: &Value) -> &str {
 #[tokio::test]
 #[serial]
 async fn test_snapshot_rollback_restores_state() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let snap_name = snap("basic");
 
     // Store 2 memories
@@ -282,7 +241,7 @@ async fn test_snapshot_rollback_restores_state() {
 #[tokio::test]
 #[serial]
 async fn test_rollback_nonexistent_snapshot_errors() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let result = memoria_mcp::git_tools::call(
         "memory_rollback",
         json!({"name": "does_not_exist_xyz"}),
@@ -300,7 +259,7 @@ async fn test_rollback_nonexistent_snapshot_errors() {
 #[tokio::test]
 #[serial]
 async fn test_multiple_snapshots_rollback_to_earlier() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let snap1 = snap("v1");
     let snap2 = snap("v2");
 
@@ -335,7 +294,7 @@ async fn test_multiple_snapshots_rollback_to_earlier() {
 #[tokio::test]
 #[serial]
 async fn test_snapshots_pagination() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let names: Vec<String> = (0..5).map(|i| snap(&format!("pg{i}"))).collect();
 
     for n in &names {
@@ -385,7 +344,7 @@ async fn test_snapshots_pagination() {
 #[tokio::test]
 #[serial]
 async fn test_snapshot_delete_by_prefix() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let prefix = format!("pre_{}", &uid[5..]);
     let s1 = format!("{prefix}_a");
     let s2 = format!("{prefix}_b");
@@ -412,10 +371,11 @@ async fn test_snapshot_delete_by_prefix() {
     println!("✅ delete by prefix: {}", text(&r));
 
     // keeper should still exist (check by internal name)
-    let snaps = git.list_snapshots().await.unwrap();
-    let keeper_internal = internal_snapshot_name(&keeper);
-    let s1_internal = internal_snapshot_name(&s1);
-    let s2_internal = internal_snapshot_name(&s2);
+    let user_git = git_for_user(&svc, &uid).await;
+    let snaps = user_git.list_snapshots().await.unwrap();
+    let keeper_internal = internal_snapshot_name(&db_name, &keeper);
+    let s1_internal = internal_snapshot_name(&db_name, &s1);
+    let s2_internal = internal_snapshot_name(&db_name, &s2);
     assert!(
         snaps.iter().any(|s| s.snapshot_name == keeper_internal),
         "keeper should survive"
@@ -445,7 +405,7 @@ async fn test_snapshot_delete_by_prefix() {
 #[tokio::test]
 #[serial]
 async fn test_snapshot_delete_batch_names() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let s1 = snap("b1");
     let s2 = snap("b2");
     let s3 = snap("b3");
@@ -469,10 +429,11 @@ async fn test_snapshot_delete_batch_names() {
         text(&r)
     );
 
-    let snaps = git.list_snapshots().await.unwrap();
-    let s1i = internal_snapshot_name(&s1);
-    let s2i = internal_snapshot_name(&s2);
-    let s3i = internal_snapshot_name(&s3);
+    let user_git = git_for_user(&svc, &uid).await;
+    let snaps = user_git.list_snapshots().await.unwrap();
+    let s1i = internal_snapshot_name(&db_name, &s1);
+    let s2i = internal_snapshot_name(&db_name, &s2);
+    let s3i = internal_snapshot_name(&db_name, &s3);
     assert!(!snaps.iter().any(|s| s.snapshot_name == s1i));
     assert!(
         snaps.iter().any(|s| s.snapshot_name == s2i),
@@ -496,7 +457,7 @@ async fn test_snapshot_delete_batch_names() {
 #[tokio::test]
 #[serial]
 async fn test_snapshot_and_branch_independent() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let snap_name = snap("pre_branch");
     let branch = format!("br_{}", &uid[5..]);
 
@@ -569,7 +530,7 @@ async fn test_snapshot_and_branch_independent() {
 #[tokio::test]
 #[serial]
 async fn test_duplicate_snapshot_name_rejected() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let snap_name = snap("dup");
 
     let first = git_call(
@@ -619,7 +580,7 @@ async fn test_duplicate_snapshot_name_rejected() {
 #[tokio::test]
 #[serial]
 async fn test_concurrent_duplicate_snapshot_name_is_coalesced() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let snap_name = snap("dupcon");
     let barrier = Arc::new(Barrier::new(3));
 
@@ -664,8 +625,9 @@ async fn test_concurrent_duplicate_snapshot_name_is_coalesced() {
     let count = regs.iter().filter(|reg| reg.name == snap_name).count();
     assert_eq!(count, 1, "concurrent create should register once");
 
-    let internal = internal_snapshot_name(&snap_name);
-    let snaps = git.list_snapshots().await.unwrap();
+    let internal = internal_snapshot_name(&db_name, &snap_name);
+    let user_git = git_for_user(&svc, &uid).await;
+    let snaps = user_git.list_snapshots().await.unwrap();
     let internal_count = snaps
         .iter()
         .filter(|snapshot| snapshot.snapshot_name == internal)
@@ -688,14 +650,12 @@ async fn test_concurrent_duplicate_snapshot_name_is_coalesced() {
 #[tokio::test]
 #[serial]
 async fn test_multi_db_snapshot_rollback_isolates_users() {
-    let (svc, git, router, user_a, user_b) = setup_multi_db().await;
+    let (svc, user_a, user_b, db_a, db_b, git, _ctx) = setup_multi_db().await;
     let snap_name = snap("multi");
 
     store("alice before snapshot", &svc, &user_a).await;
     store("bob steady state", &svc, &user_b).await;
 
-    let db_a = router.user_db_name(&user_a).await.unwrap();
-    let db_b = router.user_db_name(&user_b).await.unwrap();
     assert_ne!(
         db_a, db_b,
         "multi-db test must route users to different databases"
@@ -755,7 +715,7 @@ async fn test_multi_db_snapshot_rollback_isolates_users() {
 #[tokio::test]
 #[serial]
 async fn test_multiuser_snapshot_isolation() {
-    let (svc, git, _) = setup().await;
+    let (svc, git, _, _db_name, _ctx) = setup().await;
     let uid_a = uid();
     let uid_b = uid();
     let snap_a = snap("ua");
@@ -792,23 +752,18 @@ async fn test_multiuser_snapshot_isolation() {
     assert_eq!(a_list.len(), 1);
     assert_eq!(a_list[0].content, "user A memory");
 
-    // User B's memories must be untouched — rollback is full-table but user_id filters retrieval
-    // NOTE: rollback replaces all rows in mem_memories from snapshot, so B's rows are gone too.
-    // This is a known limitation: snapshot/rollback is account-level, not per-user.
-    // Document this behavior explicitly.
+    // In multi-db mode user B lives in a different database, so A's rollback must not affect B.
     let b_list = svc.list_active(&uid_b, 10).await.unwrap();
-    // After rollback, B's memories are gone (snapshot was taken before B stored anything)
-    // This is expected behavior — same as Python version.
     println!(
-        "ℹ️  After A's rollback, B has {} memories (expected 0 — account-level rollback)",
+        "ℹ️  After A's rollback, B has {} memories (expected 2 — isolated user DB)",
         b_list.len()
     );
     assert_eq!(
         b_list.len(),
-        0,
-        "Account-level rollback removes all users' data not in snapshot — known limitation"
+        2,
+        "multi-db rollback should leave other users' data untouched"
     );
-    println!("✅ multiuser: account-level rollback behavior documented");
+    println!("✅ multiuser: rollback isolated to the initiating user's DB");
 
     git_call(
         "memory_snapshot_delete",
@@ -823,7 +778,7 @@ async fn test_multiuser_snapshot_isolation() {
 #[tokio::test]
 #[serial]
 async fn test_snapshot_limit_is_per_user_and_capped_at_20() {
-    let (svc, git, _) = setup().await;
+    let (svc, git, _, _db_name, _ctx) = setup().await;
     let uid_a = uid();
     let uid_b = uid();
 
@@ -896,7 +851,7 @@ async fn test_snapshot_limit_is_per_user_and_capped_at_20() {
 #[tokio::test]
 #[serial]
 async fn test_snapshot_delete_is_scoped_to_owner() {
-    let (svc, git, _) = setup().await;
+    let (svc, git, _, _db_name, _ctx) = setup().await;
     let uid_a = uid();
     let uid_b = uid();
     let snap_a = snap("owned");
@@ -946,7 +901,7 @@ async fn test_snapshot_delete_is_scoped_to_owner() {
 #[tokio::test]
 #[serial]
 async fn test_snapshot_delete_older_than() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let s1 = snap("old1");
     let s2 = snap("old2");
     let s3 = snap("keep");
@@ -971,13 +926,13 @@ async fn test_snapshot_delete_older_than() {
             let snaps = git.list_snapshots().await.unwrap();
             !snaps
                 .iter()
-                .any(|s| s.snapshot_name == internal_snapshot_name(&s1))
+                .any(|s| s.snapshot_name == internal_snapshot_name(&db_name, &s1))
                 && !snaps
                     .iter()
-                    .any(|s| s.snapshot_name == internal_snapshot_name(&s2))
+                    .any(|s| s.snapshot_name == internal_snapshot_name(&db_name, &s2))
                 && !snaps
                     .iter()
-                    .any(|s| s.snapshot_name == internal_snapshot_name(&s3))
+                    .any(|s| s.snapshot_name == internal_snapshot_name(&db_name, &s3))
         },
         "expected all 3 deleted, got: {t}"
     );
@@ -1003,7 +958,7 @@ async fn test_snapshot_delete_older_than() {
 #[tokio::test]
 #[serial]
 async fn test_snapshot_list_filters_system_snapshots() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let s1 = snap("mysnap");
     git_call("memory_snapshot", json!({"name": s1}), &git, &svc, &uid).await;
 
@@ -1035,7 +990,7 @@ async fn test_snapshot_list_filters_system_snapshots() {
 #[tokio::test]
 #[serial]
 async fn test_chained_snapshot_rollback() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let snap_v1 = snap("v1");
     let snap_v2 = snap("v2");
 
@@ -1104,7 +1059,7 @@ async fn test_chained_snapshot_rollback() {
 #[tokio::test]
 #[serial]
 async fn test_branch_limit_enforced() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
 
     // Create branches up to limit (MAX_BRANCHES = 20)
     // We'll create a few and verify the limit message, not exhaust the full 20
@@ -1144,7 +1099,7 @@ async fn test_branch_limit_enforced() {
 #[tokio::test]
 #[serial]
 async fn test_branch_from_snapshot() {
-    let (svc, git, uid) = setup().await;
+    let (svc, git, uid, db_name, _ctx) = setup().await;
     let snap_name = snap("forsplit");
     let branch = format!("bfs_{}", &uid[5..]);
 
@@ -1220,7 +1175,7 @@ async fn test_branch_from_snapshot() {
 #[tokio::test]
 #[serial]
 async fn test_milestone_snapshot_not_counted_towards_limit() {
-    let (svc, git, _) = setup().await;
+    let (svc, git, _, _db_name, _ctx) = setup().await;
     let uid_a = uid();
 
     // Create 20 user snapshots (at the limit)
@@ -1234,9 +1189,12 @@ async fn test_milestone_snapshot_not_counted_towards_limit() {
         );
     }
 
-    // Create a milestone snapshot directly via git (simulating system-created milestone)
-    let milestone_name = "mem_milestone_test_milestone";
-    git.create_snapshot(milestone_name)
+    // Create a milestone snapshot directly in user A's DB (simulating system-created milestone)
+    let milestone_suffix = &Uuid::new_v4().simple().to_string()[..6];
+    let milestone_name = format!("mem_milestone_test_milestone_{milestone_suffix}");
+    let user_git = git_for_user(&svc, &uid_a).await;
+    user_git
+        .create_snapshot(&milestone_name)
         .await
         .expect("create milestone");
 
@@ -1256,18 +1214,18 @@ async fn test_milestone_snapshot_not_counted_towards_limit() {
         text(&r)
     );
 
-    // But user B should see the milestone in their list
-    let uid_b = uid();
-    let r = git_call("memory_snapshots", json!({"limit": 50}), &git, &svc, &uid_b).await;
+    // User A should see the milestone in their list.
+    let r = git_call("memory_snapshots", json!({"limit": 50}), &git, &svc, &uid_a).await;
     let t = text(&r);
     assert!(
         t.contains("auto:test_milestone"),
-        "B should see milestone: {}",
+        "A should see milestone in the same DB: {}",
         t
     );
 
     // Cleanup
-    git.drop_snapshot(milestone_name)
+    user_git
+        .drop_snapshot(&milestone_name)
         .await
         .expect("drop milestone");
     git_call(
@@ -1285,7 +1243,7 @@ async fn test_milestone_snapshot_not_counted_towards_limit() {
 #[tokio::test]
 #[serial]
 async fn test_delete_releases_quota() {
-    let (svc, git, _) = setup().await;
+    let (svc, git, _, _db_name, _ctx) = setup().await;
     let uid_a = uid();
 
     // Create 20 snapshots (at limit)
@@ -1374,24 +1332,26 @@ async fn test_delete_releases_quota() {
     .await;
 }
 
-// ── 17. Safety snapshots (mem_snap_pre_*) are globally visible ─────────────────
+// ── 17. Safety snapshots (mem_snap_pre_*) are visible within the same user DB ──
 
 #[tokio::test]
 #[serial]
 async fn test_safety_snapshot_globally_visible() {
-    let (svc, git, _) = setup().await;
+    let (svc, git, _, _db_name, _ctx) = setup().await;
     let uid_a = uid();
     let uid_b = uid();
 
-    // Create a safety snapshot directly via git (use unique name)
+    // Create a safety snapshot directly in user A's DB (use unique name)
     let unique_id = &Uuid::new_v4().simple().to_string()[..6];
     let safety_name = format!("mem_snap_pre_safety_{unique_id}");
     let display_name = format!("pre_safety_{unique_id}"); // snap_display strips mem_snap_ prefix
-    git.create_snapshot(&safety_name)
+    let user_git = git_for_user(&svc, &uid_a).await;
+    user_git
+        .create_snapshot(&safety_name)
         .await
         .expect("create safety");
 
-    // Both users should see it in their list (by display name)
+    // User A should see it in their list (by display name)
     let r_a = git_call("memory_snapshots", json!({"limit": 50}), &git, &svc, &uid_a).await;
     let t_a = text(&r_a);
     assert!(
@@ -1403,13 +1363,12 @@ async fn test_safety_snapshot_globally_visible() {
     let r_b = git_call("memory_snapshots", json!({"limit": 50}), &git, &svc, &uid_b).await;
     let t_b = text(&r_b);
     assert!(
-        t_b.contains(&display_name),
-        "B should see safety snapshot: {}",
+        !t_b.contains(&display_name),
+        "B should not see safety snapshot from another DB: {}",
         t_b
     );
 
-    // Safety snapshots are globally visible and can be deleted by any user
-    // (they are not protected, just not registered to any specific user)
+    // Safety snapshots are deletable by the user in the same DB.
     let r = git_call(
         "memory_snapshot_delete",
         json!({"names": &display_name}),

--- a/memoria/crates/memoria-mcp/tests/support/mod.rs
+++ b/memoria/crates/memoria-mcp/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub mod multi_db;

--- a/memoria/crates/memoria-mcp/tests/support/multi_db.rs
+++ b/memoria/crates/memoria-mcp/tests/support/multi_db.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use memoria_core::interfaces::EmbeddingProvider;
+use memoria_embedding::LlmClient;
+use memoria_git::GitForDataService;
+use memoria_service::MemoryService;
+use memoria_storage::{DbRouter, SqlMemoryStore};
+use memoria_test_utils::MultiDbTestContext;
+use sqlx::MySqlPool;
+
+pub struct McpTestContext {
+    inner: MultiDbTestContext,
+}
+
+impl McpTestContext {
+    pub fn service(&self) -> Arc<MemoryService> {
+        self.inner.service()
+    }
+
+    pub fn git(&self) -> Arc<GitForDataService> {
+        self.inner.git()
+    }
+
+    pub fn router(&self) -> Arc<DbRouter> {
+        self.inner.router()
+    }
+
+    pub fn shared_pool(&self) -> MySqlPool {
+        self.inner.shared_pool()
+    }
+
+    pub fn shared_store(&self) -> Arc<SqlMemoryStore> {
+        self.inner.shared_store()
+    }
+
+    pub async fn user_store(&self, user_id: &str) -> Arc<SqlMemoryStore> {
+        self.inner.user_store(user_id).await
+    }
+
+    pub async fn user_table(&self, user_id: &str, table: &str) -> String {
+        self.inner.user_table(user_id, table).await
+    }
+
+    pub async fn user_db_name(&self, user_id: &str) -> String {
+        self.inner.user_db_name(user_id).await
+    }
+
+    pub async fn user_db_pool(&self, user_id: &str) -> MySqlPool {
+        self.inner.user_db_pool(user_id).await
+    }
+}
+
+pub async fn setup_mcp_context(
+    db_name_prefix: &str,
+    embedding_dim: usize,
+    embedder: Option<Arc<dyn EmbeddingProvider>>,
+    llm: Option<Arc<LlmClient>>,
+) -> McpTestContext {
+    McpTestContext {
+        inner: MultiDbTestContext::new(
+            &db_url(),
+            db_name_prefix,
+            embedding_dim,
+            embedder,
+            llm,
+        )
+        .await,
+    }
+}
+
+fn db_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string())
+}

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -1585,11 +1585,11 @@ impl SqlMemoryStore {
         sqlx::query(
             r#"CREATE TABLE IF NOT EXISTS mem_governance_runtime_state (
                 strategy_key       VARCHAR(128) NOT NULL,
-                task               VARCHAR(32)  NOT NULL,
+                `task`             VARCHAR(32)  NOT NULL,
                 failure_count      INT          NOT NULL DEFAULT 0,
                 circuit_open_until DATETIME(6)  DEFAULT NULL,
                 updated_at         DATETIME(6)  NOT NULL,
-                PRIMARY KEY (strategy_key, task)
+                PRIMARY KEY (strategy_key, `task`)
             )"#,
         )
         .execute(&mut *conn)
@@ -2500,8 +2500,8 @@ impl SqlMemoryStore {
         let row = sqlx::query(&format!(
             "SELECT TIMESTAMPDIFF(SECOND, NOW(), circuit_open_until) AS remaining \
              FROM {runtime_table} \
-             WHERE strategy_key = ? AND task = ? \
-               AND circuit_open_until IS NOT NULL AND circuit_open_until > NOW()"
+             WHERE strategy_key = ? AND `task` = ? \
+                AND circuit_open_until IS NOT NULL AND circuit_open_until > NOW()"
         ))
         .bind(strategy_key)
         .bind(task)
@@ -2525,7 +2525,7 @@ impl SqlMemoryStore {
         let initial_failures = if open_on_insert { 0 } else { 1 };
         sqlx::query(&format!(
             "INSERT INTO {runtime_table} \
-                 (strategy_key, task, failure_count, circuit_open_until, updated_at) \
+                 (strategy_key, `task`, failure_count, circuit_open_until, updated_at) \
               VALUES (?, ?, ?, CASE WHEN ? THEN DATE_ADD(NOW(), INTERVAL ? SECOND) ELSE NULL END, NOW()) \
               ON DUPLICATE KEY UPDATE \
                  failure_count = CASE \
@@ -2565,7 +2565,7 @@ impl SqlMemoryStore {
         let runtime_table = self.t("mem_governance_runtime_state");
         sqlx::query(&format!(
             "INSERT INTO {runtime_table} \
-                 (strategy_key, task, failure_count, circuit_open_until, updated_at) \
+                 (strategy_key, `task`, failure_count, circuit_open_until, updated_at) \
               VALUES (?, ?, 0, NULL, NOW()) \
               ON DUPLICATE KEY UPDATE failure_count = 0, circuit_open_until = NULL, updated_at = NOW()"
         ))
@@ -3269,7 +3269,7 @@ impl SqlMemoryStore {
         // 1. 检查冷却
         let cooldown_check: Option<(chrono::NaiveDateTime,)> = sqlx::query_as(&format!(
             "SELECT circuit_open_until FROM {runtime_table} \
-             WHERE strategy_key = ? AND task = 'rebuild'"
+             WHERE strategy_key = ? AND `task` = 'rebuild'"
         ))
         .bind(&key)
         .fetch_optional(&mut *conn)
@@ -3295,7 +3295,7 @@ impl SqlMemoryStore {
         // 3. 查上次重建时的行数
         let last_rows: Option<(i32,)> = sqlx::query_as(&format!(
             "SELECT failure_count FROM {runtime_table} \
-             WHERE strategy_key = ? AND task = 'rebuild'"
+             WHERE strategy_key = ? AND `task` = 'rebuild'"
         ))
         .bind(&key)
         .fetch_optional(&mut *conn)
@@ -3334,7 +3334,7 @@ impl SqlMemoryStore {
 
         sqlx::query(&format!(
             "INSERT INTO {runtime_table} \
-             (strategy_key, task, failure_count, circuit_open_until, updated_at) \
+             (strategy_key, `task`, failure_count, circuit_open_until, updated_at) \
              VALUES (?, 'rebuild', ?, ?, NOW()) \
              ON DUPLICATE KEY UPDATE \
              failure_count = VALUES(failure_count), \
@@ -3365,7 +3365,7 @@ impl SqlMemoryStore {
         // 查询当前失败次数（存储在 failure_count 的负数）
         let current_failures: Option<(i32,)> = sqlx::query_as(&format!(
             "SELECT failure_count FROM {runtime_table} \
-             WHERE strategy_key = ? AND task = 'rebuild' AND failure_count < 0"
+             WHERE strategy_key = ? AND `task` = 'rebuild' AND failure_count < 0"
         ))
         .bind(&key)
         .fetch_optional(&mut *conn)
@@ -3386,7 +3386,7 @@ impl SqlMemoryStore {
 
         sqlx::query(&format!(
             "INSERT INTO {runtime_table} \
-             (strategy_key, task, failure_count, circuit_open_until, updated_at) \
+             (strategy_key, `task`, failure_count, circuit_open_until, updated_at) \
              VALUES (?, 'rebuild', ?, ?, NOW()) \
              ON DUPLICATE KEY UPDATE \
              failure_count = VALUES(failure_count), \
@@ -4488,14 +4488,14 @@ impl SqlMemoryStore {
         if cursor.is_some() {
             inner.push_str(" AND memory_id < ?");
         }
-        inner.push_str(" ORDER BY memory_id DESC LIMIT ?");
+        inner.push_str(" ORDER BY created_at DESC, memory_id DESC LIMIT ?");
 
         let sql = format!(
             "SELECT memory_id, user_id, memory_type, content, \
              session_id, is_active, superseded_by, trust_tier, \
              initial_confidence, observed_at, created_at, updated_at \
              FROM {table} WHERE memory_id IN ({inner}) \
-             ORDER BY memory_id DESC"
+             ORDER BY created_at DESC, memory_id DESC"
         );
 
         let mut q = sqlx::query(&sql).bind(user_id);

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -4488,14 +4488,14 @@ impl SqlMemoryStore {
         if cursor.is_some() {
             inner.push_str(" AND memory_id < ?");
         }
-        inner.push_str(" ORDER BY created_at DESC, memory_id DESC LIMIT ?");
+        inner.push_str(" ORDER BY memory_id DESC LIMIT ?");
 
         let sql = format!(
             "SELECT memory_id, user_id, memory_type, content, \
              session_id, is_active, superseded_by, trust_tier, \
              initial_confidence, observed_at, created_at, updated_at \
              FROM {table} WHERE memory_id IN ({inner}) \
-             ORDER BY created_at DESC, memory_id DESC"
+             ORDER BY memory_id DESC"
         );
 
         let mut q = sqlx::query(&sql).bind(user_id);

--- a/memoria/crates/memoria-test-utils/Cargo.toml
+++ b/memoria/crates/memoria-test-utils/Cargo.toml
@@ -4,8 +4,13 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
+memoria-core = { workspace = true }
+memoria-git = { workspace = true }
+memoria-service = { workspace = true }
+memoria-storage = { workspace = true }
 memoria-embedding = { workspace = true }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
+uuid = { workspace = true }

--- a/memoria/crates/memoria-test-utils/src/lib.rs
+++ b/memoria/crates/memoria-test-utils/src/lib.rs
@@ -4,12 +4,28 @@
 //! canned responses based on prompt content. Each test file can supply
 //! extra `(prompt_contains, response_json)` pairs for domain-specific prompts.
 
-use std::sync::Arc;
+use std::sync::{Arc, Once};
 use std::time::{Duration, Instant};
+
+use memoria_core::interfaces::EmbeddingProvider;
+use memoria_embedding::LlmClient;
+use memoria_git::GitForDataService;
+use memoria_service::MemoryService;
+use memoria_storage::{DbRouter, SqlMemoryStore};
+use sqlx::mysql::{MySqlPool, MySqlPoolOptions};
 
 /// A `(needle, response_body)` pair: if the prompt contains `needle`,
 /// the fake server returns `response_body` as the assistant message content.
 pub type PromptRule = (&'static str, serde_json::Value);
+
+pub struct MultiDbTestContext {
+    shared_db_url: String,
+    router: Option<Arc<DbRouter>>,
+    shared_pool: Option<MySqlPool>,
+    store: Option<Arc<SqlMemoryStore>>,
+    git: Option<Arc<GitForDataService>>,
+    service: Option<Arc<MemoryService>>,
+}
 
 /// Default rules shared by all test suites (reflect + entity extraction).
 pub fn default_rules() -> Vec<PromptRule> {
@@ -185,6 +201,191 @@ pub async fn wait_for_mysql_ready(db_url: &str, timeout: Duration) {
     );
 }
 
+impl MultiDbTestContext {
+    pub async fn new(
+        base_db_url: &str,
+        db_name_prefix: &str,
+        embedding_dim: usize,
+        embedder: Option<Arc<dyn EmbeddingProvider>>,
+        llm: Option<Arc<LlmClient>>,
+    ) -> Self {
+        configure_multi_db_test_pools();
+        let shared_db_url = unique_db_url(base_db_url, db_name_prefix);
+        wait_for_mysql_ready(&shared_db_url, Duration::from_secs(30)).await;
+
+        let router = Arc::new(
+            DbRouter::connect(
+                &shared_db_url,
+                embedding_dim,
+                uuid::Uuid::new_v4().to_string(),
+            )
+            .await
+            .expect("connect multi-db router"),
+        );
+        let shared_pool = router.shared_pool().clone();
+        let mut store = SqlMemoryStore::from_existing_pool(
+            shared_pool.clone(),
+            embedding_dim,
+            uuid::Uuid::new_v4().to_string(),
+            Some(shared_db_url.clone()),
+            Some(router.shared_pool_max_connections()),
+            "multi_db_test_shared_pool",
+        );
+        store.migrate_shared().await.expect("migrate shared db");
+        store.set_db_router(router.clone());
+        let store = Arc::new(store);
+        let git = Arc::new(GitForDataService::new(
+            shared_pool.clone(),
+            router.shared_db_name().to_string(),
+        ));
+        let service = Arc::new(
+            MemoryService::new_sql_with_llm_and_router(
+                store.clone(),
+                Some(router.clone()),
+                embedder,
+                llm,
+            )
+            .await,
+        );
+
+        Self {
+            shared_db_url,
+            router: Some(router),
+            shared_pool: Some(shared_pool),
+            store: Some(store),
+            git: Some(git),
+            service: Some(service),
+        }
+    }
+
+    pub fn shared_db_url(&self) -> &str {
+        &self.shared_db_url
+    }
+
+    pub fn router(&self) -> Arc<DbRouter> {
+        self.router.as_ref().expect("router").clone()
+    }
+
+    pub fn shared_pool(&self) -> MySqlPool {
+        self.shared_pool.as_ref().expect("shared pool").clone()
+    }
+
+    pub fn shared_store(&self) -> Arc<SqlMemoryStore> {
+        self.store.as_ref().expect("shared store").clone()
+    }
+
+    pub fn git(&self) -> Arc<GitForDataService> {
+        self.git.as_ref().expect("git service").clone()
+    }
+
+    pub fn service(&self) -> Arc<MemoryService> {
+        self.service.as_ref().expect("memory service").clone()
+    }
+
+    pub fn shared_table(&self, table: &str) -> String {
+        self.store.as_ref().expect("shared store").t(table)
+    }
+
+    pub async fn user_db_name(&self, user_id: &str) -> String {
+        self.router
+            .as_ref()
+            .expect("router")
+            .user_db_name(user_id)
+            .await
+            .expect("resolve user db")
+    }
+
+    pub async fn user_store(&self, user_id: &str) -> Arc<SqlMemoryStore> {
+        self.service
+            .as_ref()
+            .expect("memory service")
+            .user_sql_store(user_id)
+            .await
+            .expect("resolve user store")
+    }
+
+    pub async fn user_table(&self, user_id: &str, table: &str) -> String {
+        self.user_store(user_id).await.t(table)
+    }
+
+    pub async fn user_db_pool(&self, user_id: &str) -> MySqlPool {
+        let db_name = self.user_db_name(user_id).await;
+        let user_db_url = self
+            .router
+            .as_ref()
+            .expect("router")
+            .user_db_url(&db_name)
+            .expect("user db url");
+        MySqlPoolOptions::new()
+            .max_connections(1)
+            .connect(&user_db_url)
+            .await
+            .expect("connect user db")
+    }
+}
+
+fn configure_multi_db_test_pools() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        set_env_if_unset("MEMORIA_SHARED_POOL_MAX_CONNECTIONS", "1");
+        set_env_if_unset("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS", "1");
+        set_env_if_unset("MEMORIA_GIT_POOL_MAX_CONNECTIONS", "1");
+        set_env_if_unset("MEMORIA_MERGED_SHARED_POOL_MAX_CONNECTIONS", "3");
+        set_env_if_unset("MEMORIA_GLOBAL_USER_POOL_MAX", "4");
+        set_env_if_unset("MEMORIA_USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS", "1");
+        set_env_if_unset("MEMORIA_USER_SCHEMA_INIT_MAX_CONCURRENCY", "1");
+    });
+}
+
+fn set_env_if_unset(name: &str, value: &str) {
+    if std::env::var_os(name).is_none() {
+        unsafe {
+            std::env::set_var(name, value);
+        }
+    }
+}
+
+impl Drop for MultiDbTestContext {
+    fn drop(&mut self) {
+        let Some(router) = self.router.take() else {
+            return;
+        };
+        let Some(shared_pool) = self.shared_pool.take() else {
+            return;
+        };
+        let shared_db_url = self.shared_db_url.clone();
+        let global_user_pool = router.global_user_pool().clone();
+        let store = self.store.take();
+        let git = self.git.take();
+        let service = self.service.take();
+
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let db_names = sqlx::query_scalar::<_, String>(
+                    "SELECT DISTINCT db_name FROM mem_user_registry WHERE status = 'active'",
+                )
+                .fetch_all(&shared_pool)
+                .await
+                .unwrap_or_default();
+
+                drop(service);
+                drop(git);
+                drop(store);
+                drop(router);
+
+                shared_pool.close().await;
+                global_user_pool.close().await;
+                cleanup_databases(&shared_db_url, &db_names).await;
+            });
+        }
+    }
+}
+
+pub fn unique_db_url(base_db_url: &str, db_name_prefix: &str) -> String {
+    let suffix = &uuid::Uuid::new_v4().simple().to_string()[..8];
+    replace_db_name(base_db_url, &format!("{db_name_prefix}_{suffix}"))
+}
+
 fn split_db_url(db_url: &str) -> Result<(String, String), String> {
     let (base_url, db_name) = db_url
         .rsplit_once('/')
@@ -198,4 +399,37 @@ fn split_db_url(db_url: &str) -> Result<(String, String), String> {
 
 fn quote_ident(name: &str) -> String {
     format!("`{}`", name.replace('`', "``"))
+}
+
+pub fn replace_db_name(database_url: &str, db_name: &str) -> String {
+    let suffix_start = database_url.find(['?', '#']).unwrap_or(database_url.len());
+    let (without_suffix, suffix) = database_url.split_at(suffix_start);
+    let (base, _) = without_suffix
+        .rsplit_once('/')
+        .expect("database url must include db name");
+    format!("{base}/{db_name}{suffix}")
+}
+
+async fn cleanup_databases(shared_db_url: &str, user_db_names: &[String]) {
+    let (base_url, shared_db_name) = split_db_url(shared_db_url).expect("split shared db url");
+    let admin_pool = MySqlPoolOptions::new()
+        .max_connections(1)
+        .connect(&base_url)
+        .await
+        .expect("connect admin pool");
+
+    for db_name in user_db_names {
+        sqlx::raw_sql(&format!("DROP DATABASE IF EXISTS {}", quote_ident(db_name)))
+            .execute(&admin_pool)
+            .await
+            .expect("drop user db");
+    }
+    sqlx::raw_sql(&format!(
+        "DROP DATABASE IF EXISTS {}",
+        quote_ident(&shared_db_name)
+    ))
+    .execute(&admin_pool)
+    .await
+    .expect("drop shared db");
+    admin_pool.close().await;
 }


### PR DESCRIPTION
## Summary
- migrate the main API and MCP e2e suites onto shared multi-db test harnesses
- add reusable API/MCP multi-db support helpers and expose an MCP e2e make target
- fix multi-db-specific route, storage, and verification assumptions uncovered during validation

## Validation
- migrated API and MCP e2e suites onto the shared multi-db harness
- compatibility-seeded old data and verified old API keys on the current multi-db server
- exercised remaining API routes including search, correct, purge, snapshot rollback/delete, and branch merge/delete