### PR TITLE
feat(memory): unify session scope across memory interfaces

### DIFF
--- a/.kiro/steering/memory.md
+++ b/.kiro/steering/memory.md
@@ -78,16 +78,17 @@ Before storing a new memory, consider:
 | Tool | When to use | Key params |
 |------|-------------|------------|
 | `memory_store` | User shares a fact, preference, or decision | `content`, `memory_type` (default: semantic), `session_id` (optional) |
-| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason` |
-| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch, e.g. `"id1,id2"`) or `topic` (bulk keyword match), `reason` |
+| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason`; query mode also supports `session_id` + `session_scope` |
+| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch), `topic`, or exact `session_id`; `memory_types` only with `session_id` |
 
 `memory_purge` automatically creates a safety snapshot before deleting. The response includes the snapshot name — tell the user they can `memory_rollback` to undo. If the response contains a ⚠️ warning about snapshot quota, relay it and suggest `memory_snapshot_delete(prefix="pre_")`.
 
 ### Read tools
 | Tool | When to use | Key params |
 |------|-------------|------------|
-| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), `session_id` (optional), `explain` (false = no debug, true = show timing) |
-| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), `explain` (false = no debug, true = show timing) |
+| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
+| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
+| `memory_list` | User wants a bounded inventory or a session-specific listing | `limit`, optional `memory_type`, optional exact `session_id` |
 | `memory_profile` | User asks "what do you know about me" | — |
 | `memory_feedback` | After using a retrieved memory, record if it was helpful | `memory_id`, `signal` (useful/irrelevant/outdated/wrong), `context` (optional) |
 
@@ -120,9 +121,15 @@ memory_feedback(memory_id="abc123", signal="useful", context="answered DB questi
 **Impact**: Feedback accumulates over time. With default settings, a memory with 3 `useful` signals ranks ~30% higher in future retrievals. Don't call for every memory — only when you have clear signal.
 
 **`memory_retrieve` vs `memory_search`**: In MCP mode, both use the same retrieval pipeline (graph → hybrid vector+fulltext → fulltext fallback). The differences are:
-- `memory_retrieve` accepts `session_id` for session-scoped boosting; `memory_search` does not
+- Both accept optional `session_id` plus `session_scope`
+- `session_scope="prefer"` means "use this session as context, but cross-session results are still allowed" (default when `session_id` is present)
+- `session_scope="only"` means "strictly filter to this session"
 - `memory_retrieve` defaults to `top_k=5` (focused); `memory_search` defaults to `top_k=10` (broader)
-- Use `memory_retrieve` when you have a `session_id` or want focused results; use `memory_search` for broader exploration
+- Use `memory_retrieve` for prompt-relevant context; use `memory_search` for broader browsing over the same retrieval pipeline
+
+**`memory_list` session semantics**:
+- `session_id` on `memory_list` is an exact filter, not a preference hint
+- Use it to inspect one session before `memory_purge(session_id=...)` or after a session-scoped correction
 
 **Debug parameter:** `explain=true` shows execution timing and retrieval path. **ONLY use when user explicitly asks** to debug performance or investigate why certain memories were/weren't retrieved. **DO NOT use proactively** — it adds overhead and clutters output.
 

--- a/memoria/crates/memoria-api/src/models.rs
+++ b/memoria/crates/memoria-api/src/models.rs
@@ -33,12 +33,7 @@ pub struct RetrieveRequest {
     #[serde(default = "default_top_k")]
     pub top_k: i64,
     pub session_id: Option<String>,
-    /// Explicit strict session filter. Overrides include_cross_session when provided.
-    #[serde(default)]
-    pub filter_session: Option<bool>,
-    /// When false and session_id is set, only return memories from that session.
-    #[serde(default = "default_true")]
-    pub include_cross_session: bool,
+    pub session_scope: Option<String>,
     /// Explain level: false/"none" = off, true/"basic" = basic, "verbose" = per-candidate scores, "analyze" = full
     #[serde(default, deserialize_with = "deserialize_explain")]
     pub explain: String,
@@ -46,17 +41,65 @@ pub struct RetrieveRequest {
 fn default_top_k() -> i64 {
     5
 }
-fn default_true() -> bool {
-    true
+fn default_search_top_k() -> i64 {
+    10
+}
+fn parse_session_scope(
+    value: Option<&str>,
+) -> Result<Option<memoria_service::SessionScope>, String> {
+    value
+        .map(memoria_service::SessionScope::from_str)
+        .transpose()
 }
 
 impl RetrieveRequest {
-    pub fn retrieve_options(&self) -> memoria_service::RetrieveOptions {
-        memoria_service::RetrieveOptions::from_session_scope(
+    pub fn session_scope(&self) -> Result<Option<memoria_service::SessionScope>, String> {
+        parse_session_scope(self.session_scope.as_deref())
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.session_scope.is_some() && self.session_id.is_none() {
+            return Err("session_id is required when session_scope is set".to_string());
+        }
+        Ok(())
+    }
+
+    pub fn retrieve_options(&self) -> Result<memoria_service::RetrieveOptions, String> {
+        Ok(memoria_service::RetrieveOptions::from_session_scope(
             self.session_id.as_deref(),
-            self.filter_session,
-            Some(self.include_cross_session),
-        )
+            self.session_scope()?,
+        ))
+    }
+}
+
+#[derive(Deserialize)]
+pub struct SearchRequest {
+    pub query: String,
+    #[serde(default = "default_search_top_k")]
+    pub top_k: i64,
+    pub session_id: Option<String>,
+    pub session_scope: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_explain")]
+    pub explain: String,
+}
+
+impl SearchRequest {
+    pub fn session_scope(&self) -> Result<Option<memoria_service::SessionScope>, String> {
+        parse_session_scope(self.session_scope.as_deref())
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.session_scope.is_some() && self.session_id.is_none() {
+            return Err("session_id is required when session_scope is set".to_string());
+        }
+        Ok(())
+    }
+
+    pub fn retrieve_options(&self) -> Result<memoria_service::RetrieveOptions, String> {
+        Ok(memoria_service::RetrieveOptions::from_session_scope(
+            self.session_id.as_deref(),
+            self.session_scope()?,
+        ))
     }
 }
 
@@ -85,7 +128,25 @@ pub struct CorrectRequest {
 pub struct CorrectByQueryRequest {
     pub query: String,
     pub new_content: String,
+    pub session_id: Option<String>,
+    pub session_scope: Option<String>,
     pub reason: Option<String>,
+}
+
+impl CorrectByQueryRequest {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.session_scope.is_some() && self.session_id.is_none() {
+            return Err("session_id is required when session_scope is set".to_string());
+        }
+        Ok(())
+    }
+
+    pub fn retrieve_options(&self) -> Result<memoria_service::RetrieveOptions, String> {
+        Ok(memoria_service::RetrieveOptions::from_session_scope(
+            self.session_id.as_deref(),
+            parse_session_scope(self.session_scope.as_deref())?,
+        ))
+    }
 }
 
 #[derive(Deserialize)]

--- a/memoria/crates/memoria-api/src/routes/memory.rs
+++ b/memoria/crates/memoria-api/src/routes/memory.rs
@@ -66,6 +66,7 @@ async fn find_memory_any_user(
 #[derive(Deserialize, Default)]
 pub struct ListQuery {
     pub memory_type: Option<String>,
+    pub session_id: Option<String>,
     #[serde(default = "default_limit")]
     pub limit: i64,
     pub cursor: Option<String>,
@@ -116,7 +117,13 @@ pub async fn list_memories(
     let fetch_limit = limit + 1;
     let mut memories = state
         .service
-        .list_active_paged(&user_id, fetch_limit, q.memory_type.as_deref(), cursor)
+        .list_active_paged(
+            &user_id,
+            fetch_limit,
+            q.memory_type.as_deref(),
+            q.session_id.as_deref(),
+            cursor,
+        )
         .await
         .map_err(api_err)?;
     let has_more = memories.len() > limit as usize;
@@ -241,16 +248,13 @@ pub async fn retrieve(
     AuthUser { user_id, .. }: AuthUser,
     Json(req): Json<RetrieveRequest>,
 ) -> ApiResult<serde_json::Value> {
-    if req.session_id.is_none() && (req.filter_session == Some(true) || !req.include_cross_session)
-    {
-        return Err((
-            StatusCode::UNPROCESSABLE_ENTITY,
-            "session_id is required for strict session retrieval".to_string(),
-        ));
-    }
+    req.validate()
+        .map_err(|err| (StatusCode::UNPROCESSABLE_ENTITY, err))?;
     let top_k = req.top_k.clamp(1, 100);
     let level = memoria_service::ExplainLevel::from_str_or_bool(&req.explain);
-    let retrieve_options = req.retrieve_options();
+    let retrieve_options = req
+        .retrieve_options()
+        .map_err(|err| (StatusCode::UNPROCESSABLE_ENTITY, err))?;
 
     if level != memoria_service::ExplainLevel::None {
         let (results, explain) = state
@@ -282,14 +286,25 @@ pub async fn retrieve(
 pub async fn search(
     State(state): State<AppState>,
     AuthUser { user_id, .. }: AuthUser,
-    Json(req): Json<RetrieveRequest>,
+    Json(req): Json<SearchRequest>,
 ) -> ApiResult<serde_json::Value> {
+    req.validate()
+        .map_err(|err| (StatusCode::UNPROCESSABLE_ENTITY, err))?;
     let top_k = req.top_k.clamp(1, 100);
     let level = memoria_service::ExplainLevel::from_str_or_bool(&req.explain);
+    let retrieve_options = req
+        .retrieve_options()
+        .map_err(|err| (StatusCode::UNPROCESSABLE_ENTITY, err))?;
     if level != memoria_service::ExplainLevel::None {
         let (results, explain) = state
             .service
-            .search_explain_level(&user_id, &req.query, top_k, level)
+            .retrieve_explain_level_with_options(
+                &user_id,
+                &req.query,
+                top_k,
+                level,
+                &retrieve_options,
+            )
             .await
             .map_err(api_err)?;
         let items: Vec<MemoryResponse> = results.into_iter().map(Into::into).collect();
@@ -299,7 +314,7 @@ pub async fn search(
     } else {
         let results = state
             .service
-            .search(&user_id, &req.query, top_k)
+            .retrieve_with_options(&user_id, &req.query, top_k, &retrieve_options)
             .await
             .map_err(api_err)?;
         Ok(Json(serde_json::json!(results
@@ -370,9 +385,14 @@ pub async fn correct_by_query(
     AuthUser { user_id, .. }: AuthUser,
     Json(req): Json<CorrectByQueryRequest>,
 ) -> ApiResult<MemoryResponse> {
+    req.validate()
+        .map_err(|err| (StatusCode::UNPROCESSABLE_ENTITY, err))?;
+    let retrieve_options = req
+        .retrieve_options()
+        .map_err(|err| (StatusCode::UNPROCESSABLE_ENTITY, err))?;
     let results = state
         .service
-        .retrieve(&user_id, &req.query, 1)
+        .retrieve_with_options(&user_id, &req.query, 1, &retrieve_options)
         .await
         .map_err(api_err)?;
     let found = results.into_iter().next().ok_or_else(|| {

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -1817,7 +1817,7 @@ async fn test_remote_store_retrieve() {
 async fn test_remote_retrieve_session_scope_only_includes_unscoped() {
     use memoria_mcp::remote::RemoteClient;
 
-    let (base, _, _server) =
+    let (base, client, _server) =
         spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
             .await;
     let uid = uid();
@@ -1844,6 +1844,21 @@ async fn test_remote_retrieve_session_scope_only_includes_unscoped() {
         .await
         .unwrap();
 
+    wait_for_api_payload_contains(
+        &client,
+        &base,
+        &uid,
+        "/v1/memories/retrieve",
+        json!({
+            "query": "strict session query",
+            "session_id": target_session,
+            "session_scope": "only",
+            "top_k": 2
+        }),
+        &["target-session memory", "global-unscoped top"],
+    )
+    .await;
+
     let strict = remote
         .call(
             "memory_retrieve",
@@ -1851,12 +1866,16 @@ async fn test_remote_retrieve_session_scope_only_includes_unscoped() {
                 "query": "strict session query",
                 "session_id": target_session,
                 "session_scope": "only",
-                "top_k": 1
+                "top_k": 2
             }),
         )
         .await
         .unwrap();
     let strict_text = strict["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        strict_text.contains("target-session memory"),
+        "strict remote retrieve should keep requested-session memory visible: {strict_text}"
+    );
     assert!(
         strict_text.contains("global-unscoped top"),
         "strict remote retrieve should include unscoped memory: {strict_text}"
@@ -2015,7 +2034,7 @@ async fn test_remote_list_search_profile() {
 async fn test_remote_search_session_scope_only_includes_unscoped() {
     use memoria_mcp::remote::RemoteClient;
 
-    let (base, _, _server) =
+    let (base, client, _server) =
         spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
             .await;
     let uid = uid();
@@ -2042,6 +2061,21 @@ async fn test_remote_search_session_scope_only_includes_unscoped() {
         .await
         .unwrap();
 
+    wait_for_api_payload_contains(
+        &client,
+        &base,
+        &uid,
+        "/v1/memories/search",
+        json!({
+            "query": "strict session query",
+            "session_id": target_session,
+            "session_scope": "only",
+            "top_k": 2
+        }),
+        &["target-session memory", "global-unscoped top"],
+    )
+    .await;
+
     let strict = remote
         .call(
             "memory_search",
@@ -2049,12 +2083,16 @@ async fn test_remote_search_session_scope_only_includes_unscoped() {
                 "query": "strict session query",
                 "session_id": target_session,
                 "session_scope": "only",
-                "top_k": 1
+                "top_k": 2
             }),
         )
         .await
         .unwrap();
     let strict_text = strict["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        strict_text.contains("target-session memory"),
+        "strict remote search should keep requested-session memory visible: {strict_text}"
+    );
     assert!(
         strict_text.contains("global-unscoped top"),
         "strict remote search should include unscoped memory: {strict_text}"
@@ -2899,6 +2937,41 @@ async fn store_memory_unscoped(
         .to_string()
 }
 
+async fn wait_for_api_payload_contains(
+    client: &reqwest::Client,
+    base: &str,
+    user_id: &str,
+    path: &str,
+    body: Value,
+    expected_fragments: &[&str],
+) -> Value {
+    let mut last_body = Value::Null;
+    for _ in 0..60 {
+        let resp = client
+            .post(format!("{base}{path}"))
+            .header("X-User-Id", user_id)
+            .json(&body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let current_body = resp.json::<Value>().await.unwrap();
+        let haystack = current_body.to_string();
+        if expected_fragments
+            .iter()
+            .all(|fragment| haystack.contains(fragment))
+        {
+            return current_body;
+        }
+        last_body = current_body;
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    }
+    panic!(
+        "timed out waiting for {path} to contain {:?}: {last_body}",
+        expected_fragments
+    );
+}
+
 #[tokio::test]
 async fn test_episodic_no_memories_returns_error() {
     let (llm, _shutdown) = spawn_fake_llm().await;
@@ -3509,8 +3582,7 @@ async fn test_retrieve_session_scope_only_prefilters_and_skips_graph() {
     let target_mid =
         store_memory_for_session(&client, &base, &uid, "target-session memory", "sess-target")
             .await;
-    let global_mid =
-        store_memory_unscoped(&client, &base, &uid, "global-unscoped top").await;
+    let global_mid = store_memory_unscoped(&client, &base, &uid, "global-unscoped top").await;
     let other_mid =
         store_memory_for_session(&client, &base, &uid, "other-session top", "sess-other").await;
     let other_second_mid =
@@ -3561,53 +3633,66 @@ async fn test_retrieve_session_scope_only_prefilters_and_skips_graph() {
         .await
         .unwrap();
 
-    let relaxed = client
-        .post(format!("{base}/v1/memories/retrieve"))
-        .header("X-User-Id", &uid)
-        .json(&json!({
+    let relaxed_body = wait_for_api_payload_contains(
+        &client,
+        &base,
+        &uid,
+        "/v1/memories/retrieve",
+        json!({
             "query": "strict session query",
             "session_id": "sess-target",
-            "top_k": 1,
+            "top_k": 3,
             "explain": true
-        }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(relaxed.status(), 200);
-    let relaxed_body: Value = relaxed.json().await.unwrap();
+        }),
+        &["other-session top"],
+    )
+    .await;
     assert_eq!(relaxed_body["explain"]["graph_attempted"], true);
-    assert_eq!(
-        relaxed_body["results"][0]["session_id"].as_str(),
-        Some("sess-other"),
-        "cross-session retrieval should still be free to return another session",
+    let relaxed_results = relaxed_body["results"]
+        .as_array()
+        .expect("relaxed retrieve should return result array");
+    assert!(
+        relaxed_results
+            .iter()
+            .any(|item| item["session_id"].as_str() == Some("sess-other")),
+        "cross-session retrieval should still be free to return another session: {relaxed_body}",
     );
 
-    let strict = client
-        .post(format!("{base}/v1/memories/retrieve"))
-        .header("X-User-Id", &uid)
-        .json(&json!({
+    let strict_body = wait_for_api_payload_contains(
+        &client,
+        &base,
+        &uid,
+        "/v1/memories/retrieve",
+        json!({
             "query": "strict session query",
             "session_id": "sess-target",
             "session_scope": "only",
-            "top_k": 1,
+            "top_k": 2,
             "explain": true
-        }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(strict.status(), 200);
-    let strict_body: Value = strict.json().await.unwrap();
+        }),
+        &["target-session memory", "global-unscoped top"],
+    )
+    .await;
     assert_eq!(strict_body["explain"]["graph_attempted"], false);
     assert_ne!(strict_body["explain"]["path"], "graph");
-    assert_eq!(
-        strict_body["results"][0]["memory_id"].as_str(),
-        Some(global_mid.as_str()),
-        "strict session retrieval should rank within the requested session plus unscoped memories",
+    let strict_results = strict_body["results"]
+        .as_array()
+        .expect("strict retrieve should return result array");
+    let strict_ids: std::collections::HashSet<&str> = strict_results
+        .iter()
+        .filter_map(|item| item["memory_id"].as_str())
+        .collect();
+    assert!(
+        strict_ids.contains(target_mid.as_str()),
+        "strict session retrieval should still include requested-session memory: {strict_body}",
     );
-    assert_ne!(
-        strict_body["results"][0]["memory_id"].as_str(),
-        Some(other_mid.as_str()),
-        "strict session retrieval should still exclude other scoped sessions",
+    assert!(
+        strict_ids.contains(global_mid.as_str()),
+        "strict session retrieval should still include unscoped memory: {strict_body}",
+    );
+    assert!(
+        !strict_ids.contains(other_mid.as_str()),
+        "strict session retrieval should still exclude other scoped sessions: {strict_body}",
     );
 }
 
@@ -3654,28 +3739,29 @@ async fn test_retrieve_session_scope_only_preserves_top_k_with_session_candidate
         store_memory_for_session(&client, &base, &uid, "scoped-candidate-a", "sess-target").await;
     let target_second =
         store_memory_for_session(&client, &base, &uid, "scoped-candidate-b", "sess-target").await;
-    let global_shared =
-        store_memory_unscoped(&client, &base, &uid, "global-candidate-b").await;
+    let global_shared = store_memory_unscoped(&client, &base, &uid, "global-candidate-b").await;
     let _other_first =
         store_memory_for_session(&client, &base, &uid, "global-candidate-a", "sess-other").await;
     let _other_second =
-        store_memory_for_session(&client, &base, &uid, "global-candidate-b", "sess-other").await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-
-    let strict = client
-        .post(format!("{base}/v1/memories/retrieve"))
-        .header("X-User-Id", &uid)
-        .json(&json!({
+        store_memory_for_session(&client, &base, &uid, "other-session decoy", "sess-other").await;
+    let strict_body = wait_for_api_payload_contains(
+        &client,
+        &base,
+        &uid,
+        "/v1/memories/retrieve",
+        json!({
             "query": "scoped topk query",
             "session_id": "sess-target",
             "session_scope": "only",
             "top_k": 3
-        }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(strict.status(), 200);
-    let strict_body: Value = strict.json().await.unwrap();
+        }),
+        &[
+            "scoped-candidate-a",
+            "scoped-candidate-b",
+            "global-candidate-b",
+        ],
+    )
+    .await;
     let strict_results = strict_body
         .as_array()
         .expect("retrieve should return array");
@@ -3685,7 +3771,9 @@ async fn test_retrieve_session_scope_only_preserves_top_k_with_session_candidate
         "strict session retrieval should still fill top_k from session-local plus unscoped candidates",
     );
     assert!(
-        strict_results.iter().all(|item| item["session_id"].as_str() != Some("sess-other")),
+        strict_results
+            .iter()
+            .all(|item| item["session_id"].as_str() != Some("sess-other")),
         "strict session retrieval must still exclude other scoped sessions",
     );
     let strict_ids: std::collections::HashSet<&str> = strict_results
@@ -3715,43 +3803,62 @@ async fn test_search_session_scope_only_respects_session() {
     store_memory_for_session(&client, &base, &uid, "other-session top", "sess-other").await;
     store_memory_for_session(&client, &base, &uid, "other-session second", "sess-other").await;
 
-    let relaxed = client
-        .post(format!("{base}/v1/memories/search"))
-        .header("X-User-Id", &uid)
-        .json(&json!({
+    let relaxed_body = wait_for_api_payload_contains(
+        &client,
+        &base,
+        &uid,
+        "/v1/memories/search",
+        json!({
             "query": "strict session query",
             "session_id": "sess-target",
-            "top_k": 1
-        }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(relaxed.status(), 200);
-    let relaxed_body: Value = relaxed.json().await.unwrap();
-    assert_eq!(
-        relaxed_body[0]["session_id"].as_str(),
-        Some("sess-other"),
-        "relaxed search should still be free to return another session",
+            "top_k": 3
+        }),
+        &["other-session top"],
+    )
+    .await;
+    assert!(
+        relaxed_body
+            .as_array()
+            .expect("search should return array")
+            .iter()
+            .any(|item| item["session_id"].as_str() == Some("sess-other")),
+        "relaxed search should still be free to return another session: {relaxed_body}",
     );
 
-    let strict = client
-        .post(format!("{base}/v1/memories/search"))
-        .header("X-User-Id", &uid)
-        .json(&json!({
+    let strict_body = wait_for_api_payload_contains(
+        &client,
+        &base,
+        &uid,
+        "/v1/memories/search",
+        json!({
             "query": "strict session query",
             "session_id": "sess-target",
             "session_scope": "only",
-            "top_k": 1
-        }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(strict.status(), 200);
-    let strict_body: Value = strict.json().await.unwrap();
-    assert_eq!(
-        strict_body[0]["session_id"].as_str(),
-        None,
-        "session_scope=only should still include unscoped memories",
+            "top_k": 2
+        }),
+        &["target-session memory", "global-unscoped top"],
+    )
+    .await;
+    let strict_results = strict_body
+        .as_array()
+        .expect("strict search should return array");
+    assert!(
+        strict_results
+            .iter()
+            .all(|item| item["session_id"].as_str() != Some("sess-other")),
+        "session_scope=only should exclude other scoped sessions: {strict_body}",
+    );
+    assert!(
+        strict_results
+            .iter()
+            .any(|item| item["session_id"].is_null()),
+        "session_scope=only should still include unscoped memories: {strict_body}",
+    );
+    assert!(
+        strict_results
+            .iter()
+            .any(|item| item["session_id"].as_str() == Some("sess-target")),
+        "session_scope=only should still include requested-session memories: {strict_body}",
     );
 }
 
@@ -7019,6 +7126,33 @@ fn mcp_result_text(resp: &Value) -> &str {
     resp["result"]["content"][0]["text"].as_str().unwrap_or("")
 }
 
+async fn wait_for_mcp_text_contains(
+    client: &reqwest::Client,
+    base: &str,
+    body: Value,
+    headers: &[(&str, &str)],
+    expected_fragments: &[&str],
+) -> Value {
+    let mut last_resp = Value::Null;
+    for _ in 0..60 {
+        let resp = mcp_post_with_headers(client, base, body.clone(), headers).await;
+        let text = mcp_result_text(&resp);
+        if resp["error"].is_null()
+            && expected_fragments
+                .iter()
+                .all(|fragment| text.contains(fragment))
+        {
+            return resp;
+        }
+        last_resp = resp;
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    }
+    panic!(
+        "timed out waiting for MCP response to contain {:?}: {last_resp}",
+        expected_fragments
+    );
+}
+
 #[tokio::test]
 async fn test_mcp_initialize() {
     let (base, client, _server) = spawn_server().await;
@@ -7169,7 +7303,7 @@ async fn test_mcp_memory_retrieve_session_scope_end_to_end() {
         global_resp["error"]
     );
 
-    let relaxed = mcp_post_with_headers(
+    let relaxed = wait_for_mcp_text_contains(
         &client,
         &base,
         json!({
@@ -7181,25 +7315,21 @@ async fn test_mcp_memory_retrieve_session_scope_end_to_end() {
                 "arguments": {
                     "query": "strict session query",
                     "session_id": "sess-target",
-                    "top_k": 1
+                    "top_k": 3
                 }
             }
         }),
         &headers,
+        &["other-session top"],
     )
     .await;
-    assert!(
-        relaxed["error"].is_null(),
-        "unexpected relaxed error: {}",
-        relaxed["error"]
-    );
     let relaxed_text = mcp_result_text(&relaxed);
     assert!(
         relaxed_text.contains("other-session"),
         "relaxed MCP retrieve should still be free to return cross-session memory: {relaxed_text}"
     );
 
-    let strict = mcp_post_with_headers(
+    let strict = wait_for_mcp_text_contains(
         &client,
         &base,
         json!({
@@ -7212,19 +7342,19 @@ async fn test_mcp_memory_retrieve_session_scope_end_to_end() {
                     "query": "strict session query",
                     "session_id": "sess-target",
                     "session_scope": "only",
-                    "top_k": 1
+                    "top_k": 2
                 }
             }
         }),
         &headers,
+        &["target-session memory", "global-unscoped top"],
     )
     .await;
-    assert!(
-        strict["error"].is_null(),
-        "unexpected strict error: {}",
-        strict["error"]
-    );
     let strict_text = mcp_result_text(&strict);
+    assert!(
+        strict_text.contains("target-session memory"),
+        "strict MCP retrieve should keep requested-session memory visible: {strict_text}"
+    );
     assert!(
         strict_text.contains("global-unscoped top"),
         "strict MCP retrieve should include unscoped memory: {strict_text}"
@@ -7298,7 +7428,7 @@ async fn test_mcp_memory_search_session_scope_end_to_end() {
         global_resp["error"]
     );
 
-    let relaxed = mcp_post_with_headers(
+    let relaxed = wait_for_mcp_text_contains(
         &client,
         &base,
         json!({
@@ -7310,25 +7440,21 @@ async fn test_mcp_memory_search_session_scope_end_to_end() {
                 "arguments": {
                     "query": "strict session query",
                     "session_id": "sess-target",
-                    "top_k": 1
+                    "top_k": 3
                 }
             }
         }),
         &headers,
+        &["other-session top"],
     )
     .await;
-    assert!(
-        relaxed["error"].is_null(),
-        "unexpected relaxed error: {}",
-        relaxed["error"]
-    );
     let relaxed_text = mcp_result_text(&relaxed);
     assert!(
         relaxed_text.contains("other-session"),
         "relaxed MCP search should still be free to return cross-session memory: {relaxed_text}"
     );
 
-    let strict = mcp_post_with_headers(
+    let strict = wait_for_mcp_text_contains(
         &client,
         &base,
         json!({
@@ -7341,19 +7467,19 @@ async fn test_mcp_memory_search_session_scope_end_to_end() {
                     "query": "strict session query",
                     "session_id": "sess-target",
                     "session_scope": "only",
-                    "top_k": 1
+                    "top_k": 2
                 }
             }
         }),
         &headers,
+        &["target-session memory", "global-unscoped top"],
     )
     .await;
-    assert!(
-        strict["error"].is_null(),
-        "unexpected strict error: {}",
-        strict["error"]
-    );
     let strict_text = mcp_result_text(&strict);
+    assert!(
+        strict_text.contains("target-session memory"),
+        "strict MCP search should keep requested-session memory visible: {strict_text}"
+    );
     assert!(
         strict_text.contains("global-unscoped top"),
         "strict MCP search should include unscoped memory: {strict_text}"

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -57,6 +57,7 @@ impl SessionScopeTestEmbedder {
         let mut v = vec![0.0; test_dim()];
         match text {
             "strict session query" | "other-session top" => v[0] = 1.0,
+            "global-unscoped top" => v[0] = 0.99,
             "scoped topk query" | "global-candidate-a" => v[0] = 1.0,
             "other-session second" => {
                 v[0] = 0.98;
@@ -2757,6 +2758,26 @@ async fn store_memory_for_session(
         .to_string()
 }
 
+async fn store_memory_unscoped(
+    client: &reqwest::Client,
+    base: &str,
+    user_id: &str,
+    content: &str,
+) -> String {
+    let r = client
+        .post(format!("{base}/v1/memories"))
+        .header("X-User-Id", user_id)
+        .json(&json!({"content": content}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 201);
+    r.json::<Value>().await.unwrap()["memory_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
 #[tokio::test]
 async fn test_episodic_no_memories_returns_error() {
     let (llm, _shutdown) = spawn_fake_llm().await;
@@ -3367,6 +3388,8 @@ async fn test_retrieve_session_scope_only_prefilters_and_skips_graph() {
     let target_mid =
         store_memory_for_session(&client, &base, &uid, "target-session memory", "sess-target")
             .await;
+    let global_mid =
+        store_memory_unscoped(&client, &base, &uid, "global-unscoped top").await;
     let other_mid =
         store_memory_for_session(&client, &base, &uid, "other-session top", "sess-other").await;
     let other_second_mid =
@@ -3457,8 +3480,13 @@ async fn test_retrieve_session_scope_only_prefilters_and_skips_graph() {
     assert_ne!(strict_body["explain"]["path"], "graph");
     assert_eq!(
         strict_body["results"][0]["memory_id"].as_str(),
-        Some(target_mid.as_str()),
-        "strict session retrieval should pre-filter tabular candidates before ranking",
+        Some(global_mid.as_str()),
+        "strict session retrieval should rank within the requested session plus unscoped memories",
+    );
+    assert_ne!(
+        strict_body["results"][0]["memory_id"].as_str(),
+        Some(other_mid.as_str()),
+        "strict session retrieval should still exclude other scoped sessions",
     );
 }
 
@@ -3505,6 +3533,8 @@ async fn test_retrieve_session_scope_only_preserves_top_k_with_session_candidate
         store_memory_for_session(&client, &base, &uid, "scoped-candidate-a", "sess-target").await;
     let target_second =
         store_memory_for_session(&client, &base, &uid, "scoped-candidate-b", "sess-target").await;
+    let global_shared =
+        store_memory_unscoped(&client, &base, &uid, "global-candidate-b").await;
     let _other_first =
         store_memory_for_session(&client, &base, &uid, "global-candidate-a", "sess-other").await;
     let _other_second =
@@ -3518,7 +3548,7 @@ async fn test_retrieve_session_scope_only_preserves_top_k_with_session_candidate
             "query": "scoped topk query",
             "session_id": "sess-target",
             "session_scope": "only",
-            "top_k": 2
+            "top_k": 3
         }))
         .send()
         .await
@@ -3530,18 +3560,12 @@ async fn test_retrieve_session_scope_only_preserves_top_k_with_session_candidate
         .expect("retrieve should return array");
     assert_eq!(
         strict_results.len(),
-        2,
-        "strict session retrieval should still fill top_k from session-local candidates",
+        3,
+        "strict session retrieval should still fill top_k from session-local plus unscoped candidates",
     );
-    assert_eq!(
-        strict_results[0]["session_id"].as_str(),
-        Some("sess-target"),
-        "strict session retrieval must only return target-session memories",
-    );
-    assert_eq!(
-        strict_results[1]["session_id"].as_str(),
-        Some("sess-target"),
-        "strict session retrieval must only return target-session memories",
+    assert!(
+        strict_results.iter().all(|item| item["session_id"].as_str() != Some("sess-other")),
+        "strict session retrieval must still exclude other scoped sessions",
     );
     let strict_ids: std::collections::HashSet<&str> = strict_results
         .iter()
@@ -3549,8 +3573,12 @@ async fn test_retrieve_session_scope_only_preserves_top_k_with_session_candidate
         .collect();
     assert_eq!(
         strict_ids,
-        std::collections::HashSet::from([target_first.as_str(), target_second.as_str()]),
-        "strict retrieval should pre-filter before ranking instead of post-filtering a global top_k",
+        std::collections::HashSet::from([
+            target_first.as_str(),
+            target_second.as_str(),
+            global_shared.as_str(),
+        ]),
+        "strict retrieval should rank within the requested session plus unscoped memories",
     );
 }
 
@@ -3562,6 +3590,7 @@ async fn test_search_session_scope_only_respects_session() {
     let uid = uid();
 
     store_memory_for_session(&client, &base, &uid, "target-session memory", "sess-target").await;
+    store_memory_unscoped(&client, &base, &uid, "global-unscoped top").await;
     store_memory_for_session(&client, &base, &uid, "other-session top", "sess-other").await;
     store_memory_for_session(&client, &base, &uid, "other-session second", "sess-other").await;
 
@@ -3600,8 +3629,8 @@ async fn test_search_session_scope_only_respects_session() {
     let strict_body: Value = strict.json().await.unwrap();
     assert_eq!(
         strict_body[0]["session_id"].as_str(),
-        Some("sess-target"),
-        "session_scope=only should keep search inside the requested session",
+        None,
+        "session_scope=only should still include unscoped memories",
     );
 }
 

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -1814,6 +1814,61 @@ async fn test_remote_store_retrieve() {
 }
 
 #[tokio::test]
+async fn test_remote_retrieve_session_scope_only_includes_unscoped() {
+    use memoria_mcp::remote::RemoteClient;
+
+    let (base, _, _server) =
+        spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
+            .await;
+    let uid = uid();
+    let remote = RemoteClient::new(&base, None, uid.clone(), None);
+    let target_session = format!("session:test-retrieve-{}", uuid::Uuid::new_v4().simple());
+    let other_session = format!("session:test-retrieve-{}", uuid::Uuid::new_v4().simple());
+
+    remote
+        .call(
+            "memory_store",
+            json!({"content": "target-session memory", "session_id": target_session}),
+        )
+        .await
+        .unwrap();
+    remote
+        .call("memory_store", json!({"content": "global-unscoped top"}))
+        .await
+        .unwrap();
+    remote
+        .call(
+            "memory_store",
+            json!({"content": "other-session top", "session_id": other_session}),
+        )
+        .await
+        .unwrap();
+
+    let strict = remote
+        .call(
+            "memory_retrieve",
+            json!({
+                "query": "strict session query",
+                "session_id": target_session,
+                "session_scope": "only",
+                "top_k": 1
+            }),
+        )
+        .await
+        .unwrap();
+    let strict_text = strict["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        strict_text.contains("global-unscoped top"),
+        "strict remote retrieve should include unscoped memory: {strict_text}"
+    );
+    assert!(
+        !strict_text.contains("other-session top"),
+        "strict remote retrieve should exclude other scoped sessions: {strict_text}"
+    );
+    println!("✅ remote retrieve session_scope=only includes unscoped");
+}
+
+#[tokio::test]
 async fn test_remote_correct_purge() {
     use memoria_mcp::remote::RemoteClient;
 
@@ -1954,6 +2009,61 @@ async fn test_remote_list_search_profile() {
         "profile: {t}"
     );
     println!("✅ remote profile: {t}");
+}
+
+#[tokio::test]
+async fn test_remote_search_session_scope_only_includes_unscoped() {
+    use memoria_mcp::remote::RemoteClient;
+
+    let (base, _, _server) =
+        spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
+            .await;
+    let uid = uid();
+    let remote = RemoteClient::new(&base, None, uid.clone(), None);
+    let target_session = format!("session:test-search-{}", uuid::Uuid::new_v4().simple());
+    let other_session = format!("session:test-search-{}", uuid::Uuid::new_v4().simple());
+
+    remote
+        .call(
+            "memory_store",
+            json!({"content": "target-session memory", "session_id": target_session}),
+        )
+        .await
+        .unwrap();
+    remote
+        .call("memory_store", json!({"content": "global-unscoped top"}))
+        .await
+        .unwrap();
+    remote
+        .call(
+            "memory_store",
+            json!({"content": "other-session top", "session_id": other_session}),
+        )
+        .await
+        .unwrap();
+
+    let strict = remote
+        .call(
+            "memory_search",
+            json!({
+                "query": "strict session query",
+                "session_id": target_session,
+                "session_scope": "only",
+                "top_k": 1
+            }),
+        )
+        .await
+        .unwrap();
+    let strict_text = strict["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        strict_text.contains("global-unscoped top"),
+        "strict remote search should include unscoped memory: {strict_text}"
+    );
+    assert!(
+        !strict_text.contains("other-session top"),
+        "strict remote search should exclude other scoped sessions: {strict_text}"
+    );
+    println!("✅ remote search session_scope=only includes unscoped");
 }
 
 #[tokio::test]
@@ -2620,6 +2730,13 @@ async fn test_remote_list_session_id_filter() {
         )
         .await
         .unwrap();
+    remote
+        .call(
+            "memory_store",
+            json!({"content": "remote global list gamma"}),
+        )
+        .await
+        .unwrap();
 
     let list = remote
         .call(
@@ -2636,6 +2753,10 @@ async fn test_remote_list_session_id_filter() {
     assert!(
         !list_text.contains("remote other list beta"),
         "got: {list_text}"
+    );
+    assert!(
+        !list_text.contains("remote global list gamma"),
+        "exact session filter should exclude unscoped memories: {list_text}"
     );
     println!("✅ remote list session_id filter");
 }
@@ -7024,6 +7145,30 @@ async fn test_mcp_memory_retrieve_session_scope_end_to_end() {
         );
     }
 
+    let global_resp = mcp_post_with_headers(
+        &client,
+        &base,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 131,
+            "method": "tools/call",
+            "params": {
+                "name": "memory_store",
+                "arguments": {
+                    "content": "global-unscoped top",
+                    "memory_type": "semantic"
+                }
+            }
+        }),
+        &headers,
+    )
+    .await;
+    assert!(
+        global_resp["error"].is_null(),
+        "unexpected unscoped store error: {}",
+        global_resp["error"]
+    );
+
     let relaxed = mcp_post_with_headers(
         &client,
         &base,
@@ -7081,8 +7226,8 @@ async fn test_mcp_memory_retrieve_session_scope_end_to_end() {
     );
     let strict_text = mcp_result_text(&strict);
     assert!(
-        strict_text.contains("target-session memory"),
-        "strict MCP retrieve should return the target-session memory: {strict_text}"
+        strict_text.contains("global-unscoped top"),
+        "strict MCP retrieve should include unscoped memory: {strict_text}"
     );
     assert!(
         !strict_text.contains("other-session top"),
@@ -7128,6 +7273,30 @@ async fn test_mcp_memory_search_session_scope_end_to_end() {
             resp["error"]
         );
     }
+
+    let global_resp = mcp_post_with_headers(
+        &client,
+        &base,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 231,
+            "method": "tools/call",
+            "params": {
+                "name": "memory_store",
+                "arguments": {
+                    "content": "global-unscoped top",
+                    "memory_type": "semantic"
+                }
+            }
+        }),
+        &headers,
+    )
+    .await;
+    assert!(
+        global_resp["error"].is_null(),
+        "unexpected unscoped store error: {}",
+        global_resp["error"]
+    );
 
     let relaxed = mcp_post_with_headers(
         &client,
@@ -7186,8 +7355,8 @@ async fn test_mcp_memory_search_session_scope_end_to_end() {
     );
     let strict_text = mcp_result_text(&strict);
     assert!(
-        strict_text.contains("target-session memory"),
-        "strict MCP search should return the target-session memory: {strict_text}"
+        strict_text.contains("global-unscoped top"),
+        "strict MCP search should include unscoped memory: {strict_text}"
     );
     assert!(
         !strict_text.contains("other-session top"),

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -2451,11 +2451,20 @@ async fn test_remote_correct_by_query() {
     let (base, _, _server) = spawn_api_for_remote().await;
     let uid = uid();
     let remote = RemoteClient::new(&base, None, uid.clone(), None);
+    let target_session = format!("session:test-correct-{}", uuid::Uuid::new_v4().simple());
+    let other_session = format!("session:test-correct-{}", uuid::Uuid::new_v4().simple());
 
     remote
         .call(
             "memory_store",
-            json!({"content": "Uses black for Python formatting"}),
+            json!({"content": "Uses black for Python formatting in target", "session_id": target_session}),
+        )
+        .await
+        .unwrap();
+    remote
+        .call(
+            "memory_store",
+            json!({"content": "Uses black for Python formatting in other", "session_id": other_session}),
         )
         .await
         .unwrap();
@@ -2465,16 +2474,30 @@ async fn test_remote_correct_by_query() {
             "memory_correct",
             json!({
                 "query": "black formatting",
-                "new_content": "Uses ruff for Python formatting",
+                "session_id": target_session,
+                "session_scope": "only",
+                "new_content": "Uses ruff for Python formatting in target",
                 "reason": "switched"
             }),
         )
         .await
         .unwrap();
     let t = r["content"][0]["text"].as_str().unwrap_or("");
+    assert!(t.contains("Corrected"), "got: {t}");
+    assert!(t.contains("target"), "got: {t}");
+
+    let list = remote
+        .call("memory_list", json!({"limit": 10}))
+        .await
+        .unwrap();
+    let list_text = list["content"][0]["text"].as_str().unwrap_or("");
     assert!(
-        t.contains("Corrected") || t.contains("No matching"),
-        "got: {t}"
+        list_text.contains("Uses ruff for Python formatting in target"),
+        "got: {list_text}"
+    );
+    assert!(
+        list_text.contains("Uses black for Python formatting in other"),
+        "got: {list_text}"
     );
     println!("✅ remote correct by query: {t}");
 }
@@ -2571,6 +2594,49 @@ async fn test_remote_purge_by_session_id() {
         "got: {list_text}"
     );
     println!("✅ remote purge by session_id: {t}");
+}
+
+#[tokio::test]
+async fn test_remote_list_session_id_filter() {
+    use memoria_mcp::remote::RemoteClient;
+    let (base, _, _server) = spawn_api_for_remote().await;
+    let uid = uid();
+    let remote = RemoteClient::new(&base, None, uid.clone(), None);
+    let target_session = format!("session:test-list-{}", uuid::Uuid::new_v4().simple());
+    let other_session = format!("session:test-list-{}", uuid::Uuid::new_v4().simple());
+
+    remote
+        .call(
+            "memory_store",
+            json!({"content": "remote target list alpha", "session_id": target_session}),
+        )
+        .await
+        .unwrap();
+    remote
+        .call(
+            "memory_store",
+            json!({"content": "remote other list beta", "session_id": other_session}),
+        )
+        .await
+        .unwrap();
+
+    let list = remote
+        .call(
+            "memory_list",
+            json!({"limit": 10, "session_id": target_session}),
+        )
+        .await
+        .unwrap();
+    let list_text = list["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        list_text.contains("remote target list alpha"),
+        "got: {list_text}"
+    );
+    assert!(
+        !list_text.contains("remote other list beta"),
+        "got: {list_text}"
+    );
+    println!("✅ remote list session_id filter");
 }
 
 #[tokio::test]
@@ -3289,7 +3355,7 @@ async fn test_explain_verbose_candidate_scores() {
 }
 
 #[tokio::test]
-async fn test_retrieve_filter_session_prefilters_and_skips_graph() {
+async fn test_retrieve_session_scope_only_prefilters_and_skips_graph() {
     use memoria_storage::{GraphEdge, GraphNode, GraphStore, NodeType};
 
     let (base, client, server) =
@@ -3378,7 +3444,7 @@ async fn test_retrieve_filter_session_prefilters_and_skips_graph() {
         .json(&json!({
             "query": "strict session query",
             "session_id": "sess-target",
-            "filter_session": true,
+            "session_scope": "only",
             "top_k": 1,
             "explain": true
         }))
@@ -3394,30 +3460,10 @@ async fn test_retrieve_filter_session_prefilters_and_skips_graph() {
         Some(target_mid.as_str()),
         "strict session retrieval should pre-filter tabular candidates before ranking",
     );
-
-    let legacy = client
-        .post(format!("{base}/v1/memories/retrieve"))
-        .header("X-User-Id", &uid)
-        .json(&json!({
-            "query": "strict session query",
-            "session_id": "sess-target",
-            "include_cross_session": false,
-            "top_k": 1
-        }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(legacy.status(), 200);
-    let legacy_body: Value = legacy.json().await.unwrap();
-    assert_eq!(
-        legacy_body[0]["memory_id"].as_str(),
-        Some(target_mid.as_str()),
-        "legacy include_cross_session=false should keep strict session semantics",
-    );
 }
 
 #[tokio::test]
-async fn test_retrieve_filter_session_requires_session_id() {
+async fn test_retrieve_session_scope_requires_session_id() {
     let (base, client, _server) = spawn_server().await;
     let user = uid();
 
@@ -3426,7 +3472,7 @@ async fn test_retrieve_filter_session_requires_session_id() {
         .header("X-User-Id", &user)
         .json(&json!({
             "query": "strict session query",
-            "filter_session": true,
+            "session_scope": "only",
             "top_k": 1
         }))
         .send()
@@ -3435,11 +3481,11 @@ async fn test_retrieve_filter_session_requires_session_id() {
     assert_eq!(r.status(), 422);
 
     let r = client
-        .post(format!("{base}/v1/memories/retrieve"))
+        .post(format!("{base}/v1/memories/search"))
         .header("X-User-Id", &user)
         .json(&json!({
             "query": "strict session query",
-            "include_cross_session": false,
+            "session_scope": "prefer",
             "top_k": 1
         }))
         .send()
@@ -3449,7 +3495,7 @@ async fn test_retrieve_filter_session_requires_session_id() {
 }
 
 #[tokio::test]
-async fn test_retrieve_filter_session_preserves_top_k_with_session_candidates() {
+async fn test_retrieve_session_scope_only_preserves_top_k_with_session_candidates() {
     let (base, client, _server) =
         spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
             .await;
@@ -3471,7 +3517,7 @@ async fn test_retrieve_filter_session_preserves_top_k_with_session_candidates() 
         .json(&json!({
             "query": "scoped topk query",
             "session_id": "sess-target",
-            "filter_session": true,
+            "session_scope": "only",
             "top_k": 2
         }))
         .send()
@@ -3505,6 +3551,57 @@ async fn test_retrieve_filter_session_preserves_top_k_with_session_candidates() 
         strict_ids,
         std::collections::HashSet::from([target_first.as_str(), target_second.as_str()]),
         "strict retrieval should pre-filter before ranking instead of post-filtering a global top_k",
+    );
+}
+
+#[tokio::test]
+async fn test_search_session_scope_only_respects_session() {
+    let (base, client, _server) =
+        spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
+            .await;
+    let uid = uid();
+
+    store_memory_for_session(&client, &base, &uid, "target-session memory", "sess-target").await;
+    store_memory_for_session(&client, &base, &uid, "other-session top", "sess-other").await;
+    store_memory_for_session(&client, &base, &uid, "other-session second", "sess-other").await;
+
+    let relaxed = client
+        .post(format!("{base}/v1/memories/search"))
+        .header("X-User-Id", &uid)
+        .json(&json!({
+            "query": "strict session query",
+            "session_id": "sess-target",
+            "top_k": 1
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(relaxed.status(), 200);
+    let relaxed_body: Value = relaxed.json().await.unwrap();
+    assert_eq!(
+        relaxed_body[0]["session_id"].as_str(),
+        Some("sess-other"),
+        "relaxed search should still be free to return another session",
+    );
+
+    let strict = client
+        .post(format!("{base}/v1/memories/search"))
+        .header("X-User-Id", &uid)
+        .json(&json!({
+            "query": "strict session query",
+            "session_id": "sess-target",
+            "session_scope": "only",
+            "top_k": 1
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(strict.status(), 200);
+    let strict_body: Value = strict.json().await.unwrap();
+    assert_eq!(
+        strict_body[0]["session_id"].as_str(),
+        Some("sess-target"),
+        "session_scope=only should keep search inside the requested session",
     );
 }
 
@@ -6860,7 +6957,7 @@ async fn test_mcp_tools_call_memory_store() {
 }
 
 #[tokio::test]
-async fn test_mcp_memory_retrieve_filter_session_end_to_end() {
+async fn test_mcp_memory_retrieve_session_scope_end_to_end() {
     let (base, client, _server) =
         spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
             .await;
@@ -6940,7 +7037,7 @@ async fn test_mcp_memory_retrieve_filter_session_end_to_end() {
                 "arguments": {
                     "query": "strict session query",
                     "session_id": "sess-target",
-                    "filter_session": true,
+                    "session_scope": "only",
                     "top_k": 1
                 }
             }
@@ -6962,20 +7059,59 @@ async fn test_mcp_memory_retrieve_filter_session_end_to_end() {
         !strict_text.contains("other-session top"),
         "strict MCP retrieve should not leak cross-session memory: {strict_text}"
     );
+}
 
-    let legacy = mcp_post_with_headers(
+#[tokio::test]
+async fn test_mcp_memory_search_session_scope_end_to_end() {
+    let (base, client, _server) =
+        spawn_server_with_custom_embedder_and_pool(Arc::new(SessionScopeTestEmbedder), test_dim())
+            .await;
+    let uid = uid();
+    let headers = [("X-User-Id", uid.as_str())];
+
+    for (id, content, session_id) in [
+        (21, "target-session memory", "sess-target"),
+        (22, "other-session top", "sess-other"),
+        (23, "other-session second", "sess-other"),
+    ] {
+        let resp = mcp_post_with_headers(
+            &client,
+            &base,
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "tools/call",
+                "params": {
+                    "name": "memory_store",
+                    "arguments": {
+                        "content": content,
+                        "memory_type": "semantic",
+                        "session_id": session_id
+                    }
+                }
+            }),
+            &headers,
+        )
+        .await;
+        assert!(
+            resp["error"].is_null(),
+            "unexpected store error: {}",
+            resp["error"]
+        );
+    }
+
+    let relaxed = mcp_post_with_headers(
         &client,
         &base,
         json!({
             "jsonrpc": "2.0",
-            "id": 16,
+            "id": 24,
             "method": "tools/call",
             "params": {
-                "name": "memory_retrieve",
+                "name": "memory_search",
                 "arguments": {
                     "query": "strict session query",
                     "session_id": "sess-target",
-                    "include_cross_session": false,
                     "top_k": 1
                 }
             }
@@ -6984,14 +7120,49 @@ async fn test_mcp_memory_retrieve_filter_session_end_to_end() {
     )
     .await;
     assert!(
-        legacy["error"].is_null(),
-        "unexpected legacy error: {}",
-        legacy["error"]
+        relaxed["error"].is_null(),
+        "unexpected relaxed error: {}",
+        relaxed["error"]
     );
-    let legacy_text = mcp_result_text(&legacy);
+    let relaxed_text = mcp_result_text(&relaxed);
     assert!(
-        legacy_text.contains("target-session memory"),
-        "legacy MCP retrieve flag should still enforce session scope: {legacy_text}"
+        relaxed_text.contains("other-session"),
+        "relaxed MCP search should still be free to return cross-session memory: {relaxed_text}"
+    );
+
+    let strict = mcp_post_with_headers(
+        &client,
+        &base,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 25,
+            "method": "tools/call",
+            "params": {
+                "name": "memory_search",
+                "arguments": {
+                    "query": "strict session query",
+                    "session_id": "sess-target",
+                    "session_scope": "only",
+                    "top_k": 1
+                }
+            }
+        }),
+        &headers,
+    )
+    .await;
+    assert!(
+        strict["error"].is_null(),
+        "unexpected strict error: {}",
+        strict["error"]
+    );
+    let strict_text = mcp_result_text(&strict);
+    assert!(
+        strict_text.contains("target-session memory"),
+        "strict MCP search should return the target-session memory: {strict_text}"
+    );
+    assert!(
+        !strict_text.contains("other-session top"),
+        "strict MCP search should not leak cross-session memory: {strict_text}"
     );
 }
 

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -56,29 +56,49 @@ impl SessionScopeTestEmbedder {
     fn vector_for(text: &str) -> Vec<f32> {
         let mut v = vec![0.0; test_dim()];
         match text {
-            "strict session query" | "other-session top" => v[0] = 1.0,
-            "global-unscoped top" => v[0] = 0.99,
-            "scoped topk query" | "global-candidate-a" => v[0] = 1.0,
+            "strict session query" => v[0] = 1.0,
+            "other-session top" => {
+                v[0] = 0.85;
+                v[1] = 0.52;
+            }
+            "global-unscoped top" => {
+                v[0] = 0.58;
+                v[1] = 0.78;
+            }
+            "scoped topk query" => v[2] = 1.0,
+            "global-candidate-a" => v[0] = 1.0,
             "other-session second" => {
-                v[0] = 0.98;
-                v[1] = 0.02;
+                v[0] = 0.72;
+                v[1] = 0.18;
+                v[2] = 0.67;
             }
             "global-candidate-b" => {
-                v[0] = 0.97;
-                v[1] = 0.03;
+                v[1] = 0.12;
+                v[2] = 0.90;
+                v[3] = 0.38;
             }
             "target-session memory" => v[1] = 1.0,
             "scoped-candidate-a" => {
-                v[0] = 0.6;
-                v[1] = 0.4;
+                v[0] = 0.32;
+                v[1] = 0.05;
+                v[2] = 0.88;
             }
             "target-session backup" => {
-                v[1] = 0.97;
-                v[2] = 0.03;
+                v[0] = 0.10;
+                v[1] = 0.94;
+                v[2] = 0.18;
+                v[3] = 0.28;
             }
             "scoped-candidate-b" => {
-                v[0] = 0.3;
-                v[1] = 0.7;
+                v[0] = 0.05;
+                v[1] = 0.32;
+                v[2] = 0.88;
+            }
+            "other-session decoy" => {
+                v[0] = 0.78;
+                v[1] = 0.44;
+                v[2] = 0.12;
+                v[3] = 0.18;
             }
             _ => v[2] = 1.0,
         }

--- a/memoria/crates/memoria-api/tests/support/multi_db.rs
+++ b/memoria/crates/memoria-api/tests/support/multi_db.rs
@@ -105,7 +105,7 @@ pub async fn spawn_api_server(
     }
 
     let app = memoria_api::build_router(state);
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+    let listener = tokio::net::TcpListener::bind("localhost:0")
         .await
         .expect("bind");
     let port = listener.local_addr().expect("local addr").port();
@@ -123,7 +123,7 @@ pub async fn spawn_api_server(
         .no_proxy()
         .build()
         .expect("client");
-    let base = format!("http://127.0.0.1:{port}");
+    let base = format!("http://localhost:{port}");
     wait_for_server(&client, &base, &context.shared_pool()).await;
 
     ApiTestServer {

--- a/memoria/crates/memoria-cli/templates/claude_rule.md
+++ b/memoria/crates/memoria-cli/templates/claude_rule.md
@@ -74,16 +74,17 @@ Before storing a new memory, consider:
 | Tool | When to use | Key params |
 |------|-------------|------------|
 | `memory_store` | User shares a fact, preference, or decision | `content`, `memory_type` (default: semantic), `session_id` (optional) |
-| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason` |
-| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch, e.g. `"id1,id2"`) or `topic` (bulk keyword match), `reason` |
+| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason`; query mode also supports `session_id` + `session_scope` |
+| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch), `topic`, or exact `session_id`; `memory_types` only with `session_id` |
 
 `memory_purge` automatically creates a safety snapshot before deleting. The response includes the snapshot name — tell the user they can `memory_rollback` to undo. If the response contains a ⚠️ warning about snapshot quota, relay it and suggest `memory_snapshot_delete(prefix="pre_")`.
 
 ### Read tools
 | Tool | When to use | Key params |
 |------|-------------|------------|
-| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), `session_id` (optional), `explain` (false = no debug, true = show timing) |
-| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), `explain` (false = no debug, true = show timing) |
+| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
+| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
+| `memory_list` | User wants a bounded inventory or a session-specific listing | `limit`, optional `memory_type`, optional exact `session_id` |
 | `memory_profile` | User asks "what do you know about me" | — |
 | `memory_feedback` | After using a retrieved memory, record if it was helpful | `memory_id`, `signal` (useful/irrelevant/outdated/wrong), `context` (optional) |
 
@@ -116,9 +117,15 @@ memory_feedback(memory_id="abc123", signal="useful", context="answered DB questi
 **Impact**: Feedback accumulates over time. With default settings, a memory with 3 `useful` signals ranks ~30% higher in future retrievals. Don't call for every memory — only when you have clear signal.
 
 **`memory_retrieve` vs `memory_search`**: In MCP mode, both use the same retrieval pipeline (graph → hybrid vector+fulltext → fulltext fallback). The differences are:
-- `memory_retrieve` accepts `session_id` for session-scoped boosting; `memory_search` does not
+- Both accept optional `session_id` plus `session_scope`
+- `session_scope="prefer"` means "use this session as context, but cross-session results are still allowed" (default when `session_id` is present)
+- `session_scope="only"` means "strictly filter to this session"
 - `memory_retrieve` defaults to `top_k=5` (focused); `memory_search` defaults to `top_k=10` (broader)
-- Use `memory_retrieve` when you have a `session_id` or want focused results; use `memory_search` for broader exploration
+- Use `memory_retrieve` for prompt-relevant context; use `memory_search` for broader browsing over the same retrieval pipeline
+
+**`memory_list` session semantics**:
+- `session_id` on `memory_list` is an exact filter, not a preference hint
+- Use it to inspect one session before `memory_purge(session_id=...)` or after a session-scoped correction
 
 **Debug parameter:** `explain=true` shows execution timing and retrieval path. **ONLY use when user explicitly asks** to debug performance or investigate why certain memories were/weren't retrieved. **DO NOT use proactively** — it adds overhead and clutters output.
 

--- a/memoria/crates/memoria-cli/templates/codex_agents.md
+++ b/memoria/crates/memoria-cli/templates/codex_agents.md
@@ -78,16 +78,17 @@ Before storing a new memory, consider:
 | Tool | When to use | Key params |
 |------|-------------|------------|
 | `memory_store` | User shares a fact, preference, or decision | `content`, `memory_type` (default: semantic), `session_id` (optional) |
-| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason` |
-| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch, e.g. `"id1,id2"`) or `topic` (bulk keyword match), `reason` |
+| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason`; query mode also supports `session_id` + `session_scope` |
+| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch), `topic`, or exact `session_id`; `memory_types` only with `session_id` |
 
 `memory_purge` automatically creates a safety snapshot before deleting. The response includes the snapshot name — tell the user they can `memory_rollback` to undo. If the response contains a ⚠️ warning about snapshot quota, relay it and suggest `memory_snapshot_delete(prefix="pre_")`.
 
 ### Read tools
 | Tool | When to use | Key params |
 |------|-------------|------------|
-| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), `session_id` (optional), `explain` (false = no debug, true = show timing) |
-| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), `explain` (false = no debug, true = show timing) |
+| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
+| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
+| `memory_list` | User wants a bounded inventory or a session-specific listing | `limit`, optional `memory_type`, optional exact `session_id` |
 | `memory_profile` | User asks "what do you know about me" | — |
 | `memory_feedback` | After using a retrieved memory, record if it was helpful | `memory_id`, `signal` (useful/irrelevant/outdated/wrong), `context` (optional) |
 
@@ -108,9 +109,15 @@ Before storing a new memory, consider:
 **Impact**: Feedback accumulates over time. With default settings, a memory with 3 `useful` signals ranks ~30% higher in future retrievals. Don't call for every memory — only when you have clear signal.
 
 **`memory_retrieve` vs `memory_search`**: In MCP mode, both use the same retrieval pipeline (graph → hybrid vector+fulltext → fulltext fallback). The differences are:
-- `memory_retrieve` accepts `session_id` for session-scoped boosting; `memory_search` does not
+- Both accept optional `session_id` plus `session_scope`
+- `session_scope="prefer"` means "use this session as context, but cross-session results are still allowed" (default when `session_id` is present)
+- `session_scope="only"` means "strictly filter to this session"
 - `memory_retrieve` defaults to `top_k=5` (focused); `memory_search` defaults to `top_k=10` (broader)
-- Use `memory_retrieve` when you have a `session_id` or want focused results; use `memory_search` for broader exploration
+- Use `memory_retrieve` for prompt-relevant context; use `memory_search` for broader browsing over the same retrieval pipeline
+
+**`memory_list` session semantics**:
+- `session_id` on `memory_list` is an exact filter, not a preference hint
+- Use it to inspect one session before `memory_purge(session_id=...)` or after a session-scoped correction
 
 **Debug parameter:** `explain=true` shows execution timing and retrieval path. **ONLY use when user explicitly asks** to debug performance or investigate why certain memories were/weren't retrieved. **DO NOT use proactively** — it adds overhead and clutters output.
 

--- a/memoria/crates/memoria-cli/templates/cursor_rule.md
+++ b/memoria/crates/memoria-cli/templates/cursor_rule.md
@@ -83,16 +83,17 @@ Before storing a new memory, consider:
 | Tool | When to use | Key params |
 |------|-------------|------------|
 | `memory_store` | User shares a fact, preference, or decision | `content`, `memory_type` (default: semantic), `session_id` (optional) |
-| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason` |
-| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch, e.g. `"id1,id2"`) or `topic` (bulk keyword match), `reason` |
+| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason`; query mode also supports `session_id` + `session_scope` |
+| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch), `topic`, or exact `session_id`; `memory_types` only with `session_id` |
 
 `memory_purge` automatically creates a safety snapshot before deleting. The response includes the snapshot name — tell the user they can `memory_rollback` to undo. If the response contains a ⚠️ warning about snapshot quota, relay it and suggest `memory_snapshot_delete(prefix="pre_")`.
 
 ### Read tools
 | Tool | When to use | Key params |
 |------|-------------|------------|
-| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), `session_id` (optional), `explain` (false = no debug, true = show timing) |
-| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), `explain` (false = no debug, true = show timing) |
+| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
+| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
+| `memory_list` | User wants a bounded inventory or a session-specific listing | `limit`, optional `memory_type`, optional exact `session_id` |
 | `memory_profile` | User asks "what do you know about me" | — |
 | `memory_feedback` | After using a retrieved memory, record if it was helpful | `memory_id`, `signal` (useful/irrelevant/outdated/wrong), `context` (optional) |
 
@@ -125,9 +126,15 @@ memory_feedback(memory_id="abc123", signal="useful", context="answered DB questi
 **Impact**: Feedback accumulates over time. With default settings, a memory with 3 `useful` signals ranks ~30% higher in future retrievals. Don't call for every memory — only when you have clear signal.
 
 **`memory_retrieve` vs `memory_search`**: In MCP mode, both use the same retrieval pipeline (graph → hybrid vector+fulltext → fulltext fallback). The differences are:
-- `memory_retrieve` accepts `session_id` for session-scoped boosting; `memory_search` does not
+- Both accept optional `session_id` plus `session_scope`
+- `session_scope="prefer"` means "use this session as context, but cross-session results are still allowed" (default when `session_id` is present)
+- `session_scope="only"` means "strictly filter to this session"
 - `memory_retrieve` defaults to `top_k=5` (focused); `memory_search` defaults to `top_k=10` (broader)
-- Use `memory_retrieve` when you have a `session_id` or want focused results; use `memory_search` for broader exploration
+- Use `memory_retrieve` for prompt-relevant context; use `memory_search` for broader browsing over the same retrieval pipeline
+
+**`memory_list` session semantics**:
+- `session_id` on `memory_list` is an exact filter, not a preference hint
+- Use it to inspect one session before `memory_purge(session_id=...)` or after a session-scoped correction
 
 **Debug parameter:** `explain=true` shows execution timing and retrieval path. **ONLY use when user explicitly asks** to debug performance or investigate why certain memories were/weren't retrieved. **DO NOT use proactively** — it adds overhead and clutters output.
 

--- a/memoria/crates/memoria-cli/templates/gemini_rule.md
+++ b/memoria/crates/memoria-cli/templates/gemini_rule.md
@@ -74,16 +74,17 @@ Before storing a new memory, consider:
 | Tool | When to use | Key params |
 |------|-------------|------------|
 | `memory_store` | User shares a fact, preference, or decision | `content`, `memory_type` (default: semantic), `session_id` (optional) |
-| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason` |
-| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch, e.g. `"id1,id2"`) or `topic` (bulk keyword match), `reason` |
+| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason`; query mode also supports `session_id` + `session_scope` |
+| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch), `topic`, or exact `session_id`; `memory_types` only with `session_id` |
 
 `memory_purge` automatically creates a safety snapshot before deleting. The response includes the snapshot name — tell the user they can `memory_rollback` to undo. If the response contains a ⚠️ warning about snapshot quota, relay it and suggest `memory_snapshot_delete(prefix="pre_")`.
 
 ### Read tools
 | Tool | When to use | Key params |
 |------|-------------|------------|
-| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), `session_id` (optional), `explain` (false = no debug, true = show timing) |
-| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), `explain` (false = no debug, true = show timing) |
+| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
+| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
+| `memory_list` | User wants a bounded inventory or a session-specific listing | `limit`, optional `memory_type`, optional exact `session_id` |
 | `memory_profile` | User asks "what do you know about me" | — |
 | `memory_feedback` | After using a retrieved memory, record if it was helpful | `memory_id`, `signal` (useful/irrelevant/outdated/wrong), `context` (optional) |
 
@@ -116,9 +117,15 @@ memory_feedback(memory_id="abc123", signal="useful", context="answered DB questi
 **Impact**: Feedback accumulates over time. With default settings, a memory with 3 `useful` signals ranks ~30% higher in future retrievals. Don't call for every memory — only when you have clear signal.
 
 **`memory_retrieve` vs `memory_search`**: In MCP mode, both use the same retrieval pipeline (graph → hybrid vector+fulltext → fulltext fallback). The differences are:
-- `memory_retrieve` accepts `session_id` for session-scoped boosting; `memory_search` does not
+- Both accept optional `session_id` plus `session_scope`
+- `session_scope="prefer"` means "use this session as context, but cross-session results are still allowed" (default when `session_id` is present)
+- `session_scope="only"` means "strictly filter to this session"
 - `memory_retrieve` defaults to `top_k=5` (focused); `memory_search` defaults to `top_k=10` (broader)
-- Use `memory_retrieve` when you have a `session_id` or want focused results; use `memory_search` for broader exploration
+- Use `memory_retrieve` for prompt-relevant context; use `memory_search` for broader browsing over the same retrieval pipeline
+
+**`memory_list` session semantics**:
+- `session_id` on `memory_list` is an exact filter, not a preference hint
+- Use it to inspect one session before `memory_purge(session_id=...)` or after a session-scoped correction
 
 **Debug parameter:** `explain=true` shows execution timing and retrieval path. **ONLY use when user explicitly asks** to debug performance or investigate why certain memories were/weren't retrieved. **DO NOT use proactively** — it adds overhead and clutters output.
 

--- a/memoria/crates/memoria-cli/templates/kiro_steering.md
+++ b/memoria/crates/memoria-cli/templates/kiro_steering.md
@@ -78,16 +78,17 @@ Before storing a new memory, consider:
 | Tool | When to use | Key params |
 |------|-------------|------------|
 | `memory_store` | User shares a fact, preference, or decision | `content`, `memory_type` (default: semantic), `session_id` (optional) |
-| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason` |
-| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch, e.g. `"id1,id2"`) or `topic` (bulk keyword match), `reason` |
+| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason`; query mode also supports `session_id` + `session_scope` |
+| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch), `topic`, or exact `session_id`; `memory_types` only with `session_id` |
 
 `memory_purge` automatically creates a safety snapshot before deleting. The response includes the snapshot name — tell the user they can `memory_rollback` to undo. If the response contains a ⚠️ warning about snapshot quota, relay it and suggest `memory_snapshot_delete(prefix="pre_")`.
 
 ### Read tools
 | Tool | When to use | Key params |
 |------|-------------|------------|
-| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), `session_id` (optional), `explain` (false = no debug, true = show timing) |
-| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), `explain` (false = no debug, true = show timing) |
+| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
+| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
+| `memory_list` | User wants a bounded inventory or a session-specific listing | `limit`, optional `memory_type`, optional exact `session_id` |
 | `memory_profile` | User asks "what do you know about me" | — |
 | `memory_feedback` | After using a retrieved memory, record if it was helpful | `memory_id`, `signal` (useful/irrelevant/outdated/wrong), `context` (optional) |
 
@@ -120,9 +121,15 @@ memory_feedback(memory_id="abc123", signal="useful", context="answered DB questi
 **Impact**: Feedback accumulates over time. With default settings, a memory with 3 `useful` signals ranks ~30% higher in future retrievals. Don't call for every memory — only when you have clear signal.
 
 **`memory_retrieve` vs `memory_search`**: In MCP mode, both use the same retrieval pipeline (graph → hybrid vector+fulltext → fulltext fallback). The differences are:
-- `memory_retrieve` accepts `session_id` for session-scoped boosting; `memory_search` does not
+- Both accept optional `session_id` plus `session_scope`
+- `session_scope="prefer"` means "use this session as context, but cross-session results are still allowed" (default when `session_id` is present)
+- `session_scope="only"` means "strictly filter to this session"
 - `memory_retrieve` defaults to `top_k=5` (focused); `memory_search` defaults to `top_k=10` (broader)
-- Use `memory_retrieve` when you have a `session_id` or want focused results; use `memory_search` for broader exploration
+- Use `memory_retrieve` for prompt-relevant context; use `memory_search` for broader browsing over the same retrieval pipeline
+
+**`memory_list` session semantics**:
+- `session_id` on `memory_list` is an exact filter, not a preference hint
+- Use it to inspect one session before `memory_purge(session_id=...)` or after a session-scoped correction
 
 **Debug parameter:** `explain=true` shows execution timing and retrieval path. **ONLY use when user explicitly asks** to debug performance or investigate why certain memories were/weren't retrieved. **DO NOT use proactively** — it adds overhead and clutters output.
 

--- a/memoria/crates/memoria-mcp/src/remote.rs
+++ b/memoria/crates/memoria-mcp/src/remote.rs
@@ -105,22 +105,18 @@ impl RemoteClient {
                 };
                 let mut payload = json!({
                     "query": args["query"],
-                    "top_k": args["top_k"].as_i64().unwrap_or(5),
+                    "top_k": if name == "memory_search" {
+                        args["top_k"].as_i64().unwrap_or(10)
+                    } else {
+                        args["top_k"].as_i64().unwrap_or(5)
+                    },
                     "session_id": args["session_id"],
                 });
-                if name == "memory_retrieve" {
-                    if let Some(filter_session) = args
-                        .get("filter_session")
-                        .and_then(serde_json::Value::as_bool)
-                    {
-                        payload["filter_session"] = json!(filter_session);
-                    }
-                    if let Some(include_cross_session) = args
-                        .get("include_cross_session")
-                        .and_then(serde_json::Value::as_bool)
-                    {
-                        payload["include_cross_session"] = json!(include_cross_session);
-                    }
+                if let Some(session_scope) = args
+                    .get("session_scope")
+                    .and_then(serde_json::Value::as_str)
+                {
+                    payload["session_scope"] = json!(session_scope);
                 }
                 let r = self
                     .client
@@ -159,9 +155,17 @@ impl RemoteClient {
                         .send()
                         .await?
                 } else {
-                    self.client.post(self.url("/v1/memories/correct"))
-                        .json(&json!({"query": query, "new_content": new_content, "reason": args["reason"]}))
-                        .send().await?
+                    self.client
+                        .post(self.url("/v1/memories/correct"))
+                        .json(&json!({
+                            "query": query,
+                            "new_content": new_content,
+                            "session_id": args["session_id"],
+                            "session_scope": args["session_scope"],
+                            "reason": args["reason"]
+                        }))
+                        .send()
+                        .await?
                 };
                 let body = Self::parse_response(r).await?;
                 if let Some(_err) = body.get("error") {
@@ -247,12 +251,19 @@ impl RemoteClient {
 
             "memory_list" => {
                 let limit = args["limit"].as_i64().unwrap_or(20);
-                let r = self
+                let memory_type = args.get("memory_type").and_then(Value::as_str);
+                let session_id = args.get("session_id").and_then(Value::as_str);
+                let mut req = self
                     .client
-                    .get(self.url(&format!("/v1/memories?limit={limit}")))
-                    .send()
-                    .await?;
-                let body = Self::parse_response(r).await?;
+                    .get(self.url("/v1/memories"))
+                    .query(&[("limit", limit)]);
+                if let Some(memory_type) = memory_type {
+                    req = req.query(&[("memory_type", memory_type)]);
+                }
+                if let Some(session_id) = session_id {
+                    req = req.query(&[("session_id", session_id)]);
+                }
+                let body = Self::parse_response(req.send().await?).await?;
                 let items = body["items"].as_array().cloned().unwrap_or_default();
                 if items.is_empty() {
                     return Ok(Self::mcp_text("No memories found."));

--- a/memoria/crates/memoria-mcp/src/tools.rs
+++ b/memoria/crates/memoria-mcp/src/tools.rs
@@ -134,7 +134,7 @@ pub fn list() -> Value {
                     "query": {"type": "string"},
                     "top_k": {"type": "integer", "default": 5},
                     "session_id": {"type": "string"},
-                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "How to use session_id: prefer=non-strict retrieval using the provided session_id as context; only=strictly filter to that session"},
+                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "How to use session_id: prefer=non-strict retrieval using the provided session_id as context; only=limit results to that session plus unscoped memories"},
                     "explain": {"type": ["boolean", "string"], "default": false, "description": "Explain level: false/\"none\"=off, true/\"basic\"=timing+path, \"verbose\"=+per-candidate scores, \"analyze\"=full"}
                 },
                 "required": ["query"]
@@ -149,7 +149,7 @@ pub fn list() -> Value {
                     "query": {"type": "string"},
                     "top_k": {"type": "integer", "default": 10},
                     "session_id": {"type": "string"},
-                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "How to use session_id: prefer=non-strict search using the provided session_id as context; only=strictly filter to that session"},
+                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "How to use session_id: prefer=non-strict search using the provided session_id as context; only=limit results to that session plus unscoped memories"},
                     "explain": {"type": ["boolean", "string"], "default": false, "description": "Explain level: false/\"none\"=off, true/\"basic\"=timing+path, \"verbose\"=+per-candidate scores, \"analyze\"=full"}
                 },
                 "required": ["query"]
@@ -165,7 +165,7 @@ pub fn list() -> Value {
                     "query": {"type": "string", "description": "Semantic search to find memory to correct"},
                     "new_content": {"type": "string"},
                     "session_id": {"type": "string", "description": "Optional session to use when resolving query-based correction"},
-                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "Only used with query-based correction. prefer=non-strict lookup using the provided session_id as context; only=restrict lookup to the given session"},
+                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "Only used with query-based correction. prefer=non-strict lookup using the provided session_id as context; only=restrict lookup to the given session plus unscoped memories"},
                     "reason": {"type": "string"}
                 },
                 "required": ["new_content"]

--- a/memoria/crates/memoria-mcp/src/tools.rs
+++ b/memoria/crates/memoria-mcp/src/tools.rs
@@ -38,6 +38,22 @@ fn parse_session_scope_arg(args: &Value) -> Result<Option<memoria_service::Sessi
         .map_err(|e| anyhow::anyhow!("{e}"))
 }
 
+fn parse_retrieve_options_arg(args: &Value) -> Result<memoria_service::RetrieveOptions> {
+    let session_id = args
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty());
+    let session_scope = parse_session_scope_arg(args)?;
+    if session_scope.is_some() && session_id.is_none() {
+        anyhow::bail!("session_id is required when session_scope is set");
+    }
+    Ok(memoria_service::RetrieveOptions::from_session_scope(
+        session_id,
+        session_scope,
+    ))
+}
+
 enum ToolCallName {
     MemoryStore,
     MemoryRetrieve,
@@ -118,7 +134,7 @@ pub fn list() -> Value {
                     "query": {"type": "string"},
                     "top_k": {"type": "integer", "default": 5},
                     "session_id": {"type": "string"},
-                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "How to use session_id: prefer=session-aware retrieval that may still return cross-session memories; only=strictly filter to that session"},
+                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "How to use session_id: prefer=non-strict retrieval using the provided session_id as context; only=strictly filter to that session"},
                     "explain": {"type": ["boolean", "string"], "default": false, "description": "Explain level: false/\"none\"=off, true/\"basic\"=timing+path, \"verbose\"=+per-candidate scores, \"analyze\"=full"}
                 },
                 "required": ["query"]
@@ -133,7 +149,7 @@ pub fn list() -> Value {
                     "query": {"type": "string"},
                     "top_k": {"type": "integer", "default": 10},
                     "session_id": {"type": "string"},
-                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "How to use session_id: prefer=session-aware search that may still return cross-session memories; only=strictly filter to that session"},
+                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "How to use session_id: prefer=non-strict search using the provided session_id as context; only=strictly filter to that session"},
                     "explain": {"type": ["boolean", "string"], "default": false, "description": "Explain level: false/\"none\"=off, true/\"basic\"=timing+path, \"verbose\"=+per-candidate scores, \"analyze\"=full"}
                 },
                 "required": ["query"]
@@ -149,7 +165,7 @@ pub fn list() -> Value {
                     "query": {"type": "string", "description": "Semantic search to find memory to correct"},
                     "new_content": {"type": "string"},
                     "session_id": {"type": "string", "description": "Optional session to use when resolving query-based correction"},
-                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "Only used with query-based correction. prefer=session-aware lookup; only=restrict lookup to the given session"},
+                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "Only used with query-based correction. prefer=non-strict lookup using the provided session_id as context; only=restrict lookup to the given session"},
                     "reason": {"type": "string"}
                 },
                 "required": ["new_content"]
@@ -355,10 +371,7 @@ pub async fn call(
             } else {
                 args["top_k"].as_i64().unwrap_or(5)
             };
-            let retrieve_options = memoria_service::RetrieveOptions::from_session_scope(
-                args["session_id"].as_str(),
-                parse_session_scope_arg(&args)?,
-            );
+            let retrieve_options = parse_retrieve_options_arg(&args)?;
             // explain accepts bool or string: true/"basic"/"verbose"/"analyze"
             let explain_str = match &args["explain"] {
                 serde_json::Value::Bool(true) => "basic",
@@ -420,10 +433,7 @@ pub async fn call(
             let old_mid = if !memory_id.is_empty() {
                 memory_id.to_string()
             } else if !query.is_empty() {
-                let retrieve_options = memoria_service::RetrieveOptions::from_session_scope(
-                    args["session_id"].as_str(),
-                    parse_session_scope_arg(&args)?,
-                );
+                let retrieve_options = parse_retrieve_options_arg(&args)?;
                 let results = service
                     .retrieve_with_options(user_id, query, 1, &retrieve_options)
                     .await?;

--- a/memoria/crates/memoria-mcp/src/tools.rs
+++ b/memoria/crates/memoria-mcp/src/tools.rs
@@ -30,6 +30,14 @@ fn git_for_store(sql: &Arc<SqlMemoryStore>) -> Option<GitForDataService> {
         .map(|db_name| GitForDataService::new(sql.pool().clone(), db_name.to_string()))
 }
 
+fn parse_session_scope_arg(args: &Value) -> Result<Option<memoria_service::SessionScope>> {
+    args.get("session_scope")
+        .and_then(Value::as_str)
+        .map(memoria_service::SessionScope::from_str)
+        .transpose()
+        .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
 enum ToolCallName {
     MemoryStore,
     MemoryRetrieve,
@@ -103,15 +111,14 @@ pub fn list() -> Value {
         },
         {
             "name": "memory_retrieve",
-            "description": "Retrieve relevant memories for a query",
+            "description": "Retrieve relevant memories for a query, optionally scoped to a session",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "query": {"type": "string"},
                     "top_k": {"type": "integer", "default": 5},
                     "session_id": {"type": "string"},
-                    "filter_session": {"type": "boolean", "description": "When true, restrict retrieval to the given session_id and bypass cross-session graph retrieval"},
-                    "include_cross_session": {"type": "boolean", "default": true, "description": "Legacy flag. false is equivalent to filter_session=true when session_id is set"},
+                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "How to use session_id: prefer=session-aware retrieval that may still return cross-session memories; only=strictly filter to that session"},
                     "explain": {"type": ["boolean", "string"], "default": false, "description": "Explain level: false/\"none\"=off, true/\"basic\"=timing+path, \"verbose\"=+per-candidate scores, \"analyze\"=full"}
                 },
                 "required": ["query"]
@@ -119,12 +126,14 @@ pub fn list() -> Value {
         },
         {
             "name": "memory_search",
-            "description": "Semantic search across all memories",
+            "description": "Semantic search across memories, optionally scoped to a session",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "query": {"type": "string"},
                     "top_k": {"type": "integer", "default": 10},
+                    "session_id": {"type": "string"},
+                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "How to use session_id: prefer=session-aware search that may still return cross-session memories; only=strictly filter to that session"},
                     "explain": {"type": ["boolean", "string"], "default": false, "description": "Explain level: false/\"none\"=off, true/\"basic\"=timing+path, \"verbose\"=+per-candidate scores, \"analyze\"=full"}
                 },
                 "required": ["query"]
@@ -139,6 +148,8 @@ pub fn list() -> Value {
                     "memory_id": {"type": "string"},
                     "query": {"type": "string", "description": "Semantic search to find memory to correct"},
                     "new_content": {"type": "string"},
+                    "session_id": {"type": "string", "description": "Optional session to use when resolving query-based correction"},
+                    "session_scope": {"type": "string", "enum": ["prefer", "only"], "description": "Only used with query-based correction. prefer=session-aware lookup; only=restrict lookup to the given session"},
                     "reason": {"type": "string"}
                 },
                 "required": ["new_content"]
@@ -170,11 +181,13 @@ pub fn list() -> Value {
         },
         {
             "name": "memory_list",
-            "description": "List active memories for the user",
+            "description": "List active memories for the user, with optional exact session filtering",
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "limit": {"type": "integer", "default": 20}
+                    "limit": {"type": "integer", "default": 20},
+                    "memory_type": {"type": "string"},
+                    "session_id": {"type": "string", "description": "Exact session identifier — only list memories from that session"}
                 }
             }
         },
@@ -253,7 +266,6 @@ pub async fn call(
         "memory_observe" => ToolCallName::MemoryObserve,
         _ => ToolCallName::Unknown(name.to_string()),
     };
-    let is_memory_retrieve = matches!(tool, ToolCallName::MemoryRetrieve);
     match tool {
         ToolCallName::MemoryStore => {
             let content = args["content"].as_str().unwrap_or("").to_string();
@@ -338,16 +350,15 @@ pub async fn call(
 
         ToolCallName::MemoryRetrieve | ToolCallName::MemorySearch => {
             let query = args["query"].as_str().unwrap_or("").to_string();
-            let top_k = args["top_k"].as_i64().unwrap_or(5);
-            let retrieve_options = if is_memory_retrieve {
-                memoria_service::RetrieveOptions::from_session_scope(
-                    args["session_id"].as_str(),
-                    args.get("filter_session").and_then(|v| v.as_bool()),
-                    args.get("include_cross_session").and_then(|v| v.as_bool()),
-                )
+            let top_k = if matches!(tool, ToolCallName::MemorySearch) {
+                args["top_k"].as_i64().unwrap_or(10)
             } else {
-                memoria_service::RetrieveOptions::default()
+                args["top_k"].as_i64().unwrap_or(5)
             };
+            let retrieve_options = memoria_service::RetrieveOptions::from_session_scope(
+                args["session_id"].as_str(),
+                parse_session_scope_arg(&args)?,
+            );
             // explain accepts bool or string: true/"basic"/"verbose"/"analyze"
             let explain_str = match &args["explain"] {
                 serde_json::Value::Bool(true) => "basic",
@@ -409,7 +420,13 @@ pub async fn call(
             let old_mid = if !memory_id.is_empty() {
                 memory_id.to_string()
             } else if !query.is_empty() {
-                let results = service.retrieve(user_id, query, 1).await?;
+                let retrieve_options = memoria_service::RetrieveOptions::from_session_scope(
+                    args["session_id"].as_str(),
+                    parse_session_scope_arg(&args)?,
+                );
+                let results = service
+                    .retrieve_with_options(user_id, query, 1, &retrieve_options)
+                    .await?;
                 match results.into_iter().next() {
                     Some(found) => found.memory_id,
                     None => return Ok(mcp_text("No matching memory found for query")),
@@ -482,7 +499,15 @@ pub async fn call(
 
         ToolCallName::MemoryList => {
             let limit = args["limit"].as_i64().unwrap_or(20);
-            let memories = service.list_active(user_id, limit).await?;
+            let memories = service
+                .list_active_filtered(
+                    user_id,
+                    limit,
+                    args.get("memory_type").and_then(Value::as_str),
+                    args.get("session_id").and_then(Value::as_str),
+                    None,
+                )
+                .await?;
             if memories.is_empty() {
                 return Ok(mcp_text("No memories found."));
             }

--- a/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
@@ -170,6 +170,51 @@ async fn test_retrieve_empty() {
     println!("✅ retrieve empty: {}", text(&r));
 }
 
+#[tokio::test]
+async fn test_retrieve_session_scope_only() {
+    let (svc, uid, _ctx) = setup().await;
+    let target_session = format!("session:test-retrieve-{}", Uuid::new_v4().simple());
+    let other_session = format!("session:test-retrieve-{}", Uuid::new_v4().simple());
+
+    call(
+        "memory_store",
+        json!({"content": "shared retrieve token target", "session_id": target_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+    call(
+        "memory_store",
+        json!({"content": "shared retrieve token other", "session_id": other_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+    call(
+        "memory_store",
+        json!({"content": "shared retrieve token global"}),
+        &svc,
+        &uid,
+    )
+    .await;
+
+    let r = call(
+        "memory_retrieve",
+        json!({"query": "shared retrieve token", "session_id": target_session, "session_scope": "only", "top_k": 5}),
+        &svc,
+        &uid,
+    )
+    .await;
+    let t = text(&r);
+    assert!(t.contains("shared retrieve token target"), "got: {t}");
+    assert!(t.contains("shared retrieve token global"), "got: {t}");
+    assert!(
+        !t.contains("shared retrieve token other"),
+        "session_scope=only should exclude other scoped sessions: {t}"
+    );
+    println!("✅ retrieve session_scope=only");
+}
+
 // ── 5. memory_search: top_k respected ────────────────────────────────────────
 
 #[tokio::test]
@@ -702,6 +747,13 @@ async fn test_list_session_id_filter() {
         &uid,
     )
     .await;
+    call(
+        "memory_store",
+        json!({"content": "list global gamma"}),
+        &svc,
+        &uid,
+    )
+    .await;
 
     let r = call(
         "memory_list",
@@ -713,6 +765,10 @@ async fn test_list_session_id_filter() {
     let t = text(&r);
     assert!(t.contains("list target alpha"), "got: {t}");
     assert!(!t.contains("list other beta"), "got: {t}");
+    assert!(
+        !t.contains("list global gamma"),
+        "exact session list should exclude unscoped memories: {t}"
+    );
     println!("✅ list exact session filter");
 }
 

--- a/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
@@ -234,6 +234,22 @@ async fn test_search_session_scope_only() {
     println!("✅ search session_scope=only");
 }
 
+#[tokio::test]
+async fn test_search_session_scope_requires_session_id() {
+    let (svc, uid, _ctx) = setup().await;
+    let r = call(
+        "memory_search",
+        json!({"query": "shared search token", "session_scope": "only", "top_k": 5}),
+        &svc,
+        &uid,
+    )
+    .await;
+    assert_eq!(
+        text(&r),
+        "session_id is required when session_scope is set"
+    );
+}
+
 // ── 6. memory_correct by memory_id ───────────────────────────────────────────
 
 #[tokio::test]
@@ -348,6 +364,27 @@ async fn test_correct_by_query_session_scope_only() {
     assert!(contents.contains(&"formatting target uses ruff"));
     assert!(contents.contains(&"formatting other uses black"));
     println!("✅ correct by query session_scope=only");
+}
+
+#[tokio::test]
+async fn test_correct_by_query_session_scope_requires_session_id() {
+    let (svc, uid, _ctx) = setup().await;
+    let r = call(
+        "memory_correct",
+        json!({
+            "query": "formatting uses black",
+            "session_scope": "only",
+            "new_content": "formatting target uses ruff",
+            "reason": "switched"
+        }),
+        &svc,
+        &uid,
+    )
+    .await;
+    assert_eq!(
+        text(&r),
+        "session_id is required when session_scope is set"
+    );
 }
 
 // ── 8. memory_correct: no target returns error ───────────────────────────────

--- a/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
@@ -237,15 +237,16 @@ async fn test_search_session_scope_only() {
 #[tokio::test]
 async fn test_search_session_scope_requires_session_id() {
     let (svc, uid, _ctx) = setup().await;
-    let r = call(
+    let err = memoria_mcp::tools::call(
         "memory_search",
         json!({"query": "shared search token", "session_scope": "only", "top_k": 5}),
         &svc,
         &uid,
     )
-    .await;
+    .await
+    .expect_err("missing session_id should be rejected");
     assert_eq!(
-        text(&r),
+        err.to_string(),
         "session_id is required when session_scope is set"
     );
 }
@@ -369,7 +370,7 @@ async fn test_correct_by_query_session_scope_only() {
 #[tokio::test]
 async fn test_correct_by_query_session_scope_requires_session_id() {
     let (svc, uid, _ctx) = setup().await;
-    let r = call(
+    let err = memoria_mcp::tools::call(
         "memory_correct",
         json!({
             "query": "formatting uses black",
@@ -380,9 +381,10 @@ async fn test_correct_by_query_session_scope_requires_session_id() {
         &svc,
         &uid,
     )
-    .await;
+    .await
+    .expect_err("missing session_id should be rejected");
     assert_eq!(
-        text(&r),
+        err.to_string(),
         "session_id is required when session_scope is set"
     );
 }

--- a/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
@@ -30,7 +30,11 @@ async fn spawn_fake_llm() -> (
     memoria_test_utils::spawn_fake_llm(vec![]).await
 }
 
-async fn setup() -> (Arc<MemoryService>, String, support::multi_db::McpTestContext) {
+async fn setup() -> (
+    Arc<MemoryService>,
+    String,
+    support::multi_db::McpTestContext,
+) {
     let ctx = support::multi_db::setup_mcp_context("core_tools_e2e", test_dim(), None, None).await;
     (ctx.service(), uid(), ctx)
 }
@@ -193,6 +197,43 @@ async fn test_search_top_k() {
     println!("✅ search top_k=3: {count} results");
 }
 
+#[tokio::test]
+async fn test_search_session_scope_only() {
+    let (svc, uid, _ctx) = setup().await;
+    let target_session = format!("session:test-search-{}", Uuid::new_v4().simple());
+    let other_session = format!("session:test-search-{}", Uuid::new_v4().simple());
+
+    call(
+        "memory_store",
+        json!({"content": "shared search token target", "session_id": target_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+    call(
+        "memory_store",
+        json!({"content": "shared search token other", "session_id": other_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+
+    let r = call(
+        "memory_search",
+        json!({"query": "shared search token", "session_id": target_session, "session_scope": "only", "top_k": 5}),
+        &svc,
+        &uid,
+    )
+    .await;
+    let t = text(&r);
+    assert!(t.contains("shared search token target"), "got: {t}");
+    assert!(
+        !t.contains("shared search token other"),
+        "session_scope=only should exclude other sessions: {t}"
+    );
+    println!("✅ search session_scope=only");
+}
+
 // ── 6. memory_correct by memory_id ───────────────────────────────────────────
 
 #[tokio::test]
@@ -263,6 +304,50 @@ async fn test_correct_by_query() {
         &svc, &uid).await;
     assert!(text(&r).contains("ruff"), "got: {}", text(&r));
     println!("✅ correct by query: {}", text(&r));
+}
+
+#[tokio::test]
+async fn test_correct_by_query_session_scope_only() {
+    let (svc, uid, _ctx) = setup().await;
+    let target_session = format!("session:test-correct-{}", Uuid::new_v4().simple());
+    let other_session = format!("session:test-correct-{}", Uuid::new_v4().simple());
+
+    call(
+        "memory_store",
+        json!({"content": "formatting target uses black", "session_id": target_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+    call(
+        "memory_store",
+        json!({"content": "formatting other uses black", "session_id": other_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+
+    let r = call(
+        "memory_correct",
+        json!({
+            "query": "formatting uses black",
+            "session_id": target_session,
+            "session_scope": "only",
+            "new_content": "formatting target uses ruff",
+            "reason": "switched"
+        }),
+        &svc,
+        &uid,
+    )
+    .await;
+    let t = text(&r);
+    assert!(t.contains("formatting target uses ruff"), "got: {t}");
+
+    let active = svc.list_active(&uid, 10).await.unwrap();
+    let contents: Vec<&str> = active.iter().map(|m| m.content.as_str()).collect();
+    assert!(contents.contains(&"formatting target uses ruff"));
+    assert!(contents.contains(&"formatting other uses black"));
+    println!("✅ correct by query session_scope=only");
 }
 
 // ── 8. memory_correct: no target returns error ───────────────────────────────
@@ -548,6 +633,40 @@ async fn test_list_limit_and_fields() {
         assert!(line.contains('('), "missing type parens: {line}");
     }
     println!("✅ list limit=3: {count} items with id+type+content");
+}
+
+#[tokio::test]
+async fn test_list_session_id_filter() {
+    let (svc, uid, _ctx) = setup().await;
+    let target_session = format!("session:test-list-{}", Uuid::new_v4().simple());
+    let other_session = format!("session:test-list-{}", Uuid::new_v4().simple());
+
+    call(
+        "memory_store",
+        json!({"content": "list target alpha", "session_id": target_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+    call(
+        "memory_store",
+        json!({"content": "list other beta", "session_id": other_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+
+    let r = call(
+        "memory_list",
+        json!({"limit": 10, "session_id": target_session}),
+        &svc,
+        &uid,
+    )
+    .await;
+    let t = text(&r);
+    assert!(t.contains("list target alpha"), "got: {t}");
+    assert!(!t.contains("list other beta"), "got: {t}");
+    println!("✅ list exact session filter");
 }
 
 // ── 17. memory_capabilities: lists all tools ─────────────────────────────────
@@ -892,7 +1011,11 @@ async fn test_link_entities_invalid_json() {
 /// Helper: create service with explicit LLM client (for testing LLM paths).
 async fn setup_with_llm(
     llm: Option<Arc<memoria_embedding::LlmClient>>,
-) -> (Arc<MemoryService>, String, support::multi_db::McpTestContext) {
+) -> (
+    Arc<MemoryService>,
+    String,
+    support::multi_db::McpTestContext,
+) {
     let ctx =
         support::multi_db::setup_mcp_context("core_tools_e2e_llm", test_dim(), None, llm).await;
     (ctx.service(), uid(), ctx)

--- a/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/core_tools_e2e.rs
@@ -217,6 +217,13 @@ async fn test_search_session_scope_only() {
         &uid,
     )
     .await;
+    call(
+        "memory_store",
+        json!({"content": "shared search token global"}),
+        &svc,
+        &uid,
+    )
+    .await;
 
     let r = call(
         "memory_search",
@@ -227,9 +234,10 @@ async fn test_search_session_scope_only() {
     .await;
     let t = text(&r);
     assert!(t.contains("shared search token target"), "got: {t}");
+    assert!(t.contains("shared search token global"), "got: {t}");
     assert!(
         !t.contains("shared search token other"),
-        "session_scope=only should exclude other sessions: {t}"
+        "session_scope=only should exclude other scoped sessions: {t}"
     );
     println!("✅ search session_scope=only");
 }

--- a/memoria/crates/memoria-service/src/lib.rs
+++ b/memoria/crates/memoria-service/src/lib.rs
@@ -46,7 +46,7 @@ pub use scoring::{
 };
 pub use service::{
     CandidateScore, ExplainLevel, InMemoryFlusher, MemoryService, PurgeResult, RetrievalExplain,
-    RetrieveOptions, ENTITY_EXTRACTION_DROPS,
+    RetrieveOptions, SessionScope, ENTITY_EXTRACTION_DROPS,
 };
 pub use stats_reporter::StatsReporter;
 

--- a/memoria/crates/memoria-service/src/service.rs
+++ b/memoria/crates/memoria-service/src/service.rs
@@ -49,32 +49,74 @@ impl ExplainLevel {
     }
 }
 
-/// Extra retrieval controls that must be threaded through the full retrieval pipeline.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct RetrieveOptions {
-    strict_session_id: Option<String>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SessionScope {
+    #[default]
+    Prefer,
+    Only,
 }
 
-impl RetrieveOptions {
-    /// `filter_session=true` takes precedence over `include_cross_session`.
-    /// When neither is provided, retrieval remains cross-session.
-    pub fn from_session_scope(
-        session_id: Option<&str>,
-        filter_session: Option<bool>,
-        include_cross_session: Option<bool>,
-    ) -> Self {
-        let strict_session = filter_session == Some(true) || include_cross_session == Some(false);
-        Self {
-            strict_session_id: session_id.filter(|_| strict_session).map(str::to_string),
+impl SessionScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SessionScope::Prefer => "prefer",
+            SessionScope::Only => "only",
         }
     }
 
+    pub fn is_strict(self) -> bool {
+        matches!(self, SessionScope::Only)
+    }
+}
+
+impl std::str::FromStr for SessionScope {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "prefer" => Ok(SessionScope::Prefer),
+            "only" => Ok(SessionScope::Only),
+            other => Err(format!(
+                "Invalid session_scope '{other}'. Use 'prefer' or 'only'."
+            )),
+        }
+    }
+}
+
+/// Extra retrieval controls that must be threaded through the full retrieval pipeline.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RetrieveOptions {
+    session_id: Option<String>,
+    session_scope: SessionScope,
+}
+
+impl RetrieveOptions {
+    pub fn from_session_scope(
+        session_id: Option<&str>,
+        session_scope: Option<SessionScope>,
+    ) -> Self {
+        Self {
+            session_id: session_id.map(str::to_string),
+            session_scope: session_scope.unwrap_or(SessionScope::Prefer),
+        }
+    }
+
+    pub fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
+    }
+
+    pub fn session_scope(&self) -> SessionScope {
+        self.session_scope
+    }
+
     pub fn strict_session_id(&self) -> Option<&str> {
-        self.strict_session_id.as_deref()
+        self.session_id
+            .as_deref()
+            .filter(|_| self.session_scope.is_strict())
     }
 
     pub fn is_strict_session(&self) -> bool {
-        self.strict_session_id.is_some()
+        self.strict_session_id().is_some()
     }
 }
 
@@ -2067,14 +2109,8 @@ impl MemoryService {
         user_id: &str,
         limit: i64,
     ) -> Result<Vec<Memory>, MemoriaError> {
-        if self.sql_store.is_some() {
-            let sql = self.user_sql_store(user_id).await?;
-            let table = sql.active_table(user_id).await?;
-            return sql
-                .list_active_lite(&table, user_id, limit, None, None)
-                .await;
-        }
-        self.store.list_active(user_id, limit).await
+        self.list_active_filtered(user_id, limit, None, None, None)
+            .await
     }
 
     /// Paginated list with optional memory_type filter and cursor-based keyset pagination.
@@ -2083,13 +2119,26 @@ impl MemoryService {
         user_id: &str,
         limit: i64,
         memory_type: Option<&str>,
+        session_id: Option<&str>,
+        cursor: Option<&str>,
+    ) -> Result<Vec<Memory>, MemoriaError> {
+        self.list_active_filtered(user_id, limit, memory_type, session_id, cursor)
+            .await
+    }
+
+    pub async fn list_active_filtered(
+        &self,
+        user_id: &str,
+        limit: i64,
+        memory_type: Option<&str>,
+        session_id: Option<&str>,
         cursor: Option<&str>,
     ) -> Result<Vec<Memory>, MemoriaError> {
         if self.sql_store.is_some() {
             let sql = self.user_sql_store(user_id).await?;
             let table = sql.active_table(user_id).await?;
             return sql
-                .list_active_lite(&table, user_id, limit, memory_type, cursor)
+                .list_active_lite(&table, user_id, limit, memory_type, session_id, cursor)
                 .await;
         }
         // Fallback: trait path — no SQL store means no server-side filter/cursor.
@@ -2097,6 +2146,9 @@ impl MemoryService {
         let mut mems = self.store.list_active(user_id, limit).await?;
         if let Some(mt) = memory_type {
             mems.retain(|m| m.memory_type.to_string() == mt);
+        }
+        if let Some(session_id) = session_id {
+            mems.retain(|m| m.session_id.as_deref() == Some(session_id));
         }
         if let Some(cursor_id) = cursor {
             mems.retain(|m| m.memory_id.as_str() < cursor_id);

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -1547,6 +1547,8 @@ impl SqlMemoryStore {
     }
 
     pub async fn migrate_shared(&self) -> Result<(), MemoriaError> {
+        let schema_name = self.current_schema_name().await?;
+        let schema_name = schema_name.as_ref();
         let mut conn = self.conn().await?;
         sqlx::query(
             r#"CREATE TABLE IF NOT EXISTS mem_user_registry (
@@ -1739,11 +1741,23 @@ impl SqlMemoryStore {
         .await
         .map_err(db_err)?;
 
-        let _ = sqlx::query(
-            "ALTER TABLE mem_async_tasks ADD COLUMN user_id VARCHAR(64) NOT NULL DEFAULT '' AFTER instance_id",
-        )
-        .execute(&mut *conn)
-        .await;
+        let has_async_task_user_id =
+            info_schema_column_exists(&self.pool, schema_name, "mem_async_tasks", "user_id").await;
+        if !has_async_task_user_id {
+            let add_async_task_user_id = sqlx::query(
+                "ALTER TABLE mem_async_tasks ADD COLUMN user_id VARCHAR(64) NOT NULL DEFAULT '' AFTER instance_id",
+            )
+            .execute(&mut *conn)
+            .await;
+            if let Err(e) = add_async_task_user_id {
+                if !is_duplicate_column(&e) {
+                    tracing::warn!(
+                        error = %e,
+                        "shared migration: failed to add mem_async_tasks.user_id compatibility column"
+                    );
+                }
+            }
+        }
 
         // ── Ops-metrics aggregate tables (push-based stats written by Memoria) ──
         // Created here so they exist in both single-db and multi-db deployments.

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -4474,6 +4474,7 @@ impl SqlMemoryStore {
         user_id: &str,
         limit: i64,
         memory_type: Option<&str>,
+        session_id: Option<&str>,
         cursor: Option<&str>,
     ) -> Result<Vec<Memory>, MemoriaError> {
         let table = self.t(table);
@@ -4484,6 +4485,9 @@ impl SqlMemoryStore {
             format!("SELECT memory_id FROM {table} WHERE user_id = ? AND is_active = 1");
         if memory_type.is_some() {
             inner.push_str(" AND memory_type = ?");
+        }
+        if session_id.is_some() {
+            inner.push_str(" AND session_id = ?");
         }
         if cursor.is_some() {
             inner.push_str(" AND memory_id < ?");
@@ -4501,6 +4505,9 @@ impl SqlMemoryStore {
         let mut q = sqlx::query(&sql).bind(user_id);
         if let Some(mt) = memory_type {
             q = q.bind(mt);
+        }
+        if let Some(session_id) = session_id {
+            q = q.bind(session_id);
         }
         if let Some(c) = cursor {
             q = q.bind(c);

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -4632,7 +4632,7 @@ impl SqlMemoryStore {
             return Ok(vec![]);
         }
         let session_clause = if session_id.is_some() {
-            " AND session_id = ?"
+            " AND (session_id = ? OR session_id IS NULL)"
         } else {
             ""
         };
@@ -4717,6 +4717,8 @@ impl SqlMemoryStore {
     }
 
     /// Vector search with optional memory_type and strict session pre-filter.
+    /// When session_id is provided, the candidate set includes that session plus
+    /// unscoped memories (session_id IS NULL).
     #[allow(clippy::too_many_arguments)]
     pub async fn search_vector_from_filtered_scoped(
         &self,
@@ -4733,7 +4735,10 @@ impl SqlMemoryStore {
             None => String::new(),
         };
         let session_clause = match session_id {
-            Some(session_id) => format!(" AND session_id = '{}'", sanitize_sql_literal(session_id)),
+            Some(session_id) => format!(
+                " AND (session_id = '{}' OR session_id IS NULL)",
+                sanitize_sql_literal(session_id)
+            ),
             None => String::new(),
         };
         let rank_mode = if session_id.is_some() { "pre" } else { "post" };

--- a/memoria/crates/memoria-storage/tests/router_multi_db.rs
+++ b/memoria/crates/memoria-storage/tests/router_multi_db.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use memoria_core::{interfaces::MemoryStore, Memory, MemoryType, TrustTier};
 use memoria_storage::store::CURRENT_USER_SCHEMA_VERSION;
-use memoria_storage::DbRouter;
+use memoria_storage::{DbRouter, SqlMemoryStore};
 use sqlx::Row;
 use uuid::Uuid;
 
@@ -195,4 +195,30 @@ async fn router_persists_and_repairs_user_schema_version_marker() {
         .expect("repaired updated_at");
     assert_eq!(repaired_version, CURRENT_USER_SCHEMA_VERSION);
     assert!(repaired_updated_at > stale_at);
+}
+
+#[tokio::test]
+async fn shared_migrate_is_idempotent_for_async_task_user_id() {
+    let shared_url = shared_db_url();
+    let shared_store = SqlMemoryStore::connect(&shared_url, test_dim(), Uuid::new_v4().to_string())
+        .await
+        .expect("connect shared store");
+
+    shared_store
+        .migrate_shared()
+        .await
+        .expect("first shared migrate");
+    shared_store
+        .migrate_shared()
+        .await
+        .expect("second shared migrate");
+
+    let user_id_column_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM information_schema.columns \
+         WHERE table_schema = DATABASE() AND table_name = 'mem_async_tasks' AND column_name = 'user_id'",
+    )
+    .fetch_one(shared_store.pool())
+    .await
+    .expect("query async task user_id column count");
+    assert_eq!(user_id_column_count, 1);
 }

--- a/memoria/crates/memoria-storage/tests/session_consistency.rs
+++ b/memoria/crates/memoria-storage/tests/session_consistency.rs
@@ -52,6 +52,7 @@ async fn recreate_table(table: &str) {
     .execute(&mut conn)
     .await
     .expect("create test table");
+    wait_for_table_visible(table).await;
 }
 
 async fn drop_table(table: &str) {
@@ -60,6 +61,32 @@ async fn drop_table(table: &str) {
         .execute(&mut conn)
         .await
         .expect("drop test table");
+}
+
+fn is_missing_table(e: &sqlx::Error) -> bool {
+    e.to_string().contains("no such table")
+}
+
+async fn wait_for_table_visible(table: &str) {
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+
+    loop {
+        let mut conn = connect_session().await;
+        match sqlx::query_scalar::<_, i64>(&format!("SELECT COUNT(*) FROM {table}"))
+            .fetch_one(&mut conn)
+            .await
+        {
+            Ok(_) => return,
+            Err(e) if is_missing_table(&e) => {
+                assert!(
+                    Instant::now() < deadline,
+                    "timed out waiting for {table} to become visible across sessions; last error: {e}",
+                );
+            }
+            Err(e) => panic!("failed while waiting for {table} to become visible: {e}"),
+        }
+        sleep(POLL_INTERVAL).await;
+    }
 }
 
 async fn insert_row(conn: &mut MySqlConnection, table: &str, id: &str, version: i64, note: &str) {

--- a/memoria/crates/memoria-storage/tests/store_crud.rs
+++ b/memoria/crates/memoria-storage/tests/store_crud.rs
@@ -249,15 +249,19 @@ async fn test_search_vector_from_filtered_scoped_prefilters_by_session() {
     other.session_id = Some("sess-other".to_string());
     other.embedding = Some(dim_vec(0, 1.0));
 
+    let mut global_mem = make_memory(&format!("vec-scope-3-{uid}"), "global session", &uid);
+    global_mem.embedding = Some(dim_vec(0, 0.95));
+
     store.insert(&target).await.unwrap();
     store.insert(&other).await.unwrap();
+    store.insert(&global_mem).await.unwrap();
 
-    let global = store
+    let global_results = store
         .search_vector_from_filtered_scoped("mem_memories", &uid, &dim_vec(0, 1.0), 1, None, None)
         .await
         .expect("global vector search");
     assert_eq!(
-        global.first().map(|m| m.memory_id.as_str()),
+        global_results.first().map(|m| m.memory_id.as_str()),
         Some(other.memory_id.as_str()),
         "global search should return the nearest cross-session memory",
     );
@@ -280,8 +284,8 @@ async fn test_search_vector_from_filtered_scoped_prefilters_by_session() {
     );
     assert_eq!(
         scoped.first().map(|m| m.memory_id.as_str()),
-        Some(target.memory_id.as_str()),
-        "strict session search should pre-filter candidates before ranking",
+        Some(global_mem.memory_id.as_str()),
+        "strict session search should rank within the target-session plus unscoped candidate set",
     );
 }
 
@@ -312,17 +316,21 @@ async fn test_search_vector_from_filtered_scoped_fills_limit_with_session_candid
     other_b.session_id = Some("sess-other".to_string());
     other_b.embedding = Some(mk_vec(0.97, 0.03));
 
+    let mut global = make_memory(&format!("vec-scope-fill-5-{uid}"), "unscoped shared", &uid);
+    global.embedding = Some(mk_vec(0.9, 0.1));
+
     store.insert(&target_a).await.unwrap();
     store.insert(&target_b).await.unwrap();
     store.insert(&other_a).await.unwrap();
     store.insert(&other_b).await.unwrap();
+    store.insert(&global).await.unwrap();
 
     let scoped = store
         .search_vector_from_filtered_scoped(
             "mem_memories",
             &uid,
             &mk_vec(1.0, 0.0),
-            2,
+            3,
             None,
             Some("sess-target"),
         )
@@ -330,15 +338,19 @@ async fn test_search_vector_from_filtered_scoped_fills_limit_with_session_candid
         .expect("session-scoped vector search");
     assert_eq!(
         scoped.len(),
-        2,
-        "strict session search should fill top_k from the filtered session candidate set",
+        3,
+        "strict session search should fill top_k from the target-session plus unscoped candidate set",
     );
     let scoped_ids: std::collections::HashSet<&str> =
         scoped.iter().map(|m| m.memory_id.as_str()).collect();
     assert_eq!(
         scoped_ids,
-        std::collections::HashSet::from([target_a.memory_id.as_str(), target_b.memory_id.as_str()]),
-        "strict session vector search should return both session-local candidates",
+        std::collections::HashSet::from([
+            target_a.memory_id.as_str(),
+            target_b.memory_id.as_str(),
+            global.memory_id.as_str(),
+        ]),
+        "strict session vector search should return session-local plus unscoped candidates",
     );
 }
 

--- a/memoria/crates/memoria-storage/tests/store_crud.rs
+++ b/memoria/crates/memoria-storage/tests/store_crud.rs
@@ -241,23 +241,33 @@ async fn test_search_vector_from_filtered_scoped_prefilters_by_session() {
         .await
         .unwrap();
 
+    // Keep cross-session fixtures far apart: store.insert() dedups per user,
+    // not per session.
+    let mk_vec = |x: f32, y: f32, z: f32| {
+        let mut v = vec![0.0; test_dim()];
+        v[0] = x;
+        v[1] = y;
+        v[2] = z;
+        v
+    };
+
     let mut target = make_memory(&format!("vec-scope-1-{uid}"), "target session", &uid);
     target.session_id = Some("sess-target".to_string());
-    target.embedding = Some(dim_vec(1, 1.0));
+    target.embedding = Some(mk_vec(0.0, 1.0, 0.0));
 
     let mut other = make_memory(&format!("vec-scope-2-{uid}"), "other session", &uid);
     other.session_id = Some("sess-other".to_string());
-    other.embedding = Some(dim_vec(0, 1.0));
+    other.embedding = Some(mk_vec(1.0, 0.0, 0.0));
 
     let mut global_mem = make_memory(&format!("vec-scope-3-{uid}"), "global session", &uid);
-    global_mem.embedding = Some(dim_vec(0, 0.95));
+    global_mem.embedding = Some(mk_vec(0.7, 0.0, 0.7));
 
     store.insert(&target).await.unwrap();
     store.insert(&other).await.unwrap();
     store.insert(&global_mem).await.unwrap();
 
     let global_results = store
-        .search_vector_from_filtered_scoped("mem_memories", &uid, &dim_vec(0, 1.0), 1, None, None)
+        .search_vector_from_filtered_scoped("mem_memories", &uid, &mk_vec(1.0, 0.0, 0.0), 1, None, None)
         .await
         .expect("global vector search");
     assert_eq!(
@@ -270,7 +280,7 @@ async fn test_search_vector_from_filtered_scoped_prefilters_by_session() {
         .search_vector_from_filtered_scoped(
             "mem_memories",
             &uid,
-            &dim_vec(0, 1.0),
+            &mk_vec(1.0, 0.0, 0.0),
             1,
             None,
             Some("sess-target"),
@@ -293,31 +303,34 @@ async fn test_search_vector_from_filtered_scoped_prefilters_by_session() {
 async fn test_search_vector_from_filtered_scoped_fills_limit_with_session_candidates() {
     let (store, uid) = setup().await;
 
-    let mk_vec = |x: f32, y: f32| {
+    // Keep strict-scope candidates distinct enough to avoid user-global
+    // near-duplicate suppression across sessions.
+    let mk_vec = |x: f32, y: f32, z: f32| {
         let mut v = vec![0.0; test_dim()];
         v[0] = x;
         v[1] = y;
+        v[2] = z;
         v
     };
 
     let mut target_a = make_memory(&format!("vec-scope-fill-1-{uid}"), "scoped a", &uid);
     target_a.session_id = Some("sess-target".to_string());
-    target_a.embedding = Some(mk_vec(0.7, 0.3));
+    target_a.embedding = Some(mk_vec(0.95, 0.2, 0.0));
 
     let mut target_b = make_memory(&format!("vec-scope-fill-2-{uid}"), "scoped b", &uid);
     target_b.session_id = Some("sess-target".to_string());
-    target_b.embedding = Some(mk_vec(0.65, 0.35));
+    target_b.embedding = Some(mk_vec(0.7, 0.7, 0.0));
 
     let mut other_a = make_memory(&format!("vec-scope-fill-3-{uid}"), "global a", &uid);
     other_a.session_id = Some("sess-other".to_string());
-    other_a.embedding = Some(mk_vec(1.0, 0.0));
+    other_a.embedding = Some(mk_vec(0.0, 1.0, 0.0));
 
     let mut other_b = make_memory(&format!("vec-scope-fill-4-{uid}"), "global b", &uid);
     other_b.session_id = Some("sess-other".to_string());
-    other_b.embedding = Some(mk_vec(0.97, 0.03));
+    other_b.embedding = Some(mk_vec(0.0, 0.0, 1.0));
 
     let mut global = make_memory(&format!("vec-scope-fill-5-{uid}"), "unscoped shared", &uid);
-    global.embedding = Some(mk_vec(0.9, 0.1));
+    global.embedding = Some(mk_vec(0.6, 0.0, 0.8));
 
     store.insert(&target_a).await.unwrap();
     store.insert(&target_b).await.unwrap();
@@ -329,7 +342,7 @@ async fn test_search_vector_from_filtered_scoped_fills_limit_with_session_candid
         .search_vector_from_filtered_scoped(
             "mem_memories",
             &uid,
-            &mk_vec(1.0, 0.0),
+            &mk_vec(1.0, 0.0, 0.0),
             3,
             None,
             Some("sess-target"),

--- a/memoria/crates/memoria-storage/tests/store_crud.rs
+++ b/memoria/crates/memoria-storage/tests/store_crud.rs
@@ -241,8 +241,6 @@ async fn test_search_vector_from_filtered_scoped_prefilters_by_session() {
         .await
         .unwrap();
 
-    // Keep cross-session fixtures far apart: store.insert() dedups per user,
-    // not per session.
     let mk_vec = |x: f32, y: f32, z: f32| {
         let mut v = vec![0.0; test_dim()];
         v[0] = x;
@@ -260,6 +258,7 @@ async fn test_search_vector_from_filtered_scoped_prefilters_by_session() {
     other.embedding = Some(mk_vec(1.0, 0.0, 0.0));
 
     let mut global_mem = make_memory(&format!("vec-scope-3-{uid}"), "global session", &uid);
+    global_mem.session_id = None;
     global_mem.embedding = Some(mk_vec(0.7, 0.0, 0.7));
 
     store.insert(&target).await.unwrap();
@@ -303,8 +302,6 @@ async fn test_search_vector_from_filtered_scoped_prefilters_by_session() {
 async fn test_search_vector_from_filtered_scoped_fills_limit_with_session_candidates() {
     let (store, uid) = setup().await;
 
-    // Keep strict-scope candidates distinct enough to avoid user-global
-    // near-duplicate suppression across sessions.
     let mk_vec = |x: f32, y: f32, z: f32| {
         let mut v = vec![0.0; test_dim()];
         v[0] = x;
@@ -330,6 +327,7 @@ async fn test_search_vector_from_filtered_scoped_fills_limit_with_session_candid
     other_b.embedding = Some(mk_vec(0.0, 0.0, 1.0));
 
     let mut global = make_memory(&format!("vec-scope-fill-5-{uid}"), "unscoped shared", &uid);
+    global.session_id = None;
     global.embedding = Some(mk_vec(0.6, 0.0, 0.8));
 
     store.insert(&target_a).await.unwrap();

--- a/memoria/crates/memoria-storage/tests/store_crud.rs
+++ b/memoria/crates/memoria-storage/tests/store_crud.rs
@@ -691,7 +691,7 @@ async fn test_list_active_lite() {
         .expect("soft_delete");
 
     let results = store
-        .list_active_lite("mem_memories", &uid, 10, None, None)
+        .list_active_lite("mem_memories", &uid, 10, None, None, None)
         .await
         .expect("list_active_lite");
     assert_eq!(results.len(), 2, "should exclude soft-deleted");
@@ -725,14 +725,14 @@ async fn test_list_active_lite_limit_cap() {
     }
     // Request limit=2, should only get 2
     let results = store
-        .list_active_lite("mem_memories", &uid, 2, None, None)
+        .list_active_lite("mem_memories", &uid, 2, None, None, None)
         .await
         .expect("list_active_lite");
     assert_eq!(results.len(), 2, "should respect limit");
 
     // Request absurdly large limit — capped at 500 internally
     let results = store
-        .list_active_lite("mem_memories", &uid, 999999, None, None)
+        .list_active_lite("mem_memories", &uid, 999999, None, None, None)
         .await
         .expect("list_active_lite");
     assert!(results.len() <= 501, "should cap at 501");

--- a/plugins/clawhub/thememoria/references/operations.md
+++ b/plugins/clawhub/thememoria/references/operations.md
@@ -13,7 +13,7 @@ Retrieve first when:
 
 Preferred order:
 
-1. `memory_retrieve` for prompt-relevant context (`session_scope="prefer"` for the default non-strict path with a session hint, `"only"` for strict session filtering)
+1. `memory_retrieve` for prompt-relevant context (`session_scope="prefer"` for the default non-strict path with a session hint, `"only"` for the requested session plus unscoped memories)
 2. `memory_search` for broader semantic lookup with the same optional session controls
 3. `memory_list` when the user wants a bounded inventory or an exact per-session listing
 

--- a/plugins/clawhub/thememoria/references/operations.md
+++ b/plugins/clawhub/thememoria/references/operations.md
@@ -13,9 +13,9 @@ Retrieve first when:
 
 Preferred order:
 
-1. `memory_retrieve` for prompt-relevant context
-2. `memory_search` for broader semantic lookup
-3. `memory_list` when the user wants a bounded inventory
+1. `memory_retrieve` for prompt-relevant context (`session_scope="prefer"` for session-aware retrieval, `"only"` for strict session filtering)
+2. `memory_search` for broader semantic lookup with the same optional session controls
+3. `memory_list` when the user wants a bounded inventory or an exact per-session listing
 
 ## What To Store
 
@@ -38,7 +38,7 @@ Do not store:
 
 - `memory_profile`: stable user traits and preferences
 - `memory_store`: general durable facts, procedures, lessons, decisions
-- `memory_correct`: fix a wrong memory
+- `memory_correct`: fix a wrong memory; query mode can use `session_id` + `session_scope`
 - `memory_forget` or `memory_purge`: remove memory that should no longer exist
 
 After important writes or repairs, verify with `memory_retrieve`, `memory_search`, or `memory_list`.

--- a/plugins/clawhub/thememoria/references/operations.md
+++ b/plugins/clawhub/thememoria/references/operations.md
@@ -13,7 +13,7 @@ Retrieve first when:
 
 Preferred order:
 
-1. `memory_retrieve` for prompt-relevant context (`session_scope="prefer"` for session-aware retrieval, `"only"` for strict session filtering)
+1. `memory_retrieve` for prompt-relevant context (`session_scope="prefer"` for the default non-strict path with a session hint, `"only"` for strict session filtering)
 2. `memory_search` for broader semantic lookup with the same optional session controls
 3. `memory_list` when the user wants a bounded inventory or an exact per-session listing
 

--- a/plugins/clawhub/thememoria/references/tool-surface.md
+++ b/plugins/clawhub/thememoria/references/tool-surface.md
@@ -17,11 +17,11 @@ Memoria gives OpenClaw:
 
 ### Recall
 
-- `memory_retrieve`: best default for relevant context
+- `memory_retrieve`: best default for relevant context; supports optional `session_id` + `session_scope` (`prefer` or `only`)
 - `memory_recall`: compatibility alias for `memory_retrieve`
-- `memory_search`: semantic lookup across memories
+- `memory_search`: semantic lookup across memories; also supports optional `session_id` + `session_scope`
 - `memory_get`: fetch a specific prior result if you already have an id
-- `memory_list`: bounded inventory of stored memories
+- `memory_list`: bounded inventory of stored memories, with optional exact `session_id` filtering
 
 ### Write And Repair
 


### PR DESCRIPTION
## What type of PR is this?

- [x] feat (new feature)
- [x] docs (documentation)
- [x] test (adding or updating tests)

## Which issue(s) this PR fixes

Fixes #

## What this PR does / why we need it

- replace the old retrieve booleans with a consistent `session_id + session_scope` model across API, MCP, and service retrieval flows
- add session-aware support to `memory_search` and query-based `memory_correct`, and exact `session_id` filtering to `memory_list`
- update tool descriptions, agent templates, and docs so callers use the new semantics consistently
- add local API/MCP/remote-mode e2e coverage for the new behavior and switch the API test helper to `localhost` for reliable local runs
