### PR TITLE
feat: add multi-db pool budget sizing

### DIFF
--- a/docs/per-user-database-architecture.md
+++ b/docs/per-user-database-architecture.md
@@ -665,14 +665,15 @@ LLM_MODEL=<model-name>
 
 | 变量 | 用途 |
 |---|---|
+| `MEMORIA_MULTI_DB_POOL_BUDGET` | multi-db 连接池默认预算基线；默认 `512`，上限 `2048`；未显式配置的池按 `global/shared/auth/init/governance = 60/20/10/5/5` 推导 |
 | `MEMORIA_GLOBAL_USER_POOL_MAX` | global user pool 大小 |
 | `MEMORIA_LEGACY_MIGRATION_MAX_CONCURRENCY` | 启动期 legacy -> multi-db 自动迁移的用户并发上限 |
 | `MEMORIA_USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS` | 首次用户 schema init / compat migration 专用池大小 |
 | `MEMORIA_USER_SCHEMA_INIT_MAX_CONCURRENCY` | 首次用户 schema init 并发上限 |
-| `MEMORIA_SHARED_POOL_MAX_CONNECTIONS` | shared router 组件默认配额 |
-| `MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS` | shared store 组件默认配额 |
-| `MEMORIA_GIT_POOL_MAX_CONNECTIONS` | git 组件默认配额 |
-| `MEMORIA_MERGED_SHARED_POOL_MAX_CONNECTIONS` | 显式覆盖合并后 shared DB 固定池大小 |
+| `MEMORIA_SHARED_POOL_MAX_CONNECTIONS` | 兼容旧配置的 shared router 组件配额；仅在显式设置时参与 merged shared pool 计算 |
+| `MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS` | 兼容旧配置的 shared store 组件配额；仅在显式设置时参与 merged shared pool 计算 |
+| `MEMORIA_GIT_POOL_MAX_CONNECTIONS` | 兼容旧配置的 git 组件配额；仅在显式设置时参与 merged shared pool 计算 |
+| `MEMORIA_MERGED_SHARED_POOL_MAX_CONNECTIONS` | 显式覆盖 merged shared pool 大小；优先级高于 budget 推导 |
 | `MEMORIA_AUTH_POOL_MAX_CONNECTIONS` | auth 专用连接池大小 |
 | `MEMORIA_AUTH_POOL_ACQUIRE_TIMEOUT_SECS` | auth 池获取超时 |
 | `DB_MAX_LIFETIME_SECS` | DB 连接最大生命周期 |

--- a/memoria/Cargo.lock
+++ b/memoria/Cargo.lock
@@ -2268,6 +2268,7 @@ dependencies = [
  "memoria-embedding",
  "memoria-git",
  "memoria-storage",
+ "memoria-test-utils",
  "moka",
  "prost",
  "protoc-bin-vendored",

--- a/memoria/crates/memoria-api/src/state.rs
+++ b/memoria/crates/memoria-api/src/state.rs
@@ -9,6 +9,7 @@ use memoria_git::GitForDataService;
 use memoria_service::{AsyncTaskStore, MemoryService, StatsReporter};
 use memoria_storage::store::spawn_pool_monitor;
 use memoria_storage::PoolHealthSnapshot;
+use memoria_storage::{configured_multi_db_pool_size, multi_db_pool_max_size, MultiDbPoolKind};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -17,7 +18,6 @@ use tracing::{info, warn};
 
 /// Hard upper bounds to prevent misconfiguration.
 const METRICS_CACHE_TTL_MAX_SECS: u64 = 300; // 5 min
-const AUTH_POOL_MAX_CONNECTIONS_UPPER: u32 = 64;
 const AUTH_POOL_ACQUIRE_TIMEOUT_MAX_SECS: u64 = 30;
 
 pub struct CachedMetrics {
@@ -91,6 +91,7 @@ pub struct AppState {
     pub api_key_cache: ApiKeyCache,
     /// Dedicated connection pool for auth queries (isolated from business queries)
     pub auth_pool: Option<sqlx::MySqlPool>,
+    auth_pool_max_connections: Option<u32>,
     /// Batched last_used_at updater
     pub last_used_batcher: Arc<LastUsedBatcher>,
     /// Batched per-user tool usage tracker (flushed every 10 min)
@@ -152,6 +153,7 @@ impl AppState {
             instance_id: "single".into(),
             api_key_cache: ApiKeyCache::new(Duration::from_secs(300)),
             auth_pool: None,
+            auth_pool_max_connections: None,
             last_used_batcher: Arc::new(LastUsedBatcher::new()),
             tool_usage_batcher: Arc::new(ToolUsageBatcher::new()),
             call_log_batcher: Arc::new(CallLogBatcher::new()),
@@ -177,17 +179,21 @@ impl AppState {
         database_url: &str,
         ops_metrics_enabled: bool,
     ) -> Result<Self, MemoriaError> {
+        let auth_pool_max_connections_upper = multi_db_pool_max_size(MultiDbPoolKind::Auth);
         let auth_max_connections = {
             let raw: u32 = std::env::var("MEMORIA_AUTH_POOL_MAX_CONNECTIONS")
                 .ok()
                 .and_then(|s| s.parse().ok())
-                .unwrap_or(12);
-            let clamped = raw.clamp(1, AUTH_POOL_MAX_CONNECTIONS_UPPER);
+                .unwrap_or(configured_multi_db_pool_size(
+                    "MEMORIA_AUTH_POOL_MAX_CONNECTIONS",
+                    MultiDbPoolKind::Auth,
+                ));
+            let clamped = raw.clamp(1, auth_pool_max_connections_upper);
             if clamped != raw {
                 warn!(
                     raw = raw,
                     clamped = clamped,
-                    max = AUTH_POOL_MAX_CONNECTIONS_UPPER,
+                    max = auth_pool_max_connections_upper,
                     "MEMORIA_AUTH_POOL_MAX_CONNECTIONS clamped to bounds"
                 );
             }
@@ -289,6 +295,7 @@ impl AppState {
             info!("Metrics summary refresher initialized for multi-db mode");
         }
         self.auth_pool = Some(pool);
+        self.auth_pool_max_connections = Some(auth_max_connections);
         {
             let mut fs = self.flusher_state.lock().unwrap();
             fs.shutdown = Some(shutdown_tx);
@@ -300,6 +307,10 @@ impl AppState {
     pub fn with_instance_id(mut self, instance_id: String) -> Self {
         self.instance_id = instance_id;
         self
+    }
+
+    pub fn auth_pool_max_connections(&self) -> Option<u32> {
+        self.auth_pool_max_connections
     }
 
     pub async fn mark_metrics_dirty(
@@ -421,12 +432,13 @@ mod tests {
         assert_eq!(5u64.clamp(1, METRICS_CACHE_TTL_MAX_SECS), 5);
 
         // auth pool max_connections clamping
-        assert_eq!(0u32.clamp(1, AUTH_POOL_MAX_CONNECTIONS_UPPER), 1);
+        let auth_pool_max_connections_upper = multi_db_pool_max_size(MultiDbPoolKind::Auth);
+        assert_eq!(0u32.clamp(1, auth_pool_max_connections_upper), 1);
         assert_eq!(
-            200u32.clamp(1, AUTH_POOL_MAX_CONNECTIONS_UPPER),
-            AUTH_POOL_MAX_CONNECTIONS_UPPER
+            999u32.clamp(1, auth_pool_max_connections_upper),
+            auth_pool_max_connections_upper
         );
-        assert_eq!(8u32.clamp(1, AUTH_POOL_MAX_CONNECTIONS_UPPER), 8);
+        assert_eq!(8u32.clamp(1, auth_pool_max_connections_upper), 8);
 
         // auth pool acquire_timeout clamping
         assert_eq!(0u64.clamp(1, AUTH_POOL_ACQUIRE_TIMEOUT_MAX_SECS), 1);

--- a/memoria/crates/memoria-api/tests/pool_budget_e2e.rs
+++ b/memoria/crates/memoria-api/tests/pool_budget_e2e.rs
@@ -1,0 +1,238 @@
+mod support;
+
+use std::{
+    future::Future,
+    sync::{Mutex, OnceLock},
+};
+
+use support::multi_db::{spawn_api_server, ApiTestServer};
+
+#[derive(Debug, Clone, Copy)]
+struct ExpectedPools {
+    shared: u32,
+    global: u32,
+    user_init: u32,
+    auth: u32,
+}
+
+async fn with_env_async<F, Fut, T>(vars: &[(&str, Option<&str>)], f: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = T>,
+{
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    let _lock = ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
+    struct EnvGuard(Vec<(String, Option<std::ffi::OsString>)>);
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, old) in &self.0 {
+                match old {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+            }
+        }
+    }
+
+    let _restore = EnvGuard(
+        vars.iter()
+            .map(|(key, value)| {
+                let old = std::env::var_os(key);
+                match value {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+                (key.to_string(), old)
+            })
+            .collect(),
+    );
+
+    f().await
+}
+
+fn budget_envs<'a>(budget: Option<&'a str>) -> [(&'a str, Option<&'a str>); 8] {
+    [
+        ("MEMORIA_MULTI_DB_POOL_BUDGET", budget),
+        ("MEMORIA_SHARED_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_GIT_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_MERGED_SHARED_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_GLOBAL_USER_POOL_MAX", Some("")),
+        ("MEMORIA_USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_AUTH_POOL_MAX_CONNECTIONS", Some("")),
+    ]
+}
+
+fn pool_override_envs<'a>(
+    budget: &'a str,
+    merged: Option<&'a str>,
+    global: Option<&'a str>,
+    user_init: Option<&'a str>,
+    auth: Option<&'a str>,
+) -> [(&'a str, Option<&'a str>); 8] {
+    [
+        ("MEMORIA_MULTI_DB_POOL_BUDGET", Some(budget)),
+        ("MEMORIA_SHARED_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_GIT_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_MERGED_SHARED_POOL_MAX_CONNECTIONS", merged),
+        ("MEMORIA_GLOBAL_USER_POOL_MAX", global),
+        ("MEMORIA_USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS", user_init),
+        ("MEMORIA_AUTH_POOL_MAX_CONNECTIONS", auth),
+    ]
+}
+
+async fn spawn_budget_server_with_env(vars: &[(&str, Option<&str>)]) -> ApiTestServer {
+    with_env_async(vars, || async {
+        spawn_api_server(
+            "pool_budget_e2e",
+            1024,
+            String::new(),
+            None,
+            None,
+            None,
+            true,
+        )
+        .await
+    })
+    .await
+}
+
+fn assert_expected_pools(case_name: &str, server: &ApiTestServer, expected: ExpectedPools) {
+    assert_eq!(
+        server.router().shared_pool_max_connections(),
+        expected.shared,
+        "{case_name}: shared merged pool size"
+    );
+    assert_eq!(
+        server.shared_store().configured_max_connections(),
+        Some(expected.shared),
+        "{case_name}: shared store configured max"
+    );
+    assert_eq!(
+        server.router().global_user_pool_max_connections(),
+        expected.global,
+        "{case_name}: global user pool size"
+    );
+    assert_eq!(
+        server.router().user_init_pool_max_connections(),
+        expected.user_init,
+        "{case_name}: user init pool size"
+    );
+    assert_eq!(
+        server.state().auth_pool_max_connections(),
+        Some(expected.auth),
+        "{case_name}: auth pool size"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_multi_db_pool_budget_defaults_and_boundaries() {
+    let server = spawn_budget_server_with_env(&budget_envs(Some(""))).await;
+    assert_expected_pools(
+        "default budget",
+        &server,
+        ExpectedPools {
+            shared: 102,
+            global: 307,
+            user_init: 26,
+            auth: 51,
+        },
+    );
+    drop(server);
+
+    let server = spawn_budget_server_with_env(&budget_envs(Some("0"))).await;
+    assert_expected_pools(
+        "low budget floors",
+        &server,
+        ExpectedPools {
+            shared: 64,
+            global: 128,
+            user_init: 10,
+            auth: 25,
+        },
+    );
+    drop(server);
+
+    let server = spawn_budget_server_with_env(&budget_envs(Some("4096"))).await;
+    assert_expected_pools(
+        "high budget clamps to max",
+        &server,
+        ExpectedPools {
+            shared: 410,
+            global: 1229,
+            user_init: 102,
+            auth: 205,
+        },
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_multi_db_pool_budget_overrides_and_clamps() {
+    let server = spawn_budget_server_with_env(&pool_override_envs(
+        "1024",
+        Some(""),
+        Some("333"),
+        Some(""),
+        Some("88"),
+    ))
+    .await;
+    assert_expected_pools(
+        "global/auth overrides keep other pools on budget defaults",
+        &server,
+        ExpectedPools {
+            shared: 205,
+            global: 333,
+            user_init: 51,
+            auth: 88,
+        },
+    );
+    drop(server);
+
+    let server = spawn_budget_server_with_env(&pool_override_envs(
+        "1024",
+        Some("250"),
+        Some(""),
+        Some("17"),
+        Some(""),
+    ))
+    .await;
+    assert_expected_pools(
+        "shared/user-init overrides keep other pools on budget defaults",
+        &server,
+        ExpectedPools {
+            shared: 250,
+            global: 614,
+            user_init: 17,
+            auth: 102,
+        },
+    );
+    drop(server);
+
+    let server = spawn_budget_server_with_env(&pool_override_envs(
+        "4096",
+        Some("99999"),
+        Some("99999"),
+        Some("99999"),
+        Some("99999"),
+    ))
+    .await;
+    assert_expected_pools(
+        "per-pool overrides clamp to derived caps",
+        &server,
+        ExpectedPools {
+            shared: 410,
+            global: 1229,
+            user_init: 102,
+            auth: 205,
+        },
+    );
+}

--- a/memoria/crates/memoria-api/tests/support/multi_db.rs
+++ b/memoria/crates/memoria-api/tests/support/multi_db.rs
@@ -1,5 +1,8 @@
+#![allow(dead_code)]
+
 use std::sync::Arc;
 
+use memoria_api::AppState;
 use memoria_core::interfaces::EmbeddingProvider;
 use memoria_embedding::LlmClient;
 use memoria_git::GitForDataService;
@@ -12,6 +15,7 @@ pub struct ApiTestServer {
     pub base: String,
     pub client: reqwest::Client,
     context: Option<MultiDbTestContext>,
+    state: Option<AppState>,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
     server_handle: Option<tokio::task::JoinHandle<()>>,
 }
@@ -27,6 +31,10 @@ impl ApiTestServer {
 
     pub fn router(&self) -> Arc<DbRouter> {
         self.context.as_ref().expect("context").router()
+    }
+
+    pub fn state(&self) -> &AppState {
+        self.state.as_ref().expect("state")
     }
 
     pub fn shared_pool(&self) -> MySqlPool {
@@ -46,19 +54,35 @@ impl ApiTestServer {
     }
 
     pub async fn user_store(&self, user_id: &str) -> Arc<SqlMemoryStore> {
-        self.context.as_ref().expect("context").user_store(user_id).await
+        self.context
+            .as_ref()
+            .expect("context")
+            .user_store(user_id)
+            .await
     }
 
     pub async fn user_table(&self, user_id: &str, table: &str) -> String {
-        self.context.as_ref().expect("context").user_table(user_id, table).await
+        self.context
+            .as_ref()
+            .expect("context")
+            .user_table(user_id, table)
+            .await
     }
 
     pub async fn user_db_name(&self, user_id: &str) -> String {
-        self.context.as_ref().expect("context").user_db_name(user_id).await
+        self.context
+            .as_ref()
+            .expect("context")
+            .user_db_name(user_id)
+            .await
     }
 
     pub async fn user_db_pool(&self, user_id: &str) -> MySqlPool {
-        self.context.as_ref().expect("context").user_db_pool(user_id).await
+        self.context
+            .as_ref()
+            .expect("context")
+            .user_db_pool(user_id)
+            .await
     }
 }
 
@@ -67,6 +91,7 @@ impl Drop for ApiTestServer {
         let shutdown_tx = self.shutdown_tx.take();
         let server_handle = self.server_handle.take();
         let context = self.context.take();
+        let state = self.state.take();
 
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
@@ -75,6 +100,9 @@ impl Drop for ApiTestServer {
                 }
                 if let Some(server_handle) = server_handle {
                     let _ = server_handle.await;
+                }
+                if let Some(state) = state {
+                    state.drain_flushers().await;
                 }
                 drop(context);
             });
@@ -104,6 +132,7 @@ pub async fn spawn_api_server(
             .expect("init auth pool");
     }
 
+    let test_state = state.clone();
     let app = memoria_api::build_router(state);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
@@ -130,6 +159,7 @@ pub async fn spawn_api_server(
         base,
         client,
         context: Some(context),
+        state: Some(test_state),
         shutdown_tx: Some(shutdown_tx),
         server_handle: Some(server_handle),
     }

--- a/memoria/crates/memoria-service/Cargo.toml
+++ b/memoria/crates/memoria-service/Cargo.toml
@@ -32,6 +32,7 @@ dashmap = "6"
 tokio = { workspace = true }
 async-trait = { workspace = true }
 memoria-core = { workspace = true }
+memoria-test-utils = { workspace = true }
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/memoria/crates/memoria-service/src/scheduler.rs
+++ b/memoria/crates/memoria-service/src/scheduler.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use memoria_storage::SqlMemoryStore;
+use memoria_storage::{configured_multi_db_pool_size, MultiDbPoolKind, SqlMemoryStore};
 use tokio::time::{interval, Duration};
 use tracing::{error, info, warn};
 
@@ -42,6 +42,7 @@ pub struct GovernanceScheduler {
     lock: Arc<dyn DistributedLock>,
     instance_id: String,
     lock_ttl: Duration,
+    isolated_pool_max_connections: Option<u32>,
 }
 
 #[derive(Clone)]
@@ -79,17 +80,26 @@ impl GovernanceScheduler {
 
         // Create an isolated pool for governance so long-running operations
         // (consolidation, cleanup, DDL rebuilds) do not starve request connections.
-        let default_governance_pool_size = if service.db_router.is_some() { 2 } else { 4 };
-        let governance_pool_size: u32 = std::env::var("GOVERNANCE_POOL_SIZE")
+        let governance_pool_size = match std::env::var("GOVERNANCE_POOL_SIZE")
             .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(default_governance_pool_size)
-            .min(32);
+            .and_then(|s| s.parse::<u32>().ok())
+        {
+            Some(0) => 0,
+            Some(raw) => raw.clamp(
+                1,
+                memoria_storage::multi_db_pool_max_size(MultiDbPoolKind::Governance),
+            ),
+            None if service.db_router.is_some() => {
+                configured_multi_db_pool_size("GOVERNANCE_POOL_SIZE", MultiDbPoolKind::Governance)
+            }
+            None => 4,
+        };
         #[allow(clippy::type_complexity)]
-        let (gov_store, gov_sql_store, lock): (
+        let (gov_store, gov_sql_store, lock, isolated_pool_max_connections): (
             Option<Arc<dyn GovernanceStore>>,
             Option<Arc<SqlMemoryStore>>,
             Arc<dyn DistributedLock>,
+            Option<u32>,
         ) = match &service.sql_store {
             Some(store) => {
                 if governance_pool_size == 0 {
@@ -98,6 +108,7 @@ impl GovernanceScheduler {
                         Some(store.clone() as Arc<dyn GovernanceStore>),
                         Some(store.clone()),
                         store.clone() as Arc<dyn DistributedLock>,
+                        None,
                     )
                 } else {
                     match store.spawn_background_store(governance_pool_size).await {
@@ -110,6 +121,7 @@ impl GovernanceScheduler {
                                 Some(bg.clone() as Arc<dyn GovernanceStore>),
                                 Some(bg.clone()),
                                 bg as Arc<dyn DistributedLock>,
+                                Some(governance_pool_size),
                             )
                         }
                         Err(e) => {
@@ -122,6 +134,7 @@ impl GovernanceScheduler {
                                 Some(store.clone() as Arc<dyn GovernanceStore>),
                                 Some(store.clone()),
                                 store.clone() as Arc<dyn DistributedLock>,
+                                None,
                             )
                         }
                     }
@@ -131,6 +144,7 @@ impl GovernanceScheduler {
                 None,
                 None,
                 Arc::new(crate::distributed::NoopDistributedLock) as Arc<dyn DistributedLock>,
+                None,
             ),
         };
 
@@ -138,7 +152,7 @@ impl GovernanceScheduler {
         let build = |strategy: Arc<dyn GovernanceStrategy>,
                      fallback: Arc<dyn GovernanceStrategy>,
                      plugin: Option<ObservedPlugin>| {
-            Self::new_with_components(
+            let mut scheduler = Self::new_with_components(
                 gov_store.clone(),
                 gov_sql_store.clone(),
                 strategy,
@@ -148,7 +162,9 @@ impl GovernanceScheduler {
                 lock.clone(),
                 instance_id.clone(),
                 lock_ttl,
-            )
+            );
+            scheduler.isolated_pool_max_connections = isolated_pool_max_connections;
+            scheduler
         };
 
         // Dev mode: load plugin directly from local filesystem (hot-reload friendly)
@@ -328,6 +344,7 @@ impl GovernanceScheduler {
             lock,
             instance_id,
             lock_ttl,
+            isolated_pool_max_connections: None,
         }
     }
 
@@ -337,6 +354,16 @@ impl GovernanceScheduler {
 
     pub fn fallback_strategy_key(&self) -> &str {
         self.fallback_strategy.strategy_key()
+    }
+
+    pub fn isolated_pool_max_connections(&self) -> Option<u32> {
+        self.isolated_pool_max_connections
+    }
+
+    pub fn sql_store_configured_max_connections(&self) -> Option<u32> {
+        self.sql_store
+            .as_ref()
+            .and_then(|store| store.configured_max_connections())
     }
 
     /// Spawn background tasks. Returns immediately; tasks run in background.

--- a/memoria/crates/memoria-service/tests/governance_pool_budget_e2e.rs
+++ b/memoria/crates/memoria-service/tests/governance_pool_budget_e2e.rs
@@ -1,0 +1,149 @@
+use std::{
+    future::Future,
+    sync::{Mutex, OnceLock},
+};
+
+use memoria_service::{Config, GovernanceScheduler};
+
+async fn with_env_async<F, Fut, T>(vars: &[(&str, Option<&str>)], f: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = T>,
+{
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    let _lock = ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
+    struct EnvGuard(Vec<(String, Option<std::ffi::OsString>)>);
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, old) in &self.0 {
+                match old {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+            }
+        }
+    }
+
+    let _restore = EnvGuard(
+        vars.iter()
+            .map(|(key, value)| {
+                let old = std::env::var_os(key);
+                match value {
+                    Some(value) => unsafe { std::env::set_var(key, value) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+                (key.to_string(), old)
+            })
+            .collect(),
+    );
+
+    f().await
+}
+
+fn base_governance_envs<'a>(
+    budget: Option<&'a str>,
+    governance_pool: Option<&'a str>,
+) -> [(&'a str, Option<&'a str>); 10] {
+    [
+        ("MEMORIA_MULTI_DB_POOL_BUDGET", budget),
+        ("GOVERNANCE_POOL_SIZE", governance_pool),
+        ("MEMORIA_GOVERNANCE_ENABLED", Some("true")),
+        ("MEMORIA_SHARED_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_GIT_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_MERGED_SHARED_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_GLOBAL_USER_POOL_MAX", Some("")),
+        ("MEMORIA_USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS", Some("")),
+        ("MEMORIA_AUTH_POOL_MAX_CONNECTIONS", Some("")),
+    ]
+}
+
+fn db_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "mysql://root:111@localhost:6001/memoria".to_string())
+}
+
+async fn assert_governance_pool_case(
+    case_name: &str,
+    vars: &[(&str, Option<&str>)],
+    expected: Option<u32>,
+) {
+    with_env_async(vars, || async {
+        let ctx = memoria_test_utils::MultiDbTestContext::new(
+            &db_url(),
+            "governance_pool_budget_e2e",
+            1024,
+            None,
+            None,
+        )
+        .await;
+        let scheduler = GovernanceScheduler::from_config(ctx.service(), &Config::from_env())
+            .await
+            .expect("build governance scheduler");
+
+        assert_eq!(
+            scheduler.isolated_pool_max_connections(),
+            expected,
+            "{case_name}: isolated governance pool size"
+        );
+        if let Some(expected) = expected {
+            assert_eq!(
+                scheduler.sql_store_configured_max_connections(),
+                Some(expected),
+                "{case_name}: isolated governance store configured max"
+            );
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_governance_pool_budget_matrix() {
+    assert_governance_pool_case(
+        "default budget",
+        &base_governance_envs(Some(""), Some("")),
+        Some(26),
+    )
+    .await;
+
+    assert_governance_pool_case(
+        "low budget floor",
+        &base_governance_envs(Some("0"), Some("")),
+        Some(10),
+    )
+    .await;
+
+    assert_governance_pool_case(
+        "configured budget",
+        &base_governance_envs(Some("1024"), Some("")),
+        Some(51),
+    )
+    .await;
+
+    assert_governance_pool_case(
+        "explicit override",
+        &base_governance_envs(Some("1024"), Some("77")),
+        Some(77),
+    )
+    .await;
+
+    assert_governance_pool_case(
+        "override clamps to cap",
+        &base_governance_envs(Some("4096"), Some("99999")),
+        Some(102),
+    )
+    .await;
+
+    assert_governance_pool_case(
+        "zero disables isolated pool",
+        &base_governance_envs(Some("1024"), Some("0")),
+        None,
+    )
+    .await;
+}

--- a/memoria/crates/memoria-storage/src/lib.rs
+++ b/memoria/crates/memoria-storage/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod graph;
 pub mod migration;
+pub mod pool_config;
 pub mod router;
 pub mod store;
 
@@ -13,6 +14,11 @@ pub use migration::{
     plan_legacy_single_db_to_multi_db, LegacyToMultiDbMigrationOptions,
     LegacyToMultiDbMigrationReport, PendingLegacyMultiDbMigration, RuntimeTopology,
     TableMigrationReport, UserMigrationReport,
+};
+pub use pool_config::{
+    configured_multi_db_pool_budget, configured_multi_db_pool_size, multi_db_pool_default_size,
+    multi_db_pool_max_size, split_pool_budget, MultiDbPoolKind, MULTI_DB_POOL_BUDGET_DEFAULT,
+    MULTI_DB_POOL_BUDGET_ENV, MULTI_DB_POOL_BUDGET_MAX,
 };
 pub use router::{DbRouter, UserDatabaseRecord};
 pub use store::{

--- a/memoria/crates/memoria-storage/src/pool_config.rs
+++ b/memoria/crates/memoria-storage/src/pool_config.rs
@@ -1,0 +1,207 @@
+pub const MULTI_DB_POOL_BUDGET_ENV: &str = "MEMORIA_MULTI_DB_POOL_BUDGET";
+pub const MULTI_DB_POOL_BUDGET_DEFAULT: u32 = 512;
+pub const MULTI_DB_POOL_BUDGET_MAX: u32 = 2048;
+
+const RATIO_DENOMINATOR: u64 = 100;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MultiDbPoolKind {
+    GlobalUser,
+    SharedMerged,
+    Auth,
+    UserInit,
+    Governance,
+}
+
+impl MultiDbPoolKind {
+    fn ratio_percent(self) -> u32 {
+        match self {
+            Self::GlobalUser => 60,
+            Self::SharedMerged => 20,
+            Self::Auth => 10,
+            Self::UserInit => 5,
+            Self::Governance => 5,
+        }
+    }
+
+    fn floor(self) -> u32 {
+        match self {
+            Self::GlobalUser => 128,
+            Self::SharedMerged => 64,
+            Self::Auth => 25,
+            Self::UserInit => 10,
+            Self::Governance => 10,
+        }
+    }
+}
+
+pub fn configured_multi_db_pool_budget() -> u32 {
+    std::env::var(MULTI_DB_POOL_BUDGET_ENV)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(MULTI_DB_POOL_BUDGET_DEFAULT)
+        .clamp(1, MULTI_DB_POOL_BUDGET_MAX)
+}
+
+pub fn multi_db_pool_default_size(kind: MultiDbPoolKind) -> u32 {
+    scaled_size(configured_multi_db_pool_budget(), kind.ratio_percent()).max(kind.floor())
+}
+
+pub fn multi_db_pool_max_size(kind: MultiDbPoolKind) -> u32 {
+    scaled_size(MULTI_DB_POOL_BUDGET_MAX, kind.ratio_percent())
+}
+
+pub fn configured_multi_db_pool_size(env_name: &str, kind: MultiDbPoolKind) -> u32 {
+    match std::env::var(env_name)
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+    {
+        Some(raw) => raw.clamp(1, multi_db_pool_max_size(kind)),
+        None => multi_db_pool_default_size(kind),
+    }
+}
+
+pub fn split_pool_budget(total: u32, weights: &[u32]) -> Vec<u32> {
+    let weight_sum: u64 = weights.iter().map(|&w| u64::from(w)).sum();
+    if weights.is_empty() || weight_sum == 0 {
+        return vec![0; weights.len()];
+    }
+
+    let mut parts = Vec::with_capacity(weights.len());
+    let mut remainders = Vec::with_capacity(weights.len());
+    let mut used = 0u32;
+
+    for (idx, weight) in weights.iter().copied().enumerate() {
+        let numerator = u64::from(total) * u64::from(weight);
+        let base = (numerator / weight_sum) as u32;
+        parts.push(base);
+        used = used.saturating_add(base);
+        remainders.push((idx, numerator % weight_sum));
+    }
+
+    let mut remaining = total.saturating_sub(used);
+    remainders.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    for (idx, _) in remainders {
+        if remaining == 0 {
+            break;
+        }
+        parts[idx] = parts[idx].saturating_add(1);
+        remaining -= 1;
+    }
+
+    parts
+}
+
+fn scaled_size(total: u32, ratio_percent: u32) -> u32 {
+    ((u64::from(total) * u64::from(ratio_percent) + (RATIO_DENOMINATOR / 2)) / RATIO_DENOMINATOR)
+        as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        configured_multi_db_pool_budget, configured_multi_db_pool_size, multi_db_pool_default_size,
+        multi_db_pool_max_size, split_pool_budget, MultiDbPoolKind, MULTI_DB_POOL_BUDGET_ENV,
+    };
+    use std::sync::{Mutex, OnceLock};
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn with_env<F: FnOnce()>(vars: &[(&str, Option<&str>)], f: F) {
+        let _lock = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        struct EnvGuard(Vec<(String, Option<std::ffi::OsString>)>);
+
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                for (key, old) in &self.0 {
+                    match old {
+                        Some(value) => unsafe { std::env::set_var(key, value) },
+                        None => unsafe { std::env::remove_var(key) },
+                    }
+                }
+            }
+        }
+
+        let _restore = EnvGuard(
+            vars.iter()
+                .map(|(key, value)| {
+                    let old = std::env::var_os(key);
+                    match value {
+                        Some(value) => unsafe { std::env::set_var(key, value) },
+                        None => unsafe { std::env::remove_var(key) },
+                    }
+                    (key.to_string(), old)
+                })
+                .collect(),
+        );
+
+        f();
+    }
+
+    #[test]
+    fn defaults_follow_budget_split() {
+        with_env(&[(MULTI_DB_POOL_BUDGET_ENV, None)], || {
+            assert_eq!(configured_multi_db_pool_budget(), 512);
+            assert_eq!(multi_db_pool_default_size(MultiDbPoolKind::GlobalUser), 307);
+            assert_eq!(
+                multi_db_pool_default_size(MultiDbPoolKind::SharedMerged),
+                102
+            );
+            assert_eq!(multi_db_pool_default_size(MultiDbPoolKind::Auth), 51);
+            assert_eq!(multi_db_pool_default_size(MultiDbPoolKind::UserInit), 26);
+            assert_eq!(multi_db_pool_default_size(MultiDbPoolKind::Governance), 26);
+        });
+    }
+
+    #[test]
+    fn caps_follow_budget_ceiling() {
+        with_env(&[(MULTI_DB_POOL_BUDGET_ENV, Some("4096"))], || {
+            assert_eq!(configured_multi_db_pool_budget(), 2048);
+            assert_eq!(multi_db_pool_max_size(MultiDbPoolKind::GlobalUser), 1229);
+            assert_eq!(multi_db_pool_max_size(MultiDbPoolKind::SharedMerged), 410);
+            assert_eq!(multi_db_pool_max_size(MultiDbPoolKind::Auth), 205);
+            assert_eq!(multi_db_pool_max_size(MultiDbPoolKind::UserInit), 102);
+            assert_eq!(multi_db_pool_max_size(MultiDbPoolKind::Governance), 102);
+        });
+    }
+
+    #[test]
+    fn explicit_pool_envs_override_budget_without_flooring() {
+        with_env(
+            &[
+                (MULTI_DB_POOL_BUDGET_ENV, Some("512")),
+                ("MEMORIA_GLOBAL_USER_POOL_MAX", Some("4")),
+                ("MEMORIA_AUTH_POOL_MAX_CONNECTIONS", Some("999")),
+            ],
+            || {
+                assert_eq!(
+                    configured_multi_db_pool_size(
+                        "MEMORIA_GLOBAL_USER_POOL_MAX",
+                        MultiDbPoolKind::GlobalUser,
+                    ),
+                    4
+                );
+                assert_eq!(
+                    configured_multi_db_pool_size(
+                        "MEMORIA_AUTH_POOL_MAX_CONNECTIONS",
+                        MultiDbPoolKind::Auth,
+                    ),
+                    205
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn split_pool_budget_preserves_total() {
+        assert_eq!(
+            split_pool_budget(512, &[60, 20, 10, 5, 5]),
+            vec![307, 102, 51, 26, 26]
+        );
+        assert_eq!(split_pool_budget(64, &[40, 40, 20]), vec![26, 25, 13]);
+    }
+}

--- a/memoria/crates/memoria-storage/src/router.rs
+++ b/memoria/crates/memoria-storage/src/router.rs
@@ -1,3 +1,7 @@
+use crate::pool_config::{
+    configured_multi_db_pool_budget, configured_multi_db_pool_size, multi_db_pool_default_size,
+    multi_db_pool_max_size, split_pool_budget, MultiDbPoolKind, MULTI_DB_POOL_BUDGET_MAX,
+};
 use crate::store::spawn_pool_monitor;
 use crate::{PoolHealthSnapshot, SqlMemoryStore};
 use chrono::Utc;
@@ -25,13 +29,8 @@ const USER_DB_CACHE_MAX_CAPACITY: u64 = 10_000;
 const USER_STORE_CACHE_MAX_CAPACITY: u64 = 10_000;
 const USER_SCHEMA_CACHE_MAX_CAPACITY: u64 = 10_000;
 const USER_STORE_CACHE_IDLE_SECS: u64 = 600;
-const SHARED_POOL_MAX_CONNECTIONS: u32 = 8;
-const SHARED_MAIN_POOL_MAX_CONNECTIONS: u32 = 8;
-const GIT_POOL_MAX_CONNECTIONS: u32 = 4;
-const GLOBAL_USER_POOL_MAX_CONNECTIONS: u32 = 80;
-const USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS: u32 = 12;
-const POOL_MAX_CONNECTIONS_UPPER: u32 = 256;
 const MERGED_SHARED_POOL_MAX_CONNECTIONS_ENV: &str = "MEMORIA_MERGED_SHARED_POOL_MAX_CONNECTIONS";
+const LEGACY_SHARED_COMPONENT_WEIGHTS: [u32; 3] = [40, 40, 20];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct SharedPoolPlan {
@@ -60,6 +59,7 @@ pub struct DbRouter {
     global_user_pool: MySqlPool,
     global_user_pool_max_connections: u32,
     user_init_pool: MySqlPool,
+    user_init_pool_max_connections: u32,
     shared_db_url: String,
     shared_db_name: String,
     embedding_dim: usize,
@@ -77,6 +77,17 @@ impl DbRouter {
         instance_id: String,
     ) -> Result<Self, MemoriaError> {
         create_database_if_missing_from_url(shared_db_url).await?;
+        let pool_budget = configured_multi_db_pool_budget();
+        tracing::info!(
+            pool_budget,
+            pool_budget_max = MULTI_DB_POOL_BUDGET_MAX,
+            shared_merged_default = multi_db_pool_default_size(MultiDbPoolKind::SharedMerged),
+            global_user_default = multi_db_pool_default_size(MultiDbPoolKind::GlobalUser),
+            auth_default = multi_db_pool_default_size(MultiDbPoolKind::Auth),
+            user_init_default = multi_db_pool_default_size(MultiDbPoolKind::UserInit),
+            governance_default = multi_db_pool_default_size(MultiDbPoolKind::Governance),
+            "Multi-db pool budget resolved"
+        );
         let shared_plan = configured_shared_pool_plan();
         let pool = MySqlPoolOptions::new()
             .max_connections(shared_plan.max_connections)
@@ -98,15 +109,14 @@ impl DbRouter {
 
         // Global pool for all per-user DB queries.
         // statement_cache_capacity=0 prevents prepared-statement cross-DB pollution.
-        let global_max = configured_pool_max_connections(
+        let global_max = configured_multi_db_pool_size(
             "MEMORIA_GLOBAL_USER_POOL_MAX",
-            GLOBAL_USER_POOL_MAX_CONNECTIONS,
-            POOL_MAX_CONNECTIONS_UPPER,
+            MultiDbPoolKind::GlobalUser,
         );
         let global_url = append_url_param(shared_db_url, "statement_cache_capacity=0");
         let global_user_pool = MySqlPoolOptions::new()
             .max_connections(global_max)
-            .min_connections(2)
+            .min_connections(global_max.min(2))
             .max_lifetime(std::time::Duration::from_secs(3600))
             .idle_timeout(std::time::Duration::from_secs(300))
             .acquire_timeout(std::time::Duration::from_secs(15))
@@ -125,10 +135,9 @@ impl DbRouter {
             )))),
             "global_user_pool",
         );
-        let user_init_pool_max = configured_pool_max_connections(
+        let user_init_pool_max = configured_multi_db_pool_size(
             "MEMORIA_USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS",
-            USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS,
-            64,
+            MultiDbPoolKind::UserInit,
         );
         let user_init_pool = MySqlPoolOptions::new()
             .max_connections(user_init_pool_max)
@@ -157,6 +166,7 @@ impl DbRouter {
             global_user_pool,
             global_user_pool_max_connections: global_max,
             user_init_pool,
+            user_init_pool_max_connections: user_init_pool_max,
             shared_db_url: shared_db_url.to_string(),
             shared_db_name,
             embedding_dim,
@@ -192,6 +202,10 @@ impl DbRouter {
 
     pub fn global_user_pool_max_connections(&self) -> u32 {
         self.global_user_pool_max_connections
+    }
+
+    pub fn user_init_pool_max_connections(&self) -> u32 {
+        self.user_init_pool_max_connections
     }
 
     pub fn shared_db_name(&self) -> &str {
@@ -617,56 +631,62 @@ fn append_url_param(url: &str, param: &str) -> String {
 }
 
 fn configured_shared_pool_plan() -> SharedPoolPlan {
-    let routing_component_max_connections = configured_pool_max_connections(
-        "MEMORIA_SHARED_POOL_MAX_CONNECTIONS",
-        SHARED_POOL_MAX_CONNECTIONS,
-        POOL_MAX_CONNECTIONS_UPPER,
-    );
-    let shared_main_component_max_connections = configured_pool_max_connections(
-        "MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS",
-        SHARED_MAIN_POOL_MAX_CONNECTIONS,
-        POOL_MAX_CONNECTIONS_UPPER,
-    );
-    let git_component_max_connections = configured_pool_max_connections(
-        "MEMORIA_GIT_POOL_MAX_CONNECTIONS",
-        GIT_POOL_MAX_CONNECTIONS,
-        64,
-    );
+    let max_pool_size = multi_db_pool_max_size(MultiDbPoolKind::SharedMerged);
     let explicit_override = std::env::var(MERGED_SHARED_POOL_MAX_CONNECTIONS_ENV)
         .ok()
         .and_then(|s| s.parse::<u32>().ok())
-        .map(|max_connections| max_connections.clamp(1, POOL_MAX_CONNECTIONS_UPPER));
+        .map(|max_connections| max_connections.clamp(1, max_pool_size));
+    let mut default_components = split_pool_budget(
+        explicit_override
+            .unwrap_or_else(|| multi_db_pool_default_size(MultiDbPoolKind::SharedMerged)),
+        &LEGACY_SHARED_COMPONENT_WEIGHTS,
+    );
+    let routing_component_max_connections = std::env::var("MEMORIA_SHARED_POOL_MAX_CONNECTIONS")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .map(|raw| raw.clamp(1, max_pool_size))
+        .unwrap_or(default_components.remove(0));
+    let shared_main_component_max_connections =
+        std::env::var("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .map(|raw| raw.clamp(1, max_pool_size))
+            .unwrap_or(default_components.remove(0));
+    let git_component_max_connections = std::env::var("MEMORIA_GIT_POOL_MAX_CONNECTIONS")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .map(|raw| raw.clamp(1, max_pool_size))
+        .unwrap_or(default_components.remove(0));
+    let legacy_component_override = std::env::var_os("MEMORIA_SHARED_POOL_MAX_CONNECTIONS")
+        .is_some()
+        || std::env::var_os("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS").is_some()
+        || std::env::var_os("MEMORIA_GIT_POOL_MAX_CONNECTIONS").is_some();
     let max_connections = explicit_override.unwrap_or_else(|| {
-        routing_component_max_connections
-            .saturating_add(shared_main_component_max_connections)
-            .saturating_add(git_component_max_connections)
-            .clamp(1, POOL_MAX_CONNECTIONS_UPPER)
+        if legacy_component_override {
+            routing_component_max_connections
+                .saturating_add(shared_main_component_max_connections)
+                .saturating_add(git_component_max_connections)
+                .clamp(1, max_pool_size)
+        } else {
+            multi_db_pool_default_size(MultiDbPoolKind::SharedMerged)
+        }
     });
     SharedPoolPlan {
         max_connections,
         routing_component_max_connections,
         shared_main_component_max_connections,
         git_component_max_connections,
-        explicit_override: explicit_override.is_some(),
+        explicit_override: explicit_override.is_some() || legacy_component_override,
     }
-}
-
-fn configured_pool_max_connections(env_name: &str, default: u32, upper: u32) -> u32 {
-    std::env::var(env_name)
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(default)
-        .clamp(1, upper)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        configured_pool_max_connections, configured_shared_pool_plan, SharedPoolPlan,
-        GIT_POOL_MAX_CONNECTIONS, GLOBAL_USER_POOL_MAX_CONNECTIONS,
-        MERGED_SHARED_POOL_MAX_CONNECTIONS_ENV, POOL_MAX_CONNECTIONS_UPPER,
-        SHARED_MAIN_POOL_MAX_CONNECTIONS, SHARED_POOL_MAX_CONNECTIONS,
-        USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS,
+        configured_shared_pool_plan, SharedPoolPlan, MERGED_SHARED_POOL_MAX_CONNECTIONS_ENV,
+    };
+    use crate::pool_config::{
+        configured_multi_db_pool_size, multi_db_pool_default_size, MultiDbPoolKind,
     };
     use std::sync::{Mutex, OnceLock};
 
@@ -711,6 +731,7 @@ mod tests {
     fn shared_pool_plan_defaults_merge_legacy_components() {
         with_env(
             &[
+                ("MEMORIA_MULTI_DB_POOL_BUDGET", None),
                 ("MEMORIA_SHARED_POOL_MAX_CONNECTIONS", None),
                 ("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS", None),
                 ("MEMORIA_GIT_POOL_MAX_CONNECTIONS", None),
@@ -720,12 +741,10 @@ mod tests {
                 assert_eq!(
                     configured_shared_pool_plan(),
                     SharedPoolPlan {
-                        max_connections: SHARED_POOL_MAX_CONNECTIONS
-                            + SHARED_MAIN_POOL_MAX_CONNECTIONS
-                            + GIT_POOL_MAX_CONNECTIONS,
-                        routing_component_max_connections: SHARED_POOL_MAX_CONNECTIONS,
-                        shared_main_component_max_connections: SHARED_MAIN_POOL_MAX_CONNECTIONS,
-                        git_component_max_connections: GIT_POOL_MAX_CONNECTIONS,
+                        max_connections: 102,
+                        routing_component_max_connections: 41,
+                        shared_main_component_max_connections: 41,
+                        git_component_max_connections: 20,
                         explicit_override: false,
                     }
                 );
@@ -737,6 +756,7 @@ mod tests {
     fn shared_pool_plan_honors_explicit_merged_override() {
         with_env(
             &[
+                ("MEMORIA_MULTI_DB_POOL_BUDGET", Some("512")),
                 ("MEMORIA_SHARED_POOL_MAX_CONNECTIONS", Some("20")),
                 ("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS", Some("10")),
                 ("MEMORIA_GIT_POOL_MAX_CONNECTIONS", Some("6")),
@@ -761,6 +781,7 @@ mod tests {
     fn shared_pool_plan_clamps_explicit_merged_override() {
         with_env(
             &[
+                ("MEMORIA_MULTI_DB_POOL_BUDGET", Some("512")),
                 ("MEMORIA_SHARED_POOL_MAX_CONNECTIONS", Some("20")),
                 ("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS", Some("10")),
                 ("MEMORIA_GIT_POOL_MAX_CONNECTIONS", Some("6")),
@@ -782,28 +803,52 @@ mod tests {
     }
 
     #[test]
+    fn shared_pool_plan_splits_explicit_merged_override_without_legacy_components() {
+        with_env(
+            &[
+                ("MEMORIA_MULTI_DB_POOL_BUDGET", Some("512")),
+                ("MEMORIA_SHARED_POOL_MAX_CONNECTIONS", None),
+                ("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS", None),
+                ("MEMORIA_GIT_POOL_MAX_CONNECTIONS", None),
+                (MERGED_SHARED_POOL_MAX_CONNECTIONS_ENV, Some("3")),
+            ],
+            || {
+                assert_eq!(
+                    configured_shared_pool_plan(),
+                    SharedPoolPlan {
+                        max_connections: 3,
+                        routing_component_max_connections: 1,
+                        shared_main_component_max_connections: 1,
+                        git_component_max_connections: 1,
+                        explicit_override: true,
+                    }
+                );
+            },
+        );
+    }
+
+    #[test]
     fn user_pool_defaults_match_budget_split() {
         with_env(
             &[
+                ("MEMORIA_MULTI_DB_POOL_BUDGET", None),
                 ("MEMORIA_GLOBAL_USER_POOL_MAX", None),
                 ("MEMORIA_USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS", None),
             ],
             || {
                 assert_eq!(
-                    configured_pool_max_connections(
+                    configured_multi_db_pool_size(
                         "MEMORIA_GLOBAL_USER_POOL_MAX",
-                        GLOBAL_USER_POOL_MAX_CONNECTIONS,
-                        POOL_MAX_CONNECTIONS_UPPER,
+                        MultiDbPoolKind::GlobalUser,
                     ),
-                    GLOBAL_USER_POOL_MAX_CONNECTIONS
+                    multi_db_pool_default_size(MultiDbPoolKind::GlobalUser)
                 );
                 assert_eq!(
-                    configured_pool_max_connections(
+                    configured_multi_db_pool_size(
                         "MEMORIA_USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS",
-                        USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS,
-                        64,
+                        MultiDbPoolKind::UserInit,
                     ),
-                    USER_SCHEMA_INIT_POOL_MAX_CONNECTIONS
+                    multi_db_pool_default_size(MultiDbPoolKind::UserInit)
                 );
             },
         );

--- a/memoria/crates/memoria-storage/src/router.rs
+++ b/memoria/crates/memoria-storage/src/router.rs
@@ -641,26 +641,27 @@ fn configured_shared_pool_plan() -> SharedPoolPlan {
             .unwrap_or_else(|| multi_db_pool_default_size(MultiDbPoolKind::SharedMerged)),
         &LEGACY_SHARED_COMPONENT_WEIGHTS,
     );
-    let routing_component_max_connections = std::env::var("MEMORIA_SHARED_POOL_MAX_CONNECTIONS")
+    let routing_component_override = std::env::var("MEMORIA_SHARED_POOL_MAX_CONNECTIONS")
         .ok()
         .and_then(|s| s.parse::<u32>().ok())
-        .map(|raw| raw.clamp(1, max_pool_size))
-        .unwrap_or(default_components.remove(0));
+        .map(|raw| raw.clamp(1, max_pool_size));
+    let routing_component_max_connections =
+        routing_component_override.unwrap_or(default_components.remove(0));
+    let shared_main_component_override = std::env::var("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .map(|raw| raw.clamp(1, max_pool_size));
     let shared_main_component_max_connections =
-        std::env::var("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS")
-            .ok()
-            .and_then(|s| s.parse::<u32>().ok())
-            .map(|raw| raw.clamp(1, max_pool_size))
-            .unwrap_or(default_components.remove(0));
-    let git_component_max_connections = std::env::var("MEMORIA_GIT_POOL_MAX_CONNECTIONS")
+        shared_main_component_override.unwrap_or(default_components.remove(0));
+    let git_component_override = std::env::var("MEMORIA_GIT_POOL_MAX_CONNECTIONS")
         .ok()
         .and_then(|s| s.parse::<u32>().ok())
-        .map(|raw| raw.clamp(1, max_pool_size))
-        .unwrap_or(default_components.remove(0));
-    let legacy_component_override = std::env::var_os("MEMORIA_SHARED_POOL_MAX_CONNECTIONS")
-        .is_some()
-        || std::env::var_os("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS").is_some()
-        || std::env::var_os("MEMORIA_GIT_POOL_MAX_CONNECTIONS").is_some();
+        .map(|raw| raw.clamp(1, max_pool_size));
+    let git_component_max_connections =
+        git_component_override.unwrap_or(default_components.remove(0));
+    let legacy_component_override = routing_component_override.is_some()
+        || shared_main_component_override.is_some()
+        || git_component_override.is_some();
     let max_connections = explicit_override.unwrap_or_else(|| {
         if legacy_component_override {
             routing_component_max_connections
@@ -796,6 +797,31 @@ mod tests {
                         shared_main_component_max_connections: 10,
                         git_component_max_connections: 6,
                         explicit_override: true,
+                    }
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn shared_pool_plan_ignores_blank_legacy_component_envs() {
+        with_env(
+            &[
+                ("MEMORIA_MULTI_DB_POOL_BUDGET", Some("512")),
+                ("MEMORIA_SHARED_POOL_MAX_CONNECTIONS", Some("")),
+                ("MEMORIA_SHARED_MAIN_POOL_MAX_CONNECTIONS", Some("")),
+                ("MEMORIA_GIT_POOL_MAX_CONNECTIONS", Some("")),
+                (MERGED_SHARED_POOL_MAX_CONNECTIONS_ENV, None),
+            ],
+            || {
+                assert_eq!(
+                    configured_shared_pool_plan(),
+                    SharedPoolPlan {
+                        max_connections: 102,
+                        routing_component_max_connections: 41,
+                        shared_main_component_max_connections: 41,
+                        git_component_max_connections: 20,
+                        explicit_override: false,
                     }
                 );
             },

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -1043,6 +1043,11 @@ impl SqlMemoryStore {
                 );
                 let mut s = Self::new(pool, self.embedding_dim, self.instance_id.clone());
                 s.database_url = self.database_url.clone();
+                s.configured_max_connections = Some(max_connections);
+                {
+                    let mut health = s.pool_health.lock().unwrap();
+                    health.configured_max_connections = Some(max_connections);
+                }
                 // Share the same edit_log_tx Arc so clear_edit_log_tx drains all stores at once
                 s.edit_log_tx = self.edit_log_tx.clone();
                 s.db_router = self.db_router.clone();


### PR DESCRIPTION
## Summary
- add budget-based multi-db pool sizing with startup logging for resolved X/default pool sizes
- keep explicit per-pool env overrides compatible while deriving defaults and caps from the shared budget
- add API and governance e2e coverage for defaults, overrides, clamps, floors, and disabled governance pool

## Testing
- cargo test -p memoria-api --test pool_budget_e2e -- --test-threads=1
- cargo test -p memoria-service --test governance_pool_budget_e2e -- --test-threads=1
- cargo test -p memoria-storage --lib
- cargo test -p memoria-api test_connection_pool_config --lib
- cargo test -p memoria-service --lib