### PR TITLE
fix(cli): normalize MCP tool name; MatrixOne-safe srv_user_stats upsert

### DIFF
--- a/memoria/crates/memoria-cli/src/main.rs
+++ b/memoria/crates/memoria-cli/src/main.rs
@@ -93,9 +93,10 @@ enum Commands {
     /// Start MCP server (embedded or remote mode)
     #[cfg(feature = "server-runtime")]
     Mcp {
-        /// AI tool that launched this MCP server (sent as X-Memoria-Tool header)
+        /// AI tool that launched this MCP server (sent as X-Memoria-Tool header).
+        /// Accepts any string (e.g. kiro, cursor, opencode, my-agent).
         #[arg(long, env = "MEMORIA_TOOL")]
-        tool: Option<ToolName>,
+        tool: Option<String>,
         /// Remote Memoria API URL (remote mode)
         #[arg(long, env = "MEMORIA_API_URL")]
         api_url: Option<String>,
@@ -638,6 +639,24 @@ fn redact_url(url: &str) -> String {
         "***"
     };
     format!("{scheme}://{redacted_userinfo}@{host}")
+}
+
+fn normalize_tool_name(tool: Option<String>) -> Option<String> {
+    tool.and_then(|raw| {
+        // Normalize to the same format the dashboard uses:
+        // trim, lowercase, collapse whitespace runs into a single hyphen.
+        // "My Agent" → "my-agent", "cursor" → "cursor".
+        let lower = raw.trim().to_ascii_lowercase();
+        let normalized = lower
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join("-");
+        if normalized.is_empty() {
+            None
+        } else {
+            Some(normalized)
+        }
+    })
 }
 
 // ── MCP server ────────────────────────────────────────────────────────────────
@@ -3381,11 +3400,12 @@ fn main() -> Result<()> {
             transport,
             mcp_port,
         } => {
+            let tool = normalize_tool_name(tool);
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .build()?
                 .block_on(cmd_mcp(
-                    tool.map(|t| t.to_string()),
+                    tool,
                     api_url,
                     token,
                     db_url,
@@ -3485,8 +3505,8 @@ mod tests {
         LEGACY_MIGRATION_MAX_CONCURRENCY_ENV,
     };
     use super::{
-        enable_runtime_multi_db, redact_url, run_with_edit_log_drain, validate_embedding_config,
-        Cli, Commands, MigrationCommands,
+        enable_runtime_multi_db, normalize_tool_name, redact_url, run_with_edit_log_drain,
+        validate_embedding_config, Cli, Commands, MigrationCommands,
     };
     use async_trait::async_trait;
     use clap::Parser;
@@ -3771,6 +3791,26 @@ mod tests {
             redact_url("mysql://localhost:6001/memoria"),
             "mysql://localhost:6001/memoria"
         );
+    }
+
+    #[test]
+    fn normalize_tool_name_trims_lowercases_and_filters_empty() {
+        assert_eq!(
+            normalize_tool_name(Some("  CuRsOr-Agent  ".to_string())),
+            Some("cursor-agent".to_string())
+        );
+        // spaces (and multiple spaces) are collapsed into hyphens,
+        // matching the dashboard's sanitizeAgentName behaviour
+        assert_eq!(
+            normalize_tool_name(Some("My  Agent".to_string())),
+            Some("my-agent".to_string())
+        );
+        assert_eq!(
+            normalize_tool_name(Some("  Claude Code  ".to_string())),
+            Some("claude-code".to_string())
+        );
+        assert_eq!(normalize_tool_name(Some("   ".to_string())), None);
+        assert_eq!(normalize_tool_name(None), None);
     }
 
     #[test]

--- a/memoria/crates/memoria-service/src/stats_reporter.rs
+++ b/memoria/crates/memoria-service/src/stats_reporter.rs
@@ -226,8 +226,10 @@ async fn flush_batch(events: &[StatsEvent], pool: &MySqlPool) {
         qb.push(
             " ON DUPLICATE KEY UPDATE \
                total_memories    = total_memories    + VALUES(total_memories), \
-               active_memories   = GREATEST(0, active_memories   + VALUES(active_memories)), \
-               inactive_memories = GREATEST(0, inactive_memories + VALUES(inactive_memories)), \
+               active_memories   = CASE WHEN active_memories   + VALUES(active_memories) < 0 THEN 0 \
+                                        ELSE active_memories   + VALUES(active_memories) END, \
+               inactive_memories = CASE WHEN inactive_memories + VALUES(inactive_memories) < 0 THEN 0 \
+                                        ELSE inactive_memories + VALUES(inactive_memories) END, \
                total_entities    = total_entities    + VALUES(total_entities), \
                total_edits       = total_edits       + VALUES(total_edits), \
                updated_at        = VALUES(updated_at)",


### PR DESCRIPTION
…ats upsert

## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes # https://github.com/matrixorigin/memoria-website/issues/103

## What this PR does / why we need it

**Summary**

This PR improves how the CLI passes the Memoria tool identifier to remote MCP mode and fixes stats writes against MatrixOne-compatible backends.

**Changes**

- **`memoria-cli`:** The `memoria mcp --tool` / `MEMORIA_TOOL` value is now an arbitrary string (not limited to the `ToolName` enum). Values are normalized before use: trim, ASCII lowercase, and collapse whitespace runs into a single hyphen (e.g. `My  Agent` → `my-agent`), so headers and downstream usage stay consistent and avoid fragmented labels.
- **`memoria-service`:** In `stats_reporter`, `srv_user_stats` upserts no longer use `GREATEST(0, …)`, which MatrixOne rejects. The same clamping behavior is preserved using `CASE WHEN … < 0 THEN 0 ELSE … END`.
- **Tests:** Unit tests cover `normalize_tool_name`.

**Motivation**

- Support custom agent/tool names without failing CLI parsing.
- Align tool strings with dashboard-style sanitization where applicable.
- Restore successful writes to `srv_user_stats` when the shared DB is MatrixOne (error `20105`: `greatest` not supported).

**Testing**

- `cargo test -p memoria-cli`
- `cargo test -p memoria-service`