### PR TITLE
docs: add MatrixOne research paper reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@
   [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](LICENSE)
   [![MCP](https://img.shields.io/badge/Protocol-MCP-7C3AED?style=flat-square)](https://modelcontextprotocol.io)
   [![MatrixOne](https://img.shields.io/badge/Powered%20by-MatrixOne-00ADD8?style=flat-square&logo=database)](https://github.com/matrixorigin/matrixone)
+  [![Paper](https://img.shields.io/badge/arXiv-2604.03927-b31b1b?style=flat-square)](https://arxiv.org/abs/2604.03927)
 
-  [Quick Start](#-quick-start) · [Why Memoria](#-why-memoria) · [See It in Action](#-see-git-for-data-in-action) · [API Reference](#-api-reference) · [Architecture](#-architecture) · [Development](#-development)
+  [Quick Start](#-quick-start) · [Why Memoria](#-why-memoria) · [Research](#-research-foundation) · [See It in Action](#-see-git-for-data-in-action) · [API Reference](#-api-reference) · [Architecture](#-architecture) · [Development](#-development)
 
 </div>
 
@@ -170,6 +171,14 @@ Or download binaries directly from [GitHub Releases](https://github.com/matrixor
 | **Audit trail** | Full snapshot + provenance on every mutation | Limited logging |
 | **Semantic retrieval** | Vector + full-text hybrid search | Vector only |
 | **Self-governance** | Automatic contradiction detection & quarantine | Manual cleanup |
+
+---
+
+## 🔬 Research Foundation
+
+Memoria's Git-for-Data layer is backed by [**Version Control System for Data with MatrixOne**](https://arxiv.org/abs/2604.03927), our arXiv paper on bringing Git-like workflows directly into a cloud-native database.
+
+The paper describes how MatrixOne's immutable storage and MVCC architecture make `clone`, `branch` / `tag`, `diff`, `merge`, and `revert` practical at terabyte scale without loading whole datasets into memory. Memoria applies the same foundation to AI-agent memory, so every memory change can be isolated, reviewed, merged, or rolled back with database-native consistency.
 
 ---
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [x] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

N/A

## What this PR does / why we need it

This PR adds the MatrixOne data version control paper to the project homepage:

- adds an arXiv badge for `Version Control System for Data with MatrixOne`
- adds a `Research Foundation` section after `Why Memoria`
- explains how MatrixOne immutable storage and MVCC support Git-like data operations that underpin Memoria Git-for-Data

Validation:

- `git diff --check`