### PR TITLE
feat: group collaboration API with per-member branch isolation

### DIFF
--- a/.claude/rules/memory-branching-patterns.md
+++ b/.claude/rules/memory-branching-patterns.md
@@ -1,0 +1,24 @@
+# Memory Branching Patterns
+
+Use Memoria's Git-like branching to isolate experiments, evaluate alternatives, and protect stable memory state.
+
+## Selective Apply
+
+When only part of a branch should land on `main`, or you want conflict-by-conflict control, prefer `memory_apply` over merging the whole branch.
+
+```md
+memory_diff(source="experiment_notes")
+
+memory_apply(
+  source="experiment_notes",
+  adds=["mem_new_1"],
+  updates=[{"old_id": "mem_old_1", "new_id": "mem_new_1"}],
+  removes=["mem_delete_1"],
+  accept_branch_conflicts=["mem_conflict_1"]
+)
+```
+
+Rules:
+- Omit an item from `adds` / `updates` / `removes` to leave `main` unchanged for that item.
+- Omit a conflict from `accept_branch_conflicts` to keep the `main` version.
+- Use `memory_merge` only when the entire branch should land together.

--- a/.cursor/rules/memory-branching-patterns.mdc
+++ b/.cursor/rules/memory-branching-patterns.mdc
@@ -1,10 +1,10 @@
 ---
-inclusion: auto
-name: memory-branching
-description: Git-like branching for memory - isolated experiments, tech evaluation, A/B comparison. Use when exploring alternatives or risky changes.
+description: USE WHEN evaluating technologies, isolating risky memory changes, or comparing alternative approaches using memory branches
+globs:
+alwaysApply: false
 ---
 
-<!-- memoria-version: 0.1.0-->
+<!-- memoria-version: 0.2.3-->
 
 # Memory Branching Patterns
 

--- a/.cursor/rules/memory.mdc
+++ b/.cursor/rules/memory.mdc
@@ -1,8 +1,10 @@
 ---
-inclusion: always
+description: USE WHEN working with Memoria memory tools - storing, retrieving, correcting, purging memories
+globs:
+alwaysApply: true
 ---
 
-<!-- memoria-version: 0.1.0-->
+<!-- memoria-version: 0.2.3-->
 
 # Memory Integration (Memoria Lite)
 
@@ -20,6 +22,9 @@ Call `memory_retrieve` with a **semantic query** derived from the user's message
 - Results → use as reference, verify against current context
 - "No relevant memories" → normal for new users, proceed
 - ⚠️ warnings → inform user, offer `memory_governance`
+- If results come back → use them as **reference only**. Treat retrieved memories as potentially stale or incomplete — always verify against current context before acting on them. Do NOT blindly trust memory content as ground truth.
+- If "No relevant memories found" → this is normal for new users, proceed without.
+- If ⚠️ health warnings appear → inform the user and offer to run `memory_governance`.
 
 ## 🔴 MANDATORY: Every conversation turn
 After responding, decide if anything is worth remembering:
@@ -78,17 +83,16 @@ Before storing a new memory, consider:
 | Tool | When to use | Key params |
 |------|-------------|------------|
 | `memory_store` | User shares a fact, preference, or decision | `content`, `memory_type` (default: semantic), `session_id` (optional) |
-| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason`; query mode also supports `session_id` + `session_scope` |
-| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch), `topic`, or exact `session_id`; `memory_types` only with `session_id` |
+| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason` |
+| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch, e.g. `"id1,id2"`) or `topic` (bulk keyword match), `reason` |
 
 `memory_purge` automatically creates a safety snapshot before deleting. The response includes the snapshot name — tell the user they can `memory_rollback` to undo. If the response contains a ⚠️ warning about snapshot quota, relay it and suggest `memory_snapshot_delete(prefix="pre_")`.
 
 ### Read tools
 | Tool | When to use | Key params |
 |------|-------------|------------|
-| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
-| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), optional `session_id`, optional `session_scope` (`prefer`/`only`), `explain` |
-| `memory_list` | User wants a bounded inventory or a session-specific listing | `limit`, optional `memory_type`, optional exact `session_id` |
+| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), `session_id` (optional), `explain` (false = no debug, true = show timing) |
+| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), `explain` (false = no debug, true = show timing) |
 | `memory_profile` | User asks "what do you know about me" | — |
 | `memory_feedback` | After using a retrieved memory, record if it was helpful | `memory_id`, `signal` (useful/irrelevant/outdated/wrong), `context` (optional) |
 
@@ -121,15 +125,9 @@ memory_feedback(memory_id="abc123", signal="useful", context="answered DB questi
 **Impact**: Feedback accumulates over time. With default settings, a memory with 3 `useful` signals ranks ~30% higher in future retrievals. Don't call for every memory — only when you have clear signal.
 
 **`memory_retrieve` vs `memory_search`**: In MCP mode, both use the same retrieval pipeline (graph → hybrid vector+fulltext → fulltext fallback). The differences are:
-- Both accept optional `session_id` plus `session_scope`
-- `session_scope="prefer"` means "use this session as context, but cross-session results are still allowed" (default when `session_id` is present)
-- `session_scope="only"` means "strictly filter to this session"
+- `memory_retrieve` accepts `session_id` for session-scoped boosting; `memory_search` does not
 - `memory_retrieve` defaults to `top_k=5` (focused); `memory_search` defaults to `top_k=10` (broader)
-- Use `memory_retrieve` for prompt-relevant context; use `memory_search` for broader browsing over the same retrieval pipeline
-
-**`memory_list` session semantics**:
-- `session_id` on `memory_list` is an exact filter, not a preference hint
-- Use it to inspect one session before `memory_purge(session_id=...)` or after a session-scoped correction
+- Use `memory_retrieve` when you have a `session_id` or want focused results; use `memory_search` for broader exploration
 
 **Debug parameter:** `explain=true` shows execution timing and retrieval path. **ONLY use when user explicitly asks** to debug performance or investigate why certain memories were/weren't retrieved. **DO NOT use proactively** — it adds overhead and clutters output.
 

--- a/.gemini/memory-branching-patterns.md
+++ b/.gemini/memory-branching-patterns.md
@@ -1,0 +1,24 @@
+# Memory Branching Patterns
+
+Use Memoria's Git-like branching to isolate experiments, evaluate alternatives, and protect stable memory state.
+
+## Selective Apply
+
+When only part of a branch should land on `main`, or you want conflict-by-conflict control, prefer `memory_apply` over merging the whole branch.
+
+```md
+memory_diff(source="experiment_notes")
+
+memory_apply(
+  source="experiment_notes",
+  adds=["mem_new_1"],
+  updates=[{"old_id": "mem_old_1", "new_id": "mem_new_1"}],
+  removes=["mem_delete_1"],
+  accept_branch_conflicts=["mem_conflict_1"]
+)
+```
+
+Rules:
+- Omit an item from `adds` / `updates` / `removes` to leave `main` unchanged for that item.
+- Omit a conflict from `accept_branch_conflicts` to keep the `main` version.
+- Use `memory_merge` only when the entire branch should land together.

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ benchmark-*.html
 
 # Environment
 .env
+scripts/.env
 
 # IDE
 .vscode/

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,9 @@
+# Memoria Guidance
+
+For branch-based memory workflows, use `memory_apply` when only selected branch changes should be promoted back to `main`.
+
+Rules:
+- Run `memory_diff(source="...")` first to inspect adds / updates / removes / conflicts.
+- Use `memory_apply(source="...", ...)` to promote only the chosen items.
+- Omit a conflict from `accept_branch_conflicts` to keep the `main` version.
+- Use `memory_merge` only when the entire branch should land together.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,9 +1,0 @@
-# Memoria Guidance
-
-For branch-based memory workflows, use `memory_apply` when only selected branch changes should be promoted back to `main`.
-
-Rules:
-- Run `memory_diff(source="...")` first to inspect adds / updates / removes / conflicts.
-- Use `memory_apply(source="...", ...)` to promote only the chosen items.
-- Omit a conflict from `accept_branch_conflicts` to keep the `main` version.
-- Use `memory_merge` only when the entire branch should land together.

--- a/README.md
+++ b/README.md
@@ -405,6 +405,28 @@ make test            # Run all tests
 make release VERSION=0.2.0   # Bump, tag, push
 ```
 
+### Group collaboration demo
+
+The local group-collaboration UI demo reads its startup config from `scripts/.env` by default (`scripts/.env` is gitignored). Fill in at least:
+
+- `DATABASE_URL`
+- `MASTER_KEY`
+- `EMBEDDING_API_KEY`
+
+Then start the demo:
+
+```bash
+./scripts/start-group-collab-demo.sh
+```
+
+Recommended workflow:
+
+1. Register users, select an owner actor, and create a group.
+2. Add members and issue group keys so each participant gets a group actor card.
+3. For a multi-member group, create or checkout a branch before `store` / `correct` / `delete`; `main` stays read-only in that case. If the group currently has only the owner as an active member, the owner may write to `main` directly.
+4. Open **Diff & Apply** to review branch changes before promoting them to `main`.
+5. Checked items are applied to `main`; unchecked conflict items keep the `main` version, while checked conflict items mean **accept branch**.
+
 **Developer documentation** (for contributing to Memoria):
 
 | Skill | Description |

--- a/README.md
+++ b/README.md
@@ -405,27 +405,6 @@ make test            # Run all tests
 make release VERSION=0.2.0   # Bump, tag, push
 ```
 
-### Group collaboration demo
-
-The local group-collaboration UI demo reads its startup config from `scripts/.env` by default (`scripts/.env` is gitignored). Fill in at least:
-
-- `DATABASE_URL`
-- `MASTER_KEY`
-- `EMBEDDING_API_KEY`
-
-Then start the demo:
-
-```bash
-./scripts/start-group-collab-demo.sh
-```
-
-Recommended workflow:
-
-1. Register users, select an owner actor, and create a group.
-2. Add members and issue group keys so each participant gets a group actor card.
-3. For a multi-member group, create or checkout a branch before `store` / `correct` / `delete`; `main` stays read-only in that case. If the group currently has only the owner as an active member, the owner may write to `main` directly.
-4. Open **Diff & Apply** to review branch changes before promoting them to `main`.
-5. Checked items are applied to `main`; unchecked conflict items keep the `main` version, while checked conflict items mean **accept branch**.
 
 **Developer documentation** (for contributing to Memoria):
 

--- a/docs/specs/2026-04-12-group-collaboration-api.md
+++ b/docs/specs/2026-04-12-group-collaboration-api.md
@@ -6,14 +6,14 @@
 - Keep single-user behavior unchanged when a request uses a normal personal API key.
 - Let a team share one physical Memoria database per group.
 - Reuse the existing branch model for experimentation inside a group database.
-- Protect `main` in group mode so it can only be changed through explicit selective apply.
+- Protect `main` in group mode so it can only be changed through explicit selective apply (with a solo-owner bypass for initial seeding).
 - Keep the first version operationally small and avoid adding new entities unless they are necessary.
 
 ## Non-Goals
 
 - No field-level merge or three-way conflict resolution.
 - No native branch merge in group mode (blocked by middleware).
-- No editor metadata on memory rows (apply actions are logged in edit-log only).
+- No per-edit attribution tracking — `author_id` records who created a memory, but subsequent corrections preserve the original author (corrector identity is in edit-log only).
 
 ## Background
 
@@ -136,7 +136,7 @@ Membership is validated at request entry with a 5-minute in-memory cache:
    - verify `user_id` is an active member (`is_active = 1`) in `mem_group_members`,
    - reject if any check fails.
 
-If a user is removed from the group (soft-deleted in `mem_group_members`) but still holds an old group key, the membership check rejects the request once the cache expires.
+If a user is removed from the group, their API keys are deactivated and the cache is proactively invalidated. As a defense-in-depth, the DB-level membership check on cache miss also rejects requests from non-members (authoritative gate).
 
 ### Key Issuance Rule
 
@@ -218,17 +218,19 @@ Three middleware layers enforce group-mode constraints at the router level, remo
 
 ### 1. Write Guard (`group_main_write_guard`)
 
-Applied to all write routes. If the request is group-scoped and the caller's active branch is `main`, returns **403 Forbidden**: "main is read-only in group mode; checkout a branch first."
+Applied to all write routes. If the request is group-scoped and the caller's active branch is `main`, returns **403 Forbidden**: "main is read-only in group mode; create or checkout a branch, then use selective apply."
+
+**Solo-owner exception**: When a group has exactly one active member (the owner), writes to `main` are allowed. This avoids forcing branch ceremonies when a user initially seeds a group database alone before inviting collaborators.
 
 Protected routes:
 - `POST /v1/memories` (store)
 - `POST /v1/memories/batch` (batch store)
-- `POST /v1/memories/by-query` (correct by query)
+- `POST /v1/memories/correct` (correct by query)
 - `POST /v1/memories/purge` (purge)
-- `PUT /v1/memories/:id` (correct)
+- `PUT /v1/memories/:id/correct` (correct by id)
 - `DELETE /v1/memories/:id` (delete)
 - `POST /v1/observe` (observe turn)
-- `POST /v1/sessions` (session summary)
+- `POST /v1/sessions/:session_id/summary` (session summary)
 
 ### 2. Merge Guard (`group_merge_guard`)
 
@@ -278,15 +280,19 @@ is parsed by column index.
 - **Branch-side rows**: `source == branch_table`
 - **Main-side rows**: `source == "mem_memories"`
 
-Any `memory_id` that appears on **both** sides is classified as a **CONFLICT**.
+Any `memory_id` that appears on **both** sides is classified as a **CONFLICT** (along with any `superseded_by` targets referenced by conflicting rows).
 The remaining branch-only rows are classified by `flag`, `is_active`, and `superseded_by`:
 
-| Raw flag | is_active | superseded_by | Classification |
-|----------|-----------|---------------|----------------|
-| INSERT   | 1         | —             | **ADDED** |
-| INSERT   | 0         | —             | hidden |
-| UPDATE   | 0         | set           | **UPDATED** (correction pair: old → new) |
-| UPDATE   | 0         | NULL          | **REMOVED** |
+| Scenario                       | flag   | is_active | superseded_by | Classification |
+|--------------------------------|--------|-----------|---------------|----------------|
+| New memory on branch           | INSERT | 1         | NULL          | **ADDED** |
+| Created then deleted on branch | INSERT | 0         | NULL          | hidden |
+| Created then corrected (old)   | INSERT | 0         | new_id        | hidden |
+| Created then corrected (new)   | INSERT | 1         | NULL          | **ADDED** (paired → **UPDATED**) |
+| Deleted main memory on branch  | UPDATE | 0         | NULL          | **REMOVED** |
+| Corrected main memory (old)    | UPDATE | 0         | new_id        | paired into **UPDATED** |
+
+**Pairing logic**: An UPDATE row (`is_active=0`, `superseded_by=new_id`) is paired with its corresponding INSERT row (`memory_id=new_id`, `is_active=1`). Together they form a single **UPDATED** entry containing both old and new content.
 
 Main-only rows with `is_active = 1` are returned as **BEHIND_MAIN** (informational).
 
@@ -318,7 +324,9 @@ display without extra queries.
 
 ### Endpoint
 
-`GET /v1/branches/:name/diff-items?limit=50`
+`GET /v1/branches/:name/diff-items?limit=100`
+
+Default limit is 100, max 500. Each category is independently truncated at the limit.
 
 Response:
 
@@ -455,8 +463,10 @@ Apply actions are logged via the existing edit-log mechanism with a `branch_appl
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | POST | `/auth/keys` | User or Owner | Create key (with optional `group_id`) |
-| DELETE | `/auth/keys/:key_id` | Owner of key | Revoke key |
 | GET | `/auth/keys` | Any user | List caller's keys |
+| GET | `/auth/keys/:id` | Owner of key | Get key details |
+| PUT | `/auth/keys/:id/rotate` | Owner of key | Rotate key (new secret, same metadata) |
+| DELETE | `/auth/keys/:id` | Owner of key | Revoke key |
 
 ### Branch Diff & Apply
 
@@ -503,50 +513,6 @@ Snapshot and rollback operations in a group database affect all members' data. N
 
 Group databases (`mem_grp_*`) are not registered in `mem_user_registry`. This means governance and stats operations do not traverse group databases. Adding group DB registration is a future improvement.
 
-## Test UI
+## Test UI (not shipped)
 
-A local HTML+JS test UI is provided at `tools/group-collab-ui/`.
-
-### Starting the UI Server
-
-```bash
-cd tools/group-collab-ui
-python3 server.py \
-  --host 0.0.0.0 \          # default; listens on all interfaces (LAN-accessible)
-  --port 8301 \
-  --backend http://127.0.0.1:8100 \
-  --master-key <master_key> \
-  --master-user admin
-```
-
-Environment variable overrides:
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MEMORIA_UI_HOST` | `0.0.0.0` | Bind address |
-| `MEMORIA_UI_BACKEND` | `http://127.0.0.1:8100` | Memoria API base URL |
-| `MEMORIA_UI_MASTER_KEY` | — | Master key for admin operations |
-| `MEMORIA_UI_MASTER_USER` | `admin` | Master user ID |
-
-The UI proxies all `/api/*` requests to the backend, so the browser never needs direct
-access to the Memoria API port.
-
-### Diff Display
-
-The diff panel renders all 5 categories:
-
-| Section | Color | Selectable for Apply |
-|---------|-------|----------------------|
-| ✅ Added | green | ✓ |
-| 🔄 Updated | blue | ✓ |
-| 🗑️ Removed | red | ✓ |
-| ⚠️ Conflicts | purple | optional checkbox (accept branch) |
-| 📥 Behind Main | blue-grey | ✗ (informational) |
-
-All diff cards show `author_id` as a pill badge. Conflict cards show both sides
-(branch vs main) side-by-side, including `superseded_by` target content when available.
-
-
-
-
-1. personal 也变成分享的
+A local HTML+JS dev UI exists at `tools/group-collab-ui/` (git-excluded, for local verification only). It provides a proxy server and a diff panel that renders all 5 diff categories with author badges and conflict side-by-side comparison.

--- a/docs/specs/2026-04-12-group-collaboration-api.md
+++ b/docs/specs/2026-04-12-group-collaboration-api.md
@@ -1,0 +1,552 @@
+# Group Collaboration API Design
+
+## Goals
+
+- Add a small-team collaboration mode on top of the existing per-user Memoria architecture.
+- Keep single-user behavior unchanged when a request uses a normal personal API key.
+- Let a team share one physical Memoria database per group.
+- Reuse the existing branch model for experimentation inside a group database.
+- Protect `main` in group mode so it can only be changed through explicit selective apply.
+- Keep the first version operationally small and avoid adding new entities unless they are necessary.
+
+## Non-Goals
+
+- No field-level merge or three-way conflict resolution.
+- No native branch merge in group mode (blocked by middleware).
+- No editor metadata on memory rows (apply actions are logged in edit-log only).
+
+## Background
+
+The current system already has two important properties:
+
+1. Per-user physical database routing exists as the base architecture.
+2. Branches already exist as separate tables inside one database, with `main` backed by `mem_memories` and branch checkout implemented through `active_table()`.
+
+This design keeps both properties intact. Group collaboration is added as a control-plane extension, not as a rewrite of the memory data model.
+
+## Design Summary
+
+The system supports two request modes:
+
+- **Personal mode**: API key has no `group_id`. Requests continue to use the user's personal Memoria database exactly as they do today.
+- **Group mode**: API key is bound to a `group_id`. Requests are routed to that group's shared physical database. In this mode, `main` is read-only and only selective apply may modify it.
+
+## Data Model
+
+### Shared Control-Plane Tables
+
+Two tables in the shared metadata database:
+
+```sql
+CREATE TABLE mem_groups (
+    group_id      VARCHAR(64)  PRIMARY KEY,
+    group_name    VARCHAR(128) NOT NULL,
+    db_name       VARCHAR(128) NOT NULL UNIQUE,
+    owner_user_id VARCHAR(64)  NOT NULL,
+    status        VARCHAR(20)  NOT NULL DEFAULT 'active',
+    created_at    DATETIME(6)  NOT NULL,
+    updated_at    DATETIME(6)  NOT NULL
+);
+
+CREATE TABLE mem_group_members (
+    group_id     VARCHAR(64)  NOT NULL,
+    user_id      VARCHAR(64)  NOT NULL,
+    display_name VARCHAR(128),
+    role         VARCHAR(20)  NOT NULL DEFAULT 'member',
+    is_active    TINYINT(1)   NOT NULL DEFAULT 1,
+    joined_at    DATETIME(6)  NOT NULL,
+    removed_at   DATETIME(6)  DEFAULT NULL,
+    PRIMARY KEY (group_id, user_id),
+    KEY idx_gmem_user (user_id, is_active)
+);
+```
+
+Field meanings:
+
+- `group_id`: stable identifier, format `grp_<12-char hex>`.
+- `group_name`: human-readable display name.
+- `db_name`: physical database name for the shared group memory store, format `mem_grp_<12-char hex>`.
+- `owner_user_id`: creator and manager of the group.
+- `status`: lifecycle flag (`active` or `deleted`).
+
+`mem_group_members` tracks membership with soft-delete support:
+
+- `role`: `owner` for the group creator, `member` for invited users.
+- `is_active`: `1` for current members, `0` for removed members (soft-delete).
+- `removed_at`: timestamp when the member was removed (NULL if active).
+- Re-adding a previously removed member reactivates the row (`is_active = 1`, `removed_at = NULL`).
+
+### Memory Author Tracking
+
+The `mem_memories` table (in each user/group database) includes an `author_id` column:
+
+```sql
+ALTER TABLE mem_memories ADD COLUMN author_id VARCHAR(64) DEFAULT NULL;
+```
+
+- **Group mode**: `author_id = auth.user_id` (the real human user who created the memory).
+- **Personal mode**: `author_id = NULL` (not needed; `user_id` already identifies the author).
+- On `correct()` operations, the original `author_id` is preserved (the corrector is not reassigned as author).
+
+This is a separate concept from `user_id`, which in group mode is the `grp_xxx` scope ID used for database routing.
+
+### API Key Extension
+
+The existing `mem_api_keys` table is extended with:
+
+```sql
+group_id VARCHAR(64) DEFAULT NULL
+```
+
+Semantics:
+
+- `group_id IS NULL`: personal key, use existing per-user database routing.
+- `group_id IS NOT NULL`: group key, route to the shared group database.
+
+Old keys remain fully valid without behavior change.
+
+## Routing and Authentication
+
+### AuthUser and scope_id
+
+Upon authentication, the middleware constructs an `AuthUser` struct:
+
+```rust
+pub struct AuthUser {
+    pub user_id: String,       // real human user
+    pub scope_id: String,      // routing key: user_id (personal) or group_id (group)
+    pub group_id: Option<String>,
+    pub is_master: bool,
+}
+```
+
+- In personal mode: `scope_id == user_id`.
+- In group mode: `scope_id == group_id` (e.g. `grp_abc123`).
+
+All downstream service calls use `scope_id` as the database routing key. The DB router detects `grp_` prefix and routes to the group's physical database via `mem_groups.db_name`.
+
+### Membership Enforcement
+
+Membership is validated at request entry with a 5-minute in-memory cache:
+
+1. Load the API key record.
+2. If `group_id` is present:
+   - JOIN `mem_groups` with `mem_group_members` by `group_id`,
+   - verify group exists and `status = 'active'`,
+   - verify `user_id` is an active member (`is_active = 1`) in `mem_group_members`,
+   - reject if any check fails.
+
+If a user is removed from the group (soft-deleted in `mem_group_members`) but still holds an old group key, the membership check rejects the request once the cache expires.
+
+### Key Issuance Rule
+
+Group-scoped API keys may only be issued for users that are active members in `mem_group_members`. The group owner creates keys on behalf of members.
+
+Key issuance is a separate explicit step from group creation.
+
+## Per-Member Active Branch (ACTOR_USER_ID)
+
+### Problem
+
+In group mode, `scope_id` is the group ID (e.g. `grp_abc`). The storage layer uses this to key `mem_user_state` for active branch tracking. Without correction, all group members would share a single active branch pointer — Member A's checkout would overwrite Member B's state.
+
+### Solution
+
+A tokio task-local variable `ACTOR_USER_ID` carries the real human user ID through the request lifecycle:
+
+```rust
+tokio::task_local! {
+    pub static ACTOR_USER_ID: String;
+}
+```
+
+The `actor_scope_layer` middleware sets this for every group-scoped request. Storage functions that manage per-user state (`active_branch_name`, `set_active_branch`, `active_table`) read `ACTOR_USER_ID` to key on the real user, while still using `scope_id` (group ID) for shared resources like `mem_branches`.
+
+This means:
+
+- **Branch list**: shared across group (keyed by `scope_id`).
+- **Branch data**: shared across group (keyed by `scope_id`).
+- **Active branch pointer**: per-member (keyed by real `user_id` via `ACTOR_USER_ID`).
+- **Cache keys**: per-member (prevents cross-member cache pollution).
+
+In personal mode, the task-local is not set and the fallback is the passed `user_id`, so behavior is unchanged.
+
+## Group Lifecycle
+
+### Create Group
+
+`POST /v1/groups`
+
+1. Insert a row in `mem_groups`.
+2. Create the physical database via `CREATE DATABASE IF NOT EXISTS`.
+3. Bootstrap the Memoria schema in that database (via `migrate_user()`).
+4. Insert membership rows into `mem_group_members` for the creator (role `owner`) and any initial members (role `member`).
+5. Optional seed import: when `seed.db_name` is provided and matches the current key's accessible scope DB, copy active rows from the source database's `mem_memories` main table into the new group DB, rewriting `user_id` to the new `group_id`.
+
+No API key is auto-issued; key creation is a separate step.
+
+### Add Member
+
+`POST /v1/groups/:group_id/members/:user_id`
+
+- Owner only.
+- Validates the target user is registered in `mem_user_registry` (must have created at least one personal key first).
+- Inserts a new row into `mem_group_members` (or reactivates a previously removed member).
+
+### Remove Member
+
+`DELETE /v1/groups/:group_id/members/:user_id`
+
+- Owner only.
+- Cannot remove the owner themselves.
+- Soft-deletes the member (`is_active = 0`, `removed_at = NOW()`) in `mem_group_members`.
+- Deactivates all active group-bound API keys for that `(user_id, group_id)`.
+- Invalidates the key cache for affected keys.
+
+### Delete Group
+
+`DELETE /v1/groups/:group_id`
+
+- Owner only.
+- Marks group `status = 'deleted'`.
+- Deactivates all API keys bound to this group.
+- Drops the physical group database.
+
+## Middleware Guards
+
+Three middleware layers enforce group-mode constraints at the router level, removing the need for per-handler guard calls:
+
+### 1. Write Guard (`group_main_write_guard`)
+
+Applied to all write routes. If the request is group-scoped and the caller's active branch is `main`, returns **403 Forbidden**: "main is read-only in group mode; checkout a branch first."
+
+Protected routes:
+- `POST /v1/memories` (store)
+- `POST /v1/memories/batch` (batch store)
+- `POST /v1/memories/by-query` (correct by query)
+- `POST /v1/memories/purge` (purge)
+- `PUT /v1/memories/:id` (correct)
+- `DELETE /v1/memories/:id` (delete)
+- `POST /v1/observe` (observe turn)
+- `POST /v1/sessions` (session summary)
+
+### 2. Merge Guard (`group_merge_guard`)
+
+Applied to `POST /v1/branches/:name/merge`. Blocks native branch merge entirely in group mode with **403 Forbidden**: "native branch merge is disabled in group mode; use selective apply instead."
+
+### 3. Actor Scope Layer (`actor_scope_layer`)
+
+Applied to all routes. Sets the `ACTOR_USER_ID` task-local for group-scoped requests, enabling per-member active branch tracking.
+
+## Branch Workflow in Group Mode
+
+The intended group workflow is:
+
+1. Read `main` (always allowed).
+2. Create a branch from `main`.
+3. Checkout the branch (per-member, does not affect other members).
+4. Perform experiments on the branch.
+5. Diff the branch against latest `main`.
+6. User reviews and selects records to apply.
+7. System applies selected changes into `main` transactionally.
+
+## Diff Model
+
+### Comparison Base
+
+Branch diff uses MatrixOne's native `data branch diff` command, not SQL JOINs.
+The branch table **must** be created with `data branch create table` (not `CREATE TABLE LIKE`);
+only native branches produce correct INSERT/UPDATE flags.
+
+```sql
+data branch diff {db}.{branch_table} against {db}.{main_table}
+    columns (user_id, memory_id, content, memory_type, is_active, superseded_by, author_id)
+    output limit {limit}
+```
+
+### Output Format
+
+`data branch diff` returns rows with a leading **source column** (index 0) whose value is the
+table name each row originates from (`br_<name>` for the branch, `mem_memories` for main).
+The column header is dynamic (`diff {branch} against {main}`) and is not relied upon; the source
+is parsed by column index.
+
+### Source-Aware Classification
+
+`classify_diff_rows(rows, branch_table)` first separates all rows by source:
+
+- **Branch-side rows**: `source == branch_table`
+- **Main-side rows**: `source == "mem_memories"`
+
+Any `memory_id` that appears on **both** sides is classified as a **CONFLICT**.
+The remaining branch-only rows are classified by `flag`, `is_active`, and `superseded_by`:
+
+| Raw flag | is_active | superseded_by | Classification |
+|----------|-----------|---------------|----------------|
+| INSERT   | 1         | —             | **ADDED** |
+| INSERT   | 0         | —             | hidden |
+| UPDATE   | 0         | set           | **UPDATED** (correction pair: old → new) |
+| UPDATE   | 0         | NULL          | **REMOVED** |
+
+Main-only rows with `is_active = 1` are returned as **BEHIND_MAIN** (informational).
+
+### Classification Output (5 categories)
+
+| Category | Meaning |
+|----------|---------|
+| `added` | New memories created on the branch, not yet in main |
+| `updated` | Correction pairs: old memory superseded by new on the branch |
+| `removed` | Soft-deleted on the branch but still active in main |
+| `conflicts` | Same `memory_id` appears on both sides (concurrent modification) |
+| `behind_main` | Active memories in main that do not appear on this branch (added by others) |
+
+### Conflict Structure
+
+A conflict carries both sides of the divergence:
+
+```
+DiffConflict {
+  memory_id: String,
+  branch_side: DiffConflictSide { content, is_active, superseded_by, superseded_by_content, author_id },
+  main_side:   DiffConflictSide { content, is_active, superseded_by, superseded_by_content, author_id },
+}
+```
+
+`superseded_by_content` is resolved from the same diff output — if a conflicting row has
+`superseded_by` pointing to another row in the same diff, that row's content is inlined for
+display without extra queries.
+
+### Endpoint
+
+`GET /v1/branches/:name/diff-items?limit=50`
+
+Response:
+
+```json
+{
+  "branch": "exp-a",
+  "against": "main",
+  "added": [
+    { "memory_id": "m1", "content": "new memory", "memory_type": "semantic", "author_id": "alice" }
+  ],
+  "updated": [
+    {
+      "memory_id": "new_id", "content": "corrected content", "memory_type": "semantic",
+      "old_memory_id": "old_id", "old_content": "original content",
+      "author_id": "alice"
+    }
+  ],
+  "removed": [
+    { "memory_id": "m3", "content": "deleted memory", "memory_type": "procedural", "author_id": "alice" }
+  ],
+  "conflicts": [
+    {
+      "memory_id": "mx",
+      "branch": {
+        "content": "alice's version", "is_active": 1,
+        "superseded_by": null, "superseded_by_content": null,
+        "author_id": "alice"
+      },
+      "main": {
+        "content": "bob's version", "is_active": 1,
+        "superseded_by": null, "superseded_by_content": null,
+        "author_id": "bob"
+      }
+    }
+  ],
+  "behind_main": [
+    { "memory_id": "m9", "content": "bob added this", "memory_type": "semantic", "author_id": "bob" }
+  ]
+}
+```
+
+- All items include `author_id` (the real human user who created the memory in group mode; `null` in personal mode).
+- `conflicts` support **per-item accept-branch selection** during apply; unchecked conflicts implicitly keep main.
+- `behind_main` is informational only — not selectable for apply.
+
+## Selective Apply
+
+### Endpoint
+
+`POST /v1/branches/:name/apply`
+
+Request:
+
+```json
+{
+  "adds": ["m1"],
+  "updates": [{"old_id": "old_m2", "new_id": "new_m2"}],
+  "removes": ["m3"],
+  "accept_branch_conflicts": ["mx"]
+}
+```
+
+Response:
+
+```json
+{
+  "applied_adds": ["m1"],
+  "applied_updates": ["old_m2→new_m2"],
+  "applied_removes": ["m3"],
+  "applied_conflicts": ["mx"],
+  "skipped_adds": [],
+  "skipped_updates": [],
+  "skipped_removes": [],
+  "skipped_conflicts": []
+}
+```
+
+### Apply Semantics
+
+All operations run in a single database transaction. The core principle is **verbatim copy**: rows are copied from the branch table to main exactly as they are, preserving all fields including `updated_at`.
+
+**Add**: For each selected add:
+1. Verify the memory is active in the branch (`is_active = 1`) and absent from main.
+2. `INSERT INTO main SELECT ... FROM branch WHERE memory_id = ? AND is_active = 1`.
+3. Skip if main already has that `memory_id`.
+
+**Update** (correction pair `{old_id, new_id}`): For each selected update:
+1. Verify `old_id` exists in main (the original memory to be corrected).
+2. Verify `old_id` exists in branch (superseded version, `is_active = 0`, `superseded_by = new_id`).
+3. Verify `new_id` exists in branch and is active (`is_active = 1`).
+4. `DELETE FROM main WHERE memory_id = old_id` (hard delete the original).
+5. `INSERT INTO main SELECT ... FROM branch WHERE memory_id = old_id` (copy superseded row, preserving `is_active = 0` and `superseded_by`).
+6. `INSERT INTO main SELECT ... FROM branch WHERE memory_id = new_id AND is_active = 1` (copy the corrected replacement).
+
+**Remove**: For each selected remove:
+1. Verify the memory is active in main (`is_active = 1`).
+2. Verify the branch has the soft-deleted version (`is_active = 0`).
+3. `DELETE FROM main WHERE memory_id = ?` (hard delete the active row).
+4. `INSERT INTO main SELECT ... FROM branch WHERE memory_id = ? AND is_active = 0` (copy the soft-deleted version verbatim).
+5. Skip if main is already inactive or branch doesn't have the soft-deleted version.
+
+**Accept Branch Conflict**: For each selected conflict `memory_id`:
+1. Re-run diff classification and verify the item is still a current conflict.
+2. Build the **main conflict subgraph**: `memory_id` plus `main.superseded_by` (if any).
+3. Build the **branch conflict subgraph**: `memory_id` plus `branch.superseded_by` (if any).
+4. `DELETE FROM main WHERE memory_id IN (main subgraph)` to remove the current main-side resolution.
+5. `INSERT INTO main SELECT ... FROM branch WHERE memory_id IN (branch subgraph)` to copy the branch-side resolution verbatim.
+6. Unselected conflicts are treated as **accept main** (no-op on main; the branch still remains divergent until changed separately).
+
+### Logging
+
+Apply actions are logged via the existing edit-log mechanism with a `branch_apply` action type. The log payload includes:
+
+- `actor_user_id` (real human user, not scope_id)
+- `group_id`
+- `source_branch` (branch name)
+- Applied and skipped counts for each category
+
+## API Reference
+
+### Group Management
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/v1/groups` | Any user | Create group (caller becomes owner) |
+| GET | `/v1/groups` | Any user | List groups where caller is a member |
+| GET | `/v1/groups/:group_id` | Member | Get group details |
+| POST | `/v1/groups/:group_id/members/:user_id` | Owner | Add member |
+| DELETE | `/v1/groups/:group_id/members/:user_id` | Owner | Remove member + revoke keys |
+| DELETE | `/v1/groups/:group_id` | Owner | Delete group + drop DB |
+
+### Key Management
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/auth/keys` | User or Owner | Create key (with optional `group_id`) |
+| DELETE | `/auth/keys/:key_id` | Owner of key | Revoke key |
+| GET | `/auth/keys` | Any user | List caller's keys |
+
+### Branch Diff & Apply
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/v1/branches/:name/diff-items` | Member | 5-category structured diff (added/updated/removed/conflicts/behind_main) |
+| POST | `/v1/branches/:name/apply` | Member | Selective apply to main |
+
+## Compatibility Notes
+
+This design is intentionally conservative:
+
+- Personal mode remains unchanged.
+- Existing branch storage remains unchanged.
+- Existing memory row schema remains unchanged (only nullable `author_id` column added).
+- Existing soft-delete semantics remain unchanged.
+- Group management adds two tables (`mem_groups`, `mem_group_members`) and one nullable column (`group_id` on `mem_api_keys`).
+- MatrixOne compatibility: qualified table names used instead of `USE` statements.
+
+## Risks and Deferred Work
+
+### Conflict Detection (Partial)
+
+Concurrent-modification conflicts are detected at diff time via the `source` column in
+`data branch diff` output. Any `memory_id` appearing on both branch and main sides is
+surfaced as a `conflict` entry in the diff response.
+
+Conflict **resolution** is not yet automated — the caller must decide which side wins and
+apply changes manually. Options being considered:
+
+- "Accept branch" — implemented as a per-conflict apply option that replaces the main-side conflict subgraph with the branch-side subgraph.
+- "Accept main" — currently a no-op on main when the conflict is left unchecked.
+- "Manual merge" — user edits the content in a separate operation before applying.
+
+### No Dedicated Merge Session Table
+
+Audit data is stored in edit logs. If the feature later needs browsing, retries, or historical merge inspection, a dedicated merge-session entity can be introduced.
+
+### Snapshot/Rollback Safety in Groups
+
+Snapshot and rollback operations in a group database affect all members' data. No per-member isolation exists for these operations. Restricting snapshot/rollback to group owners is a potential future improvement.
+
+### Group DB Not in User Registry
+
+Group databases (`mem_grp_*`) are not registered in `mem_user_registry`. This means governance and stats operations do not traverse group databases. Adding group DB registration is a future improvement.
+
+## Test UI
+
+A local HTML+JS test UI is provided at `tools/group-collab-ui/`.
+
+### Starting the UI Server
+
+```bash
+cd tools/group-collab-ui
+python3 server.py \
+  --host 0.0.0.0 \          # default; listens on all interfaces (LAN-accessible)
+  --port 8301 \
+  --backend http://127.0.0.1:8100 \
+  --master-key <master_key> \
+  --master-user admin
+```
+
+Environment variable overrides:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MEMORIA_UI_HOST` | `0.0.0.0` | Bind address |
+| `MEMORIA_UI_BACKEND` | `http://127.0.0.1:8100` | Memoria API base URL |
+| `MEMORIA_UI_MASTER_KEY` | — | Master key for admin operations |
+| `MEMORIA_UI_MASTER_USER` | `admin` | Master user ID |
+
+The UI proxies all `/api/*` requests to the backend, so the browser never needs direct
+access to the Memoria API port.
+
+### Diff Display
+
+The diff panel renders all 5 categories:
+
+| Section | Color | Selectable for Apply |
+|---------|-------|----------------------|
+| ✅ Added | green | ✓ |
+| 🔄 Updated | blue | ✓ |
+| 🗑️ Removed | red | ✓ |
+| ⚠️ Conflicts | purple | optional checkbox (accept branch) |
+| 📥 Behind Main | blue-grey | ✗ (informational) |
+
+All diff cards show `author_id` as a pill badge. Conflict cards show both sides
+(branch vs main) side-by-side, including `superseded_by` target content when available.
+
+
+
+
+1. personal 也变成分享的

--- a/memoria/crates/memoria-api/src/auth.rs
+++ b/memoria/crates/memoria-api/src/auth.rs
@@ -19,10 +19,15 @@ use std::sync::Mutex;
 use subtle::ConstantTimeEq;
 use tracing::warn;
 
-use crate::state::AppState;
+use crate::state::{AppState, CachedApiKeyPrincipal};
 
 pub struct AuthUser {
     pub user_id: String,
+    /// Routing scope: equals `user_id` in personal mode, `group_id` (e.g. `grp_xxx`)
+    /// in group mode.  Passed to service-layer methods to select the correct
+    /// physical database via `DbRouter::scope_store()`.
+    pub scope_id: String,
+    pub group_id: Option<String>,
     pub is_master: bool,
 }
 
@@ -34,6 +39,233 @@ impl AuthUser {
             Ok(())
         }
     }
+
+    pub fn scope_id(&self) -> &str {
+        &self.scope_id
+    }
+
+    pub fn is_group_scoped(&self) -> bool {
+        self.group_id.is_some()
+    }
+}
+
+async fn cached_or_db_principal(token: &str, state: &AppState) -> Option<CachedApiKeyPrincipal> {
+    let key_hash = format!("{:x}", Sha256::digest(token.as_bytes()));
+    if let Some(principal) = state.api_key_cache.get(&key_hash) {
+        return Some(principal);
+    }
+
+    let pool = state
+        .auth_pool
+        .as_ref()
+        .or_else(|| state.service.sql_store.as_ref().map(|s| s.pool()))?;
+
+    let row = sqlx::query(
+        "SELECT user_id, group_id FROM mem_api_keys \
+         WHERE key_hash = ? AND is_active = 1 \
+         AND (expires_at IS NULL OR expires_at > NOW(6))",
+    )
+    .bind(&key_hash)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| warn!("cached_or_db_principal: DB query failed: {e}"))
+    .ok()??;
+
+    let principal = CachedApiKeyPrincipal {
+        user_id: row.try_get("user_id").ok()?,
+        group_id: row.try_get("group_id").ok().flatten(),
+    };
+    state.api_key_cache.insert(
+        key_hash,
+        principal.user_id.clone(),
+        principal.group_id.clone(),
+    );
+    Some(principal)
+}
+
+async fn group_main_write_allowed_for_solo_owner(
+    state: &AppState,
+    group_id: &str,
+    user_id: &str,
+) -> bool {
+    let Some(pool) = state
+        .auth_pool
+        .as_ref()
+        .or_else(|| state.service.sql_store.as_ref().map(|s| s.pool()))
+    else {
+        return false;
+    };
+
+    let row = match sqlx::query(
+        "SELECT g.owner_user_id, CAST(COUNT(m.user_id) AS SIGNED) AS active_member_count \
+         FROM mem_groups g \
+         JOIN mem_group_members m ON g.group_id = m.group_id AND m.is_active = 1 \
+         WHERE g.group_id = ? AND g.status = 'active' \
+         GROUP BY g.owner_user_id \
+         LIMIT 1",
+    )
+    .bind(group_id)
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(row) => row,
+        Err(e) => {
+            warn!("group_main_write_allowed_for_solo_owner: DB query failed: {e}");
+            return false;
+        }
+    };
+
+    let Some(row) = row else {
+        return false;
+    };
+
+    let Ok(owner_user_id) = row.try_get::<String, _>("owner_user_id") else {
+        return false;
+    };
+    let Ok(active_member_count) = row.try_get::<i64, _>("active_member_count") else {
+        return false;
+    };
+
+    owner_user_id == user_id && active_member_count == 1
+}
+
+// ── Group main-write guard (middleware) ──────────────────────────────────────
+
+/// Axum middleware that rejects write requests to `main` in group mode.
+///
+/// Applied as a route-layer on all memory-write endpoints so that individual
+/// handlers never need to call `reject_group_main_writes` manually.
+/// The token is resolved from the in-memory cache (no extra DB round-trip
+/// for the auth lookup itself).
+pub async fn group_main_write_guard(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    req: axum::http::Request<axum::body::Body>,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    // Extract bearer token from Authorization header
+    let principal = req
+        .headers()
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .filter(|v| v.starts_with("Bearer "))
+        .map(|v| v[7..].to_string());
+
+    if let Some(token) = principal {
+        let master_match = !state.master_key.is_empty()
+            && token.len() == state.master_key.len()
+            && token.as_bytes().ct_eq(state.master_key.as_bytes()).into();
+        if master_match {
+            return next.run(req).await;
+        }
+        if let Some(p) = cached_or_db_principal(&token, &state)
+            .await
+            .filter(|p| p.group_id.is_some())
+        {
+            let gid = p.group_id.as_ref().unwrap();
+            // Set task-local so active_branch_name resolves per-member state
+            let user_id = p.user_id.clone();
+            // Check whether the user's active branch is `main`
+            if let Ok(sql) = state.service.user_sql_store(gid).await {
+                let branch = memoria_storage::ACTOR_USER_ID
+                    .scope(user_id, sql.active_branch_name(gid))
+                    .await;
+                if let Ok(branch) = branch {
+                    if branch == "main" {
+                        if group_main_write_allowed_for_solo_owner(&state, gid, &p.user_id).await {
+                            return next.run(req).await;
+                        }
+                        return (
+                            StatusCode::FORBIDDEN,
+                            "main is read-only in group mode; \
+                             create or checkout a branch, then use selective apply"
+                                .to_string(),
+                        )
+                            .into_response();
+                    }
+                }
+            }
+        }
+    }
+
+    next.run(req).await
+}
+
+/// Axum middleware that blocks native merge in group mode.
+///
+/// Applied only to the `/v1/branches/:name/merge` route.
+pub async fn group_merge_guard(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    req: axum::http::Request<axum::body::Body>,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    let token = req
+        .headers()
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .filter(|v| v.starts_with("Bearer "))
+        .map(|v| v[7..].to_string());
+
+    if let Some(token) = token {
+        let master_match = !state.master_key.is_empty()
+            && token.len() == state.master_key.len()
+            && token.as_bytes().ct_eq(state.master_key.as_bytes()).into();
+        if !master_match
+            && cached_or_db_principal(&token, &state)
+                .await
+                .and_then(|p| p.group_id)
+                .is_some()
+        {
+            return (
+                StatusCode::FORBIDDEN,
+                "native branch merge is disabled in group mode; use selective apply instead"
+                    .to_string(),
+            )
+                .into_response();
+        }
+    }
+
+    next.run(req).await
+}
+
+// ── Actor scope middleware ───────────────────────────────────────────────────
+
+/// Axum middleware that sets the `ACTOR_USER_ID` task-local for group-scoped
+/// requests.  This lets the storage layer key per-user state (active branch)
+/// on the real human user rather than the group scope ID.
+pub async fn actor_scope_layer(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    req: axum::http::Request<axum::body::Body>,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let token = req
+        .headers()
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .filter(|v| v.starts_with("Bearer "))
+        .map(|v| v[7..].to_string());
+
+    if let Some(token) = token {
+        let master_match = !state.master_key.is_empty()
+            && token.len() == state.master_key.len()
+            && token.as_bytes().ct_eq(state.master_key.as_bytes()).into();
+        if master_match {
+            return next.run(req).await;
+        }
+        if let Some(uid) = cached_or_db_principal(&token, &state)
+            .await
+            .and_then(|p| p.group_id.as_ref().map(|_| p.user_id))
+        {
+            return memoria_storage::ACTOR_USER_ID
+                .scope(uid, next.run(req))
+                .await;
+        }
+    }
+
+    next.run(req).await
 }
 
 #[derive(Deserialize)]
@@ -686,7 +918,7 @@ impl FromRequestParts<AppState> for AuthUser {
                 // fall through
             }
             // 2) API key — user_id resolved from DB, never master
-            else if let Some(uid) = validate_api_key(token, state).await {
+            else if let Some((uid, group_id)) = validate_api_key(token, state).await {
                 if let Some(tool) = tool_name {
                     state.tool_usage_batcher.mark_used(uid.clone(), tool);
                 }
@@ -698,8 +930,11 @@ impl FromRequestParts<AppState> for AuthUser {
                         *guard = Some(uid.clone());
                     }
                 }
+                let scope_id = group_id.clone().unwrap_or_else(|| uid.clone());
                 return Ok(AuthUser {
                     user_id: uid,
+                    scope_id,
+                    group_id,
                     is_master: false,
                 });
             } else {
@@ -743,6 +978,8 @@ impl FromRequestParts<AppState> for AuthUser {
         }
 
         Ok(AuthUser {
+            scope_id: user_id.clone(),
+            group_id: None,
             user_id,
             is_master: true,
         })
@@ -755,7 +992,7 @@ impl FromRequestParts<AppState> for AuthUser {
 /// Uses a dedicated auth connection pool so that auth validation is never
 /// blocked by slow business queries on the main pool.
 /// `last_used_at` is updated via batched writes (see [`LastUsedBatcher`]).
-async fn validate_api_key(token: &str, state: &AppState) -> Option<String> {
+async fn validate_api_key(token: &str, state: &AppState) -> Option<(String, Option<String>)> {
     state.service.sql_store.as_ref()?;
     let key_hash = format!("{:x}", Sha256::digest(token.as_bytes()));
 
@@ -765,11 +1002,15 @@ async fn validate_api_key(token: &str, state: &AppState) -> Option<String> {
         return None;
     }
 
-    // Check cache first — no DB hit at all
-    if let Some(user_id) = state.api_key_cache.get(&key_hash) {
+    // Check cache first — no DB hit at all.
+    // Note: cached entries skip the membership check below.  This is acceptable
+    // because (a) cache TTL is 5 min, and (b) remove_member / delete_group invalidate
+    // the cache for revoked keys.  The DB-level check on cache miss is the
+    // authoritative membership gate.
+    if let Some(principal) = state.api_key_cache.get(&key_hash) {
         // Still enqueue last_used_at update (batched, no DB pressure)
         state.last_used_batcher.mark_used(key_hash);
-        return Some(user_id);
+        return Some((principal.user_id, principal.group_id));
     }
 
     let Some(pool) = state.auth_pool.as_ref() else {
@@ -778,7 +1019,7 @@ async fn validate_api_key(token: &str, state: &AppState) -> Option<String> {
     };
 
     let row = sqlx::query(
-        "SELECT user_id FROM mem_api_keys \
+        "SELECT user_id, group_id FROM mem_api_keys \
          WHERE key_hash = ? AND is_active = 1 \
          AND (expires_at IS NULL OR expires_at > NOW(6))",
     )
@@ -789,16 +1030,45 @@ async fn validate_api_key(token: &str, state: &AppState) -> Option<String> {
     .ok()??;
 
     let user_id: String = row.try_get("user_id").ok()?;
+    let group_id: Option<String> = row.try_get("group_id").ok().flatten();
+
+    // Enforce real-time group membership: even if the key references a group,
+    // the user must still be an active member in `mem_group_members` and the
+    // group must be active.  This prevents access after member removal (the
+    // key-revocation path is eventually-consistent; this check is the
+    // authoritative gate).
+    if let Some(gid) = &group_id {
+        let cnt: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM mem_groups g \
+             JOIN mem_group_members m ON g.group_id = m.group_id \
+             WHERE g.group_id = ? AND g.status = 'active' \
+             AND m.user_id = ? AND m.is_active = 1",
+        )
+        .bind(gid)
+        .bind(&user_id)
+        .fetch_one(pool)
+        .await
+        .map_err(|e| warn!("validate_api_key: membership check failed: {e}"))
+        .ok()?;
+        if cnt == 0 {
+            warn!(
+                user_id = %user_id,
+                group_id = %gid,
+                "auth: user not a member of group (or group inactive)"
+            );
+            return None;
+        }
+    }
 
     // Cache the result (TTL 5 min)
     state
         .api_key_cache
-        .insert(key_hash.clone(), user_id.clone());
+        .insert(key_hash.clone(), user_id.clone(), group_id.clone());
 
     // Enqueue batched last_used_at update — zero DB pressure on hot path
     state.last_used_batcher.mark_used(key_hash);
 
-    Some(user_id)
+    Some((user_id, group_id))
 }
 #[cfg(test)]
 mod tests {

--- a/memoria/crates/memoria-api/src/lib.rs
+++ b/memoria/crates/memoria-api/src/lib.rs
@@ -84,14 +84,12 @@ async fn call_log_mw(
             // which is necessary because JSON-RPC errors return HTTP 200.
             if !is_dashboard && !path.starts_with("/v1/mcp") {
                 if let Some(reporter) = &state.stats_reporter {
-                    reporter.report(
-                        memoria_service::stats_reporter::StatsEvent::ApiCallLogged {
-                            user_id: uid.clone(),
-                            path: path.clone(),
-                            is_mcp: false,
-                            is_success: status_code < 400,
-                        },
-                    );
+                    reporter.report(memoria_service::stats_reporter::StatsEvent::ApiCallLogged {
+                        user_id: uid.clone(),
+                        path: path.clone(),
+                        is_mcp: false,
+                        is_success: status_code < 400,
+                    });
                 }
             }
             if let Some(mask) = should_mark_metrics_dirty(&method, &path, status_code) {
@@ -149,7 +147,9 @@ fn should_mark_metrics_dirty(
                     || path.starts_with("/v1/branches/") && path.ends_with("/merge")
                 {
                     Some(DirtyMask::FULL)
-                } else if path.starts_with("/v1/sessions/") && path.ends_with("/summary") {
+                } else if (path.starts_with("/v1/branches/") && path.ends_with("/apply"))
+                    || (path.starts_with("/v1/sessions/") && path.ends_with("/summary"))
+                {
                     Some(DirtyMask::MEMORY)
                 } else {
                     None
@@ -178,7 +178,55 @@ fn should_mark_metrics_dirty(
 }
 
 /// Build the full API router with all routes.
+///
+/// Routes are organised into three groups:
+///
+/// 1. **Write routes** — guarded by [`auth::group_main_write_guard`] so that
+///    group-scoped requests on `main` are automatically rejected (403) without
+///    each handler needing a manual check.
+/// 2. **Merge route** — guarded by [`auth::group_merge_guard`] which blocks
+///    native merge entirely in group mode.
+/// 3. **Read / other routes** — no group-mode restrictions.
 pub fn build_router(state: AppState) -> Router {
+    // ── Write routes (group main-write guard) ────────────────────────────
+    // All endpoints that mutate the active memory table.
+    // In group mode these are forbidden when checked-out on `main`.
+    let write_routes = Router::new()
+        .route("/v1/memories", post(routes::memory::store_memory))
+        .route("/v1/memories/batch", post(routes::memory::batch_store))
+        .route(
+            "/v1/memories/correct",
+            post(routes::memory::correct_by_query),
+        )
+        .route("/v1/memories/purge", post(routes::memory::purge_memories))
+        .route(
+            "/v1/memories/:id/correct",
+            put(routes::memory::correct_memory),
+        )
+        .route("/v1/memories/:id", delete(routes::memory::delete_memory))
+        .route("/v1/observe", post(routes::memory::observe_turn))
+        .route(
+            "/v1/sessions/:session_id/summary",
+            post(routes::sessions::create_session_summary),
+        )
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::group_main_write_guard,
+        ));
+
+    // ── Merge route (group merge guard) ──────────────────────────────────
+    // Native merge is entirely disabled in group mode.
+    let merge_route = Router::new()
+        .route(
+            "/v1/branches/:name/merge",
+            post(routes::snapshots::merge_branch),
+        )
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::group_merge_guard,
+        ));
+
+    // ── Read / ungrouped routes ──────────────────────────────────────────
     Router::new()
         // Streamable HTTP MCP endpoint
         .route("/mcp", post(routes::mcp::mcp_handler))
@@ -187,32 +235,19 @@ pub fn build_router(state: AppState) -> Router {
         .route("/health/instance", get(routes::memory::health_instance))
         // Metrics
         .route("/metrics", get(routes::metrics::prometheus_metrics))
-        // Memory CRUD
+        // Memory reads
         .route("/v1/memories", get(routes::memory::list_memories))
-        .route("/v1/memories", post(routes::memory::store_memory))
-        .route("/v1/memories/batch", post(routes::memory::batch_store))
         .route("/v1/memories/retrieve", post(routes::memory::retrieve))
         .route("/v1/memories/search", post(routes::memory::search))
-        .route(
-            "/v1/memories/correct",
-            post(routes::memory::correct_by_query),
-        )
-        .route("/v1/memories/purge", post(routes::memory::purge_memories))
         .route("/v1/memories/:id", get(routes::memory::get_memory))
-        .route(
-            "/v1/memories/:id/correct",
-            put(routes::memory::correct_memory),
-        )
         .route(
             "/v1/memories/:id/history",
             get(routes::memory::get_memory_history),
         )
-        .route("/v1/memories/:id", delete(routes::memory::delete_memory))
         .route(
             "/v1/profiles/:target_user_id",
             get(routes::memory::get_profile),
         )
-        .route("/v1/observe", post(routes::memory::observe_turn))
         // Feedback
         .route(
             "/v1/memories/:id/feedback",
@@ -276,22 +311,22 @@ pub fn build_router(state: AppState) -> Router {
             post(routes::snapshots::checkout_branch),
         )
         .route(
-            "/v1/branches/:name/merge",
-            post(routes::snapshots::merge_branch),
-        )
-        .route(
             "/v1/branches/:name/diff",
             get(routes::snapshots::diff_branch),
+        )
+        .route(
+            "/v1/branches/:name/diff-items",
+            get(routes::snapshots::diff_branch_items),
+        )
+        .route(
+            "/v1/branches/:name/apply",
+            post(routes::snapshots::apply_branch),
         )
         .route(
             "/v1/branches/:name",
             delete(routes::snapshots::delete_branch),
         )
-        // Sessions (episodic memory)
-        .route(
-            "/v1/sessions/:session_id/summary",
-            post(routes::sessions::create_session_summary),
-        )
+        // Sessions
         .route("/v1/tasks/:task_id", get(routes::sessions::get_task_status))
         // API key management
         .route("/auth/keys", post(routes::auth::create_key))
@@ -299,6 +334,22 @@ pub fn build_router(state: AppState) -> Router {
         .route("/auth/keys/:id", get(routes::auth::get_key))
         .route("/auth/keys/:id/rotate", put(routes::auth::rotate_key))
         .route("/auth/keys/:id", delete(routes::auth::revoke_key))
+        // Group management (user-facing)
+        .route("/v1/groups", post(routes::groups::create_group))
+        .route("/v1/groups", get(routes::groups::list_my_groups))
+        .route("/v1/groups/:group_id", get(routes::groups::get_group))
+        .route(
+            "/v1/groups/:group_id/members/:user_id",
+            post(routes::groups::add_member),
+        )
+        .route(
+            "/v1/groups/:group_id/members/:user_id",
+            delete(routes::groups::remove_member),
+        )
+        .route("/v1/groups/:group_id", delete(routes::groups::delete_group))
+        // Merge write routes and merge-guarded route
+        .merge(write_routes)
+        .merge(merge_route)
         // Admin
         .route("/admin/stats", get(routes::admin::system_stats))
         .route("/admin/config", get(routes::admin::get_config))
@@ -386,6 +437,10 @@ pub fn build_router(state: AppState) -> Router {
             get(routes::plugins::list_audit_events),
         )
         .with_state(state.clone())
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::actor_scope_layer,
+        ))
         .layer(DefaultBodyLimit::max(2 * 1024 * 1024)) // 2 MB
         .layer(axum::middleware::from_fn(metrics::middleware::http_metrics))
         .layer(

--- a/memoria/crates/memoria-api/src/models.rs
+++ b/memoria/crates/memoria-api/src/models.rs
@@ -222,6 +222,8 @@ impl PurgeRequest {
 pub struct MemoryResponse {
     pub memory_id: String,
     pub user_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_id: Option<String>,
     pub memory_type: String,
     pub content: String,
     pub trust_tier: String,
@@ -238,6 +240,7 @@ impl From<Memory> for MemoryResponse {
         Self {
             memory_id: m.memory_id,
             user_id: m.user_id,
+            author_id: m.author_id,
             memory_type: m.memory_type.to_string(),
             content: m.content,
             trust_tier: m.trust_tier.to_string(),

--- a/memoria/crates/memoria-api/src/routes/admin.rs
+++ b/memoria/crates/memoria-api/src/routes/admin.rs
@@ -352,7 +352,11 @@ pub async fn health_hygiene_global(
         let mut orphan_stats = 0i64;
 
         for user_id in user_ids {
-            let user_store = state.service.user_sql_store(&user_id).await.map_err(api_err)?;
+            let user_store = state
+                .service
+                .user_sql_store(&user_id)
+                .await
+                .map_err(api_err)?;
             let hygiene = user_store.health_hygiene(&user_id).await.map_err(db_err)?;
             inactive += hygiene["inactive_memories"].as_i64().unwrap_or(0);
             stale_working += hygiene["stale_working_memories"].as_i64().unwrap_or(0);

--- a/memoria/crates/memoria-api/src/routes/auth.rs
+++ b/memoria/crates/memoria-api/src/routes/auth.rs
@@ -41,12 +41,14 @@ pub struct CreateKeyRequest {
     pub user_id: String,
     pub name: String,
     pub expires_at: Option<String>,
+    pub group_id: Option<String>,
 }
 
 #[derive(Serialize)]
 pub struct KeyResponse {
     pub key_id: String,
     pub user_id: String,
+    pub group_id: Option<String>,
     pub name: String,
     pub key_prefix: String,
     pub created_at: String,
@@ -56,26 +58,83 @@ pub struct KeyResponse {
     pub raw_key: Option<String>,
 }
 
+async fn ensure_group_membership(
+    pool: &sqlx::MySqlPool,
+    user_id: &str,
+    group_id: &str,
+) -> Result<(), (StatusCode, String)> {
+    let cnt: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mem_groups g \
+         JOIN mem_group_members m ON g.group_id = m.group_id \
+         WHERE g.group_id = ? AND g.status = 'active' \
+         AND m.user_id = ? AND m.is_active = 1",
+    )
+    .bind(group_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .map_err(api_err)?;
+    if cnt == 0 {
+        return Err((
+            StatusCode::FORBIDDEN,
+            format!("User {user_id} is not an active member of group {group_id}"),
+        ));
+    }
+    Ok(())
+}
+
 // ── Handlers ──────────────────────────────────────────────────────────────────
 
-/// POST /auth/keys — create API key (master key required)
+/// POST /auth/keys — create API key
+///
+/// Access: master key can create any key. Group owners can create keys
+/// scoped to their own groups (group_id must be set, target user must be a member).
 pub async fn create_key(
     State(state): State<AppState>,
     auth: AuthUser,
     Json(req): Json<CreateKeyRequest>,
 ) -> Result<(StatusCode, Json<KeyResponse>), (StatusCode, String)> {
-    auth.require_master()?;
     let pool = auth_pool(&state)?;
+
+    match req.group_id.as_deref() {
+        Some(group_id) => {
+            // Group-scoped key: master OR group owner may create
+            if !auth.is_master {
+                // Verify caller is the group owner
+                let owner_row = sqlx::query(
+                    "SELECT owner_user_id FROM mem_groups WHERE group_id = ? AND status = 'active' LIMIT 1",
+                )
+                .bind(group_id)
+                .fetch_optional(pool)
+                .await
+                .map_err(api_err)?
+                .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Group not found: {group_id}")))?;
+
+                let owner: String = owner_row.try_get("owner_user_id").map_err(api_err)?;
+                if owner != auth.user_id {
+                    return Err((
+                        StatusCode::FORBIDDEN,
+                        "Only the group owner or master can create group keys".into(),
+                    ));
+                }
+            }
+            ensure_group_membership(pool, &req.user_id, group_id).await?;
+        }
+        None => {
+            // Personal key: master only
+            auth.require_master()?;
+        }
+    }
 
     let (raw_key, key_hash, key_prefix) = generate_key();
     let key_id = uuid::Uuid::new_v4().to_string();
     let now = chrono::Utc::now().naive_utc();
 
     sqlx::query(
-        "INSERT INTO mem_api_keys (key_id, user_id, name, key_hash, key_prefix, is_active, created_at, expires_at) \
-         VALUES (?,?,?,?,?,1,?,?)"
+        "INSERT INTO mem_api_keys (key_id, user_id, group_id, name, key_hash, key_prefix, is_active, created_at, expires_at) \
+         VALUES (?,?,?,?,?,?,1,?,?)"
     )
-    .bind(&key_id).bind(&req.user_id).bind(&req.name)
+    .bind(&key_id).bind(&req.user_id).bind(req.group_id.as_deref()).bind(&req.name)
     .bind(&key_hash).bind(&key_prefix).bind(now)
     .bind(req.expires_at.as_deref())
     .execute(pool).await.map_err(api_err)?;
@@ -85,6 +144,7 @@ pub async fn create_key(
         Json(KeyResponse {
             key_id,
             user_id: req.user_id,
+            group_id: req.group_id,
             name: req.name,
             key_prefix,
             created_at: now.to_string(),
@@ -103,7 +163,7 @@ pub async fn list_keys(
     let pool = auth_pool(&state)?;
 
     let rows = sqlx::query(
-        "SELECT key_id, user_id, name, key_prefix, created_at, expires_at, last_used_at \
+        "SELECT key_id, user_id, group_id, name, key_prefix, created_at, expires_at, last_used_at \
          FROM mem_api_keys WHERE user_id = ? AND is_active = 1 ORDER BY created_at DESC",
     )
     .bind(&user_id)
@@ -116,6 +176,7 @@ pub async fn list_keys(
         .map(|r| KeyResponse {
             key_id: r.try_get("key_id").unwrap_or_default(),
             user_id: r.try_get("user_id").unwrap_or_default(),
+            group_id: r.try_get("group_id").ok(),
             name: r.try_get("name").unwrap_or_default(),
             key_prefix: r.try_get("key_prefix").unwrap_or_default(),
             created_at: r
@@ -142,13 +203,15 @@ pub async fn list_keys(
 /// GET /auth/keys/:id — get a single API key by ID
 pub async fn get_key(
     State(state): State<AppState>,
-    AuthUser { user_id, is_master }: AuthUser,
+    AuthUser {
+        user_id, is_master, ..
+    }: AuthUser,
     Path(key_id): Path<String>,
 ) -> Result<Json<KeyResponse>, (StatusCode, String)> {
     let pool = auth_pool(&state)?;
 
     let row = sqlx::query(
-        "SELECT key_id, user_id, name, key_prefix, created_at, expires_at, last_used_at \
+        "SELECT key_id, user_id, group_id, name, key_prefix, created_at, expires_at, last_used_at \
          FROM mem_api_keys WHERE key_id = ? AND is_active = 1",
     )
     .bind(&key_id)
@@ -164,6 +227,7 @@ pub async fn get_key(
     Ok(Json(KeyResponse {
         key_id: r.try_get("key_id").unwrap_or_default(),
         user_id: owner,
+        group_id: r.try_get("group_id").ok(),
         name: r.try_get("name").unwrap_or_default(),
         key_prefix: r.try_get("key_prefix").unwrap_or_default(),
         created_at: r
@@ -187,13 +251,15 @@ pub async fn get_key(
 /// PUT /auth/keys/:id/rotate — revoke old key, issue new one
 pub async fn rotate_key(
     State(state): State<AppState>,
-    AuthUser { user_id, is_master }: AuthUser,
+    AuthUser {
+        user_id, is_master, ..
+    }: AuthUser,
     Path(key_id): Path<String>,
 ) -> Result<(StatusCode, Json<KeyResponse>), (StatusCode, String)> {
     let pool = auth_pool(&state)?;
 
     let old = sqlx::query(
-        "SELECT user_id, name, expires_at, key_hash FROM mem_api_keys WHERE key_id = ? AND is_active = 1",
+        "SELECT user_id, group_id, name, expires_at, key_hash FROM mem_api_keys WHERE key_id = ? AND is_active = 1",
     )
     .bind(&key_id)
     .fetch_optional(pool)
@@ -207,6 +273,7 @@ pub async fn rotate_key(
     }
 
     let name: String = old.try_get("name").map_err(api_err)?;
+    let group_id: Option<String> = old.try_get("group_id").ok();
     let expires_at: Option<chrono::NaiveDateTime> = old.try_get("expires_at").ok().flatten();
 
     // Invalidate cache before DB update
@@ -227,10 +294,10 @@ pub async fn rotate_key(
     let now = chrono::Utc::now().naive_utc();
 
     sqlx::query(
-        "INSERT INTO mem_api_keys (key_id, user_id, name, key_hash, key_prefix, is_active, created_at, expires_at) \
-         VALUES (?,?,?,?,?,1,?,?)"
+        "INSERT INTO mem_api_keys (key_id, user_id, group_id, name, key_hash, key_prefix, is_active, created_at, expires_at) \
+         VALUES (?,?,?,?,?,?,1,?,?)"
     )
-    .bind(&new_id).bind(&old_user).bind(&name)
+    .bind(&new_id).bind(&old_user).bind(group_id.as_deref()).bind(&name)
     .bind(&key_hash).bind(&key_prefix).bind(now)
     .bind(expires_at)
     .execute(pool).await.map_err(api_err)?;
@@ -240,6 +307,7 @@ pub async fn rotate_key(
         Json(KeyResponse {
             key_id: new_id,
             user_id: old_user,
+            group_id,
             name,
             key_prefix,
             created_at: now.to_string(),
@@ -251,22 +319,45 @@ pub async fn rotate_key(
 }
 
 /// DELETE /auth/keys/:id — revoke key
+///
+/// Access: key owner can revoke own key; master can revoke any key;
+/// group owner can revoke any key scoped to their group.
 pub async fn revoke_key(
     State(state): State<AppState>,
-    AuthUser { user_id, is_master }: AuthUser,
+    AuthUser {
+        user_id, is_master, ..
+    }: AuthUser,
     Path(key_id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     let pool = auth_pool(&state)?;
 
-    let row = sqlx::query("SELECT user_id, key_hash FROM mem_api_keys WHERE key_id = ?")
+    let row = sqlx::query("SELECT user_id, group_id, key_hash FROM mem_api_keys WHERE key_id = ?")
         .bind(&key_id)
         .fetch_optional(pool)
         .await
         .map_err(api_err)?
         .ok_or_else(|| (StatusCode::NOT_FOUND, "Key not found".to_string()))?;
 
-    let owner: String = row.try_get("user_id").map_err(api_err)?;
-    if owner != user_id && !is_master {
+    let key_owner: String = row.try_get("user_id").map_err(api_err)?;
+    let key_group: Option<String> = row.try_get("group_id").ok().flatten();
+
+    let mut authorized = is_master || key_owner == user_id;
+    if !authorized {
+        if let Some(gid) = &key_group {
+            // Check if caller is the group owner
+            let group_owner =
+                sqlx::query("SELECT owner_user_id FROM mem_groups WHERE group_id = ? LIMIT 1")
+                    .bind(gid)
+                    .fetch_optional(pool)
+                    .await
+                    .map_err(api_err)?
+                    .and_then(|r| r.try_get::<String, _>("owner_user_id").ok());
+            if group_owner.as_deref() == Some(&user_id) {
+                authorized = true;
+            }
+        }
+    }
+    if !authorized {
         return Err((StatusCode::FORBIDDEN, "Not your key".to_string()));
     }
 

--- a/memoria/crates/memoria-api/src/routes/governance.rs
+++ b/memoria/crates/memoria-api/src/routes/governance.rs
@@ -9,19 +9,19 @@ use crate::{auth::AuthUser, models::*, routes::memory::api_err, state::AppState}
 
 pub async fn governance(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<GovernanceRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let sql = state
         .service
-        .user_sql_store(&user_id)
+        .user_sql_store(auth.scope_id())
         .await
         .map_err(api_err)?;
 
     const COOLDOWN_SECS: i64 = 3600;
     if !req.force {
         if let Some(remaining) = sql
-            .check_cooldown(&user_id, "governance", COOLDOWN_SECS)
+            .check_cooldown(auth.scope_id(), "governance", COOLDOWN_SECS)
             .await
             .map_err(api_err)?
         {
@@ -31,10 +31,10 @@ pub async fn governance(
         }
     }
     let quarantined = sql
-        .quarantine_low_confidence(&user_id)
+        .quarantine_low_confidence(auth.scope_id())
         .await
         .map_err(api_err)?;
-    let cleaned = sql.cleanup_stale(&user_id).await.map_err(api_err)?;
+    let cleaned = sql.cleanup_stale(auth.scope_id()).await.map_err(api_err)?;
     let orphan_graph_cleaned = if req.force {
         sql.cleanup_orphan_graph_data().await.unwrap_or_else(|e| {
             warn!("orphan graph cleanup failed: {e}");
@@ -42,7 +42,7 @@ pub async fn governance(
         })
     } else {
         match sql
-            .check_cooldown(&user_id, "orphan_graph_cleanup", COOLDOWN_SECS)
+            .check_cooldown(auth.scope_id(), "orphan_graph_cleanup", COOLDOWN_SECS)
             .await
         {
             Ok(Some(_)) => 0,
@@ -60,12 +60,14 @@ pub async fn governance(
         }
     };
     if orphan_graph_cleaned > 0 {
-        let _ = sql.set_cooldown(&user_id, "orphan_graph_cleanup").await;
+        let _ = sql
+            .set_cooldown(auth.scope_id(), "orphan_graph_cleanup")
+            .await;
     }
     if quarantined > 0 {
         let payload = serde_json::json!({"quarantined": quarantined}).to_string();
         state.service.send_edit_log(
-            &user_id,
+            auth.scope_id(),
             "governance:quarantine",
             None,
             Some(&payload),
@@ -76,7 +78,7 @@ pub async fn governance(
     if cleaned > 0 {
         let payload = serde_json::json!({"cleaned_stale": cleaned}).to_string();
         state.service.send_edit_log(
-            &user_id,
+            auth.scope_id(),
             "governance:cleanup_stale",
             None,
             Some(&payload),
@@ -87,7 +89,7 @@ pub async fn governance(
     if orphan_graph_cleaned > 0 {
         let payload = serde_json::json!({"orphan_graph_cleaned": orphan_graph_cleaned}).to_string();
         state.service.send_edit_log(
-            &user_id,
+            auth.scope_id(),
             "governance:cleanup_orphan_graph",
             None,
             Some(&payload),
@@ -95,7 +97,7 @@ pub async fn governance(
             None,
         );
     }
-    sql.set_cooldown(&user_id, "governance")
+    sql.set_cooldown(auth.scope_id(), "governance")
         .await
         .map_err(api_err)?;
     Ok(Json(
@@ -105,19 +107,19 @@ pub async fn governance(
 
 pub async fn consolidate(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<GovernanceRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let sql = state
         .service
-        .user_sql_store(&user_id)
+        .user_sql_store(auth.scope_id())
         .await
         .map_err(api_err)?;
 
     const COOLDOWN_SECS: i64 = 1800;
     if !req.force {
         if let Some(remaining) = sql
-            .check_cooldown(&user_id, "consolidate", COOLDOWN_SECS)
+            .check_cooldown(auth.scope_id(), "consolidate", COOLDOWN_SECS)
             .await
             .map_err(api_err)?
         {
@@ -128,10 +130,13 @@ pub async fn consolidate(
     }
     let graph = sql.graph_store();
     let result = DefaultConsolidationStrategy::default()
-        .consolidate(&graph, &ConsolidationInput::for_user(user_id.clone()))
+        .consolidate(
+            &graph,
+            &ConsolidationInput::for_user(auth.scope_id().to_string()),
+        )
         .await
         .map_err(api_err)?;
-    sql.set_cooldown(&user_id, "consolidate")
+    sql.set_cooldown(auth.scope_id(), "consolidate")
         .await
         .map_err(api_err)?;
     Ok(Json(json!({
@@ -147,12 +152,12 @@ pub async fn consolidate(
 
 pub async fn reflect(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<ReflectRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let sql = state
         .service
-        .user_sql_store(&user_id)
+        .user_sql_store(auth.scope_id())
         .await
         .map_err(api_err)?;
 
@@ -166,7 +171,7 @@ pub async fn reflect(
     const COOLDOWN_SECS: i64 = 7200;
     if req.mode != "candidates" && !req.force {
         if let Some(remaining) = sql
-            .check_cooldown(&user_id, "reflect", COOLDOWN_SECS)
+            .check_cooldown(auth.scope_id(), "reflect", COOLDOWN_SECS)
             .await
             .map_err(api_err)?
         {
@@ -177,7 +182,7 @@ pub async fn reflect(
     }
 
     let graph = sql.graph_store();
-    let clusters = memoria_mcp::tools::build_reflect_clusters(&graph, &user_id)
+    let clusters = memoria_mcp::tools::build_reflect_clusters(&graph, auth.scope_id())
         .await
         .map_err(api_err)?;
 
@@ -240,11 +245,12 @@ pub async fn reflect(
             let _ = state
                 .service
                 .store_memory(
-                    &user_id,
+                    auth.scope_id(),
                     &content,
                     mt,
                     None,
                     Some(memoria_core::TrustTier::T4Unverified),
+                    None,
                     None,
                     None,
                 )
@@ -252,7 +258,7 @@ pub async fn reflect(
             scenes_created += 1;
         }
     }
-    sql.set_cooldown(&user_id, "reflect")
+    sql.set_cooldown(auth.scope_id(), "reflect")
         .await
         .map_err(api_err)?;
     Ok(Json(
@@ -262,12 +268,12 @@ pub async fn reflect(
 
 pub async fn extract_entities(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<ExtractEntitiesRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let sql = state
         .service
-        .user_sql_store(&user_id)
+        .user_sql_store(auth.scope_id())
         .await
         .map_err(api_err)?;
 
@@ -280,7 +286,7 @@ pub async fn extract_entities(
 
     let graph = sql.graph_store();
     let unlinked = graph
-        .get_unlinked_memories(&user_id, 50)
+        .get_unlinked_memories(auth.scope_id(), 50)
         .await
         .map_err(api_err)?;
     if unlinked.is_empty() {
@@ -288,7 +294,10 @@ pub async fn extract_entities(
     }
 
     if req.mode == "candidates" || state.service.llm.is_none() {
-        let existing = graph.get_user_entities(&user_id).await.map_err(api_err)?;
+        let existing = graph
+            .get_user_entities(auth.scope_id())
+            .await
+            .map_err(api_err)?;
         return Ok(Json(json!({
             "status": "candidates",
             "unlinked": unlinked.len(),
@@ -332,8 +341,9 @@ pub async fn extract_entities(
             }
             let display = item["name"].as_str().unwrap_or("").trim().to_string();
             let etype = item["type"].as_str().unwrap_or("concept").to_string();
-            if let Ok((entity_id, is_new)) =
-                graph.upsert_entity(&user_id, &name, &display, &etype).await
+            if let Ok((entity_id, is_new)) = graph
+                .upsert_entity(auth.scope_id(), &name, &display, &etype)
+                .await
             {
                 links.push((memory_id.to_string(), entity_id, "llm"));
                 if is_new {
@@ -347,7 +357,7 @@ pub async fn extract_entities(
                 .map(|(m, e, s)| (m.as_str(), e.as_str(), *s))
                 .collect();
             let _ = graph
-                .batch_upsert_memory_entity_links(&user_id, &refs)
+                .batch_upsert_memory_entity_links(auth.scope_id(), &refs)
                 .await;
         }
     }
@@ -358,12 +368,12 @@ pub async fn extract_entities(
 
 pub async fn link_entities(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<LinkEntitiesRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let sql = state
         .service
-        .user_sql_store(&user_id)
+        .user_sql_store(auth.scope_id())
         .await
         .map_err(api_err)?;
     let graph = sql.graph_store();
@@ -377,7 +387,7 @@ pub async fn link_entities(
                 continue;
             }
             let (entity_id, is_new) = graph
-                .upsert_entity(&user_id, &name, &ent.name, &ent.entity_type)
+                .upsert_entity(auth.scope_id(), &name, &ent.name, &ent.entity_type)
                 .await
                 .map_err(api_err)?;
             links.push((link.memory_id.clone(), entity_id, "manual"));
@@ -394,7 +404,7 @@ pub async fn link_entities(
             .map(|(m, e, s)| (m.as_str(), e.as_str(), *s))
             .collect();
         graph
-            .batch_upsert_memory_entity_links(&user_id, &refs)
+            .batch_upsert_memory_entity_links(auth.scope_id(), &refs)
             .await
             .map_err(api_err)?;
     }
@@ -405,15 +415,18 @@ pub async fn link_entities(
 
 pub async fn get_entities(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let sql = state
         .service
-        .user_sql_store(&user_id)
+        .user_sql_store(auth.scope_id())
         .await
         .map_err(api_err)?;
     let graph = sql.graph_store();
-    let entities = graph.get_user_entities(&user_id).await.map_err(api_err)?;
+    let entities = graph
+        .get_user_entities(auth.scope_id())
+        .await
+        .map_err(api_err)?;
     Ok(Json(json!({
         "entities": entities.iter().map(|(n, t)| json!({"name": n, "entity_type": t})).collect::<Vec<_>>()
     })))

--- a/memoria/crates/memoria-api/src/routes/groups.rs
+++ b/memoria/crates/memoria-api/src/routes/groups.rs
@@ -94,7 +94,7 @@ async fn load_group(
 ) -> Result<Option<GroupEntry>, (StatusCode, String)> {
     let row = sqlx::query(
         "SELECT group_id, group_name, db_name, owner_user_id, status, created_at, updated_at \
-         FROM mem_groups WHERE group_id = ?",
+         FROM mem_groups WHERE group_id = ? AND status = 'active'",
     )
     .bind(group_id)
     .fetch_optional(pool)
@@ -294,6 +294,16 @@ pub async fn create_group(
     let db_name = req
         .db_name
         .unwrap_or_else(|| default_group_db_name(&group_id));
+    if db_name.len() > 128
+        || !db_name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "db_name must be 1-128 chars of [A-Za-z0-9_]".into(),
+        ));
+    }
     let now = chrono::Utc::now().naive_utc();
 
     let mut members = req.members;
@@ -321,49 +331,54 @@ pub async fn create_group(
     .await
     .map_err(api_err)?;
 
-    sqlx::query(
-        "INSERT INTO mem_groups (group_id, group_name, db_name, owner_user_id, status, created_at, updated_at) \
-         VALUES (?, ?, ?, ?, 'active', ?, ?)",
-    )
-    .bind(&group_id)
-    .bind(&req.group_name)
-    .bind(&db_name)
-    .bind(&auth.user_id)
-    .bind(now)
-    .bind(now)
-    .execute(pool)
-    .await
-    .map_err(api_err)?;
-
-    // Insert members into mem_group_members
-    for member in &members {
-        let role = if member == &auth.user_id {
-            "owner"
-        } else {
-            "member"
-        };
+    let setup_result: Result<(), (StatusCode, String)> = async {
         sqlx::query(
-            "INSERT INTO mem_group_members (group_id, user_id, role, is_active, joined_at) \
-             VALUES (?, ?, ?, 1, ?)",
+            "INSERT INTO mem_groups (group_id, group_name, db_name, owner_user_id, status, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, 'active', ?, ?)",
         )
         .bind(&group_id)
-        .bind(member)
-        .bind(role)
+        .bind(&req.group_name)
+        .bind(&db_name)
+        .bind(&auth.user_id)
+        .bind(now)
         .bind(now)
         .execute(pool)
         .await
         .map_err(api_err)?;
-    }
 
-    let group_store = router.routed_store_for_db_name(&db_name).map_err(api_err)?;
-    group_store.migrate_user().await.map_err(api_err)?;
-
-    if let Some(seed) = req.seed.as_ref() {
-        if let Err(err) = seed_group_memories(router, &auth, &group_id, &db_name, seed, pool).await
-        {
-            cleanup_failed_group_creation(pool, &group_id, &db_name).await;
-            return Err(err);
+        for member in &members {
+            let role = if member == &auth.user_id {
+                "owner"
+            } else {
+                "member"
+            };
+            sqlx::query(
+                "INSERT INTO mem_group_members (group_id, user_id, role, is_active, joined_at) \
+                 VALUES (?, ?, ?, 1, ?)",
+            )
+            .bind(&group_id)
+            .bind(member)
+            .bind(role)
+            .bind(now)
+            .execute(pool)
+            .await
+            .map_err(api_err)?;
         }
+
+        let group_store = router.routed_store_for_db_name(&db_name).map_err(api_err)?;
+        group_store.migrate_user().await.map_err(api_err)?;
+
+        if let Some(seed) = req.seed.as_ref() {
+            seed_group_memories(router, &auth, &group_id, &db_name, seed, pool).await?;
+        }
+
+        Ok(())
+    }
+    .await;
+
+    if let Err(err) = setup_result {
+        cleanup_failed_group_creation(pool, &group_id, &db_name).await;
+        return Err(err);
     }
 
     let group = load_group(pool, &group_id).await?.ok_or((

--- a/memoria/crates/memoria-api/src/routes/groups.rs
+++ b/memoria/crates/memoria-api/src/routes/groups.rs
@@ -1,0 +1,642 @@
+//! User-facing group management endpoints.
+//! Any authenticated user can create groups, manage members (if owner), and delete groups.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use memoria_storage::DbRouter;
+use serde::{Deserialize, Serialize};
+use sqlx::{MySqlPool, Row};
+
+use crate::{auth::AuthUser, routes::memory::api_err, state::AppState};
+
+// ── Request / Response types ─────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct CreateGroupRequest {
+    pub group_name: String,
+    /// Initial members (besides the creator). Creator is always added.
+    #[serde(default)]
+    pub members: Vec<String>,
+    /// Custom database name. Auto-generated if omitted.
+    pub db_name: Option<String>,
+    #[serde(default)]
+    pub seed: Option<CreateGroupSeedRequest>,
+}
+
+#[derive(Deserialize)]
+pub struct CreateGroupSeedRequest {
+    pub db_name: String,
+    #[serde(default = "default_seed_mode")]
+    pub mode: String,
+}
+
+#[derive(Serialize, Clone)]
+pub struct GroupEntry {
+    pub group_id: String,
+    pub group_name: String,
+    pub db_name: String,
+    pub owner_user_id: String,
+    pub members: Vec<String>,
+    pub status: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+fn default_seed_mode() -> String {
+    "active_only".to_string()
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+fn get_shared_pool(state: &AppState) -> Result<&MySqlPool, (StatusCode, String)> {
+    state
+        .auth_pool
+        .as_ref()
+        .or_else(|| state.service.sql_store.as_ref().map(|s| s.pool()))
+        .ok_or((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "No shared SQL pool".into(),
+        ))
+}
+
+fn make_group_id() -> String {
+    format!("grp_{}", &uuid::Uuid::new_v4().simple().to_string()[..12])
+}
+
+fn default_group_db_name(group_id: &str) -> String {
+    format!("mem_grp_{}", group_id.trim_start_matches("grp_"))
+}
+
+/// Load active member user_ids for a group from mem_group_members.
+async fn load_group_member_ids(
+    pool: &MySqlPool,
+    group_id: &str,
+) -> Result<Vec<String>, (StatusCode, String)> {
+    let rows = sqlx::query(
+        "SELECT user_id FROM mem_group_members WHERE group_id = ? AND is_active = 1 ORDER BY user_id",
+    )
+    .bind(group_id)
+    .fetch_all(pool)
+    .await
+    .map_err(api_err)?;
+    Ok(rows
+        .iter()
+        .map(|r| r.try_get::<String, _>("user_id").unwrap_or_default())
+        .collect())
+}
+
+async fn load_group(
+    pool: &MySqlPool,
+    group_id: &str,
+) -> Result<Option<GroupEntry>, (StatusCode, String)> {
+    let row = sqlx::query(
+        "SELECT group_id, group_name, db_name, owner_user_id, status, created_at, updated_at \
+         FROM mem_groups WHERE group_id = ?",
+    )
+    .bind(group_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(api_err)?;
+    match row {
+        None => Ok(None),
+        Some(row) => {
+            let gid: String = row.try_get("group_id").map_err(api_err)?;
+            let members = load_group_member_ids(pool, &gid).await?;
+            Ok(Some(GroupEntry {
+                group_id: gid,
+                group_name: row.try_get("group_name").map_err(api_err)?,
+                db_name: row.try_get("db_name").map_err(api_err)?,
+                owner_user_id: row.try_get("owner_user_id").map_err(api_err)?,
+                members,
+                status: row.try_get("status").map_err(api_err)?,
+                created_at: row
+                    .try_get::<chrono::NaiveDateTime, _>("created_at")
+                    .map_err(api_err)?
+                    .to_string(),
+                updated_at: row
+                    .try_get::<chrono::NaiveDateTime, _>("updated_at")
+                    .map_err(api_err)?
+                    .to_string(),
+            }))
+        }
+    }
+}
+
+/// Verify the caller is the owner of the group. Returns the loaded group on success.
+async fn require_owner(
+    pool: &MySqlPool,
+    group_id: &str,
+    user_id: &str,
+) -> Result<GroupEntry, (StatusCode, String)> {
+    let group = load_group(pool, group_id)
+        .await?
+        .ok_or((StatusCode::NOT_FOUND, "Group not found".into()))?;
+    if group.owner_user_id != user_id {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "Only the group owner can perform this action".into(),
+        ));
+    }
+    Ok(group)
+}
+
+async fn seed_database_exists(
+    pool: &MySqlPool,
+    db_name: &str,
+) -> Result<bool, (StatusCode, String)> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = ?",
+    )
+    .bind(db_name)
+    .fetch_one(pool)
+    .await
+    .map_err(api_err)?;
+    Ok(count > 0)
+}
+
+async fn current_scope_db_name(
+    pool: &MySqlPool,
+    router: &DbRouter,
+    auth: &AuthUser,
+) -> Result<String, (StatusCode, String)> {
+    if auth.is_group_scoped() {
+        return router.group_db_name(auth.scope_id()).await.map_err(api_err);
+    }
+
+    let row = sqlx::query(
+        "SELECT db_name FROM mem_user_registry WHERE user_id = ? AND status = 'active'",
+    )
+    .bind(&auth.user_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(api_err)?;
+    Ok(row
+        .and_then(|row| row.try_get::<String, _>("db_name").ok())
+        .unwrap_or_else(|| DbRouter::user_db_name_for_id(&auth.user_id)))
+}
+
+async fn seed_group_memories(
+    router: &DbRouter,
+    auth: &AuthUser,
+    target_group_id: &str,
+    target_db_name: &str,
+    seed: &CreateGroupSeedRequest,
+    pool: &MySqlPool,
+) -> Result<usize, (StatusCode, String)> {
+    if seed.db_name.trim().is_empty() {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "seed.db_name must not be empty".into(),
+        ));
+    }
+    if seed.mode != "active_only" {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "seed.mode must be 'active_only'".into(),
+        ));
+    }
+    if seed.db_name == target_db_name {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "seed.db_name must differ from the target group db".into(),
+        ));
+    }
+
+    let accessible_db_name = current_scope_db_name(pool, router, auth).await?;
+    if seed.db_name != accessible_db_name {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "seed db is not accessible by the current key".into(),
+        ));
+    }
+    if !seed_database_exists(pool, &seed.db_name).await? {
+        return Err((StatusCode::NOT_FOUND, "seed database not found".into()));
+    }
+
+    let source_scope_id = if auth.is_group_scoped() {
+        auth.scope_id().to_string()
+    } else {
+        auth.user_id.clone()
+    };
+    let source_store = router
+        .routed_store_for_db_name(&seed.db_name)
+        .map_err(api_err)?;
+    let source_table = source_store.qualified_table("mem_memories");
+    let target_store = router
+        .routed_store_for_db_name(target_db_name)
+        .map_err(api_err)?;
+    let target_table = target_store.qualified_table("mem_memories");
+    let fallback_author_id = if auth.is_group_scoped() {
+        None
+    } else {
+        Some(auth.user_id.clone())
+    };
+    let result = sqlx::query(&format!(
+        "INSERT INTO {target_table} \
+         (memory_id, user_id, author_id, memory_type, content, embedding, session_id, \
+          source_event_ids, extra_metadata, is_active, superseded_by, \
+          trust_tier, initial_confidence, observed_at, created_at, updated_at) \
+         SELECT memory_id, ?, COALESCE(author_id, ?), memory_type, content, embedding, session_id, \
+                source_event_ids, extra_metadata, is_active, superseded_by, \
+                trust_tier, initial_confidence, observed_at, created_at, NOW(6) \
+         FROM {source_table} WHERE user_id = ? AND is_active = 1 \
+         ORDER BY memory_id DESC"
+    ))
+    .bind(target_group_id)
+    .bind(fallback_author_id)
+    .bind(&source_scope_id)
+    .execute(pool)
+    .await
+    .map_err(api_err)?;
+    Ok(result.rows_affected() as usize)
+}
+
+async fn cleanup_failed_group_creation(pool: &MySqlPool, group_id: &str, db_name: &str) {
+    let _ = sqlx::query("DELETE FROM mem_group_members WHERE group_id = ?")
+        .bind(group_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM mem_groups WHERE group_id = ?")
+        .bind(group_id)
+        .execute(pool)
+        .await;
+    let safe_db = db_name.replace('`', "``");
+    let _ = sqlx::query(&format!("DROP DATABASE IF EXISTS `{safe_db}`"))
+        .execute(pool)
+        .await;
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────
+
+/// POST /v1/groups — create a new group (caller becomes owner)
+pub async fn create_group(
+    auth: AuthUser,
+    State(state): State<AppState>,
+    Json(req): Json<CreateGroupRequest>,
+) -> Result<(StatusCode, Json<GroupEntry>), (StatusCode, String)> {
+    if req.group_name.trim().is_empty() {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "group_name must not be empty".into(),
+        ));
+    }
+    let pool = get_shared_pool(&state)?;
+    let router = state
+        .service
+        .db_router
+        .as_ref()
+        .ok_or((StatusCode::SERVICE_UNAVAILABLE, "DB router required".into()))?;
+
+    let group_id = make_group_id();
+    let db_name = req
+        .db_name
+        .unwrap_or_else(|| default_group_db_name(&group_id));
+    let now = chrono::Utc::now().naive_utc();
+
+    let mut members = req.members;
+    if !members.iter().any(|m| m == &auth.user_id) {
+        members.push(auth.user_id.clone());
+    }
+    members.sort();
+    members.dedup();
+
+    // Validate all initial members (except creator, who may be new) are registered
+    let non_creator: Vec<String> = members
+        .iter()
+        .filter(|m| *m != &auth.user_id)
+        .cloned()
+        .collect();
+    if !non_creator.is_empty() {
+        require_registered_users(pool, &non_creator).await?;
+    }
+
+    sqlx::raw_sql(&format!(
+        "CREATE DATABASE IF NOT EXISTS `{}`",
+        db_name.replace('`', "``")
+    ))
+    .execute(pool)
+    .await
+    .map_err(api_err)?;
+
+    sqlx::query(
+        "INSERT INTO mem_groups (group_id, group_name, db_name, owner_user_id, status, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, 'active', ?, ?)",
+    )
+    .bind(&group_id)
+    .bind(&req.group_name)
+    .bind(&db_name)
+    .bind(&auth.user_id)
+    .bind(now)
+    .bind(now)
+    .execute(pool)
+    .await
+    .map_err(api_err)?;
+
+    // Insert members into mem_group_members
+    for member in &members {
+        let role = if member == &auth.user_id {
+            "owner"
+        } else {
+            "member"
+        };
+        sqlx::query(
+            "INSERT INTO mem_group_members (group_id, user_id, role, is_active, joined_at) \
+             VALUES (?, ?, ?, 1, ?)",
+        )
+        .bind(&group_id)
+        .bind(member)
+        .bind(role)
+        .bind(now)
+        .execute(pool)
+        .await
+        .map_err(api_err)?;
+    }
+
+    let group_store = router.routed_store_for_db_name(&db_name).map_err(api_err)?;
+    group_store.migrate_user().await.map_err(api_err)?;
+
+    if let Some(seed) = req.seed.as_ref() {
+        if let Err(err) = seed_group_memories(router, &auth, &group_id, &db_name, seed, pool).await
+        {
+            cleanup_failed_group_creation(pool, &group_id, &db_name).await;
+            return Err(err);
+        }
+    }
+
+    let group = load_group(pool, &group_id).await?.ok_or((
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "group creation verification failed".into(),
+    ))?;
+    Ok((StatusCode::CREATED, Json(group)))
+}
+
+/// GET /v1/groups — list groups the caller belongs to
+pub async fn list_my_groups(
+    auth: AuthUser,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<GroupEntry>>, (StatusCode, String)> {
+    let pool = get_shared_pool(&state)?;
+    let rows = sqlx::query(
+        "SELECT DISTINCT g.group_id, g.group_name, g.db_name, g.owner_user_id, \
+                g.status, g.created_at, g.updated_at \
+         FROM mem_groups g \
+         JOIN mem_group_members m ON g.group_id = m.group_id \
+         WHERE g.status = 'active' AND m.user_id = ? AND m.is_active = 1 \
+         ORDER BY g.created_at DESC",
+    )
+    .bind(&auth.user_id)
+    .fetch_all(pool)
+    .await
+    .map_err(api_err)?;
+
+    let mut groups = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let gid: String = row.try_get("group_id").map_err(api_err)?;
+        let members = load_group_member_ids(pool, &gid).await?;
+        groups.push(GroupEntry {
+            group_id: gid,
+            group_name: row.try_get("group_name").map_err(api_err)?,
+            db_name: row.try_get("db_name").map_err(api_err)?,
+            owner_user_id: row.try_get("owner_user_id").map_err(api_err)?,
+            members,
+            status: row.try_get("status").map_err(api_err)?,
+            created_at: row
+                .try_get::<chrono::NaiveDateTime, _>("created_at")
+                .map_err(api_err)?
+                .to_string(),
+            updated_at: row
+                .try_get::<chrono::NaiveDateTime, _>("updated_at")
+                .map_err(api_err)?
+                .to_string(),
+        });
+    }
+    Ok(Json(groups))
+}
+
+/// GET /v1/groups/:group_id — get a group (must be a member)
+pub async fn get_group(
+    auth: AuthUser,
+    State(state): State<AppState>,
+    Path(group_id): Path<String>,
+) -> Result<Json<GroupEntry>, (StatusCode, String)> {
+    let pool = get_shared_pool(&state)?;
+    let group = load_group(pool, &group_id)
+        .await?
+        .ok_or((StatusCode::NOT_FOUND, "Group not found".into()))?;
+    if !group.members.iter().any(|m| m == &auth.user_id) {
+        return Err((StatusCode::FORBIDDEN, "Not a member of this group".into()));
+    }
+    Ok(Json(group))
+}
+
+/// Verify that every user_id in `user_ids` exists in mem_user_registry with status = 'active'.
+/// Returns an error naming the first unknown user.
+async fn require_registered_users(
+    pool: &MySqlPool,
+    user_ids: &[String],
+) -> Result<(), (StatusCode, String)> {
+    for uid in user_ids {
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM mem_user_registry WHERE user_id = ? AND status = 'active'",
+        )
+        .bind(uid)
+        .fetch_one(pool)
+        .await
+        .map_err(api_err)?;
+        if count == 0 {
+            return Err((
+                StatusCode::UNPROCESSABLE_ENTITY,
+                format!("user '{uid}' is not registered"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// POST /v1/groups/:group_id/members/:user_id — invite/add a member (owner only)
+pub async fn add_member(
+    auth: AuthUser,
+    State(state): State<AppState>,
+    Path((group_id, target_user_id)): Path<(String, String)>,
+) -> Result<Json<GroupEntry>, (StatusCode, String)> {
+    let pool = get_shared_pool(&state)?;
+    let _group = require_owner(pool, &group_id, &auth.user_id).await?;
+
+    require_registered_users(pool, std::slice::from_ref(&target_user_id)).await?;
+
+    // Check if already an active member
+    let existing: Option<(i8,)> = sqlx::query_as(
+        "SELECT is_active FROM mem_group_members WHERE group_id = ? AND user_id = ?",
+    )
+    .bind(&group_id)
+    .bind(&target_user_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(api_err)?;
+
+    let now = chrono::Utc::now().naive_utc();
+    match existing {
+        Some((1,)) => {
+            return Err((
+                StatusCode::CONFLICT,
+                format!("{target_user_id} is already a member"),
+            ));
+        }
+        Some(_) => {
+            // Re-activate previously removed member
+            sqlx::query(
+                "UPDATE mem_group_members SET is_active = 1, removed_at = NULL, joined_at = ? \
+                 WHERE group_id = ? AND user_id = ?",
+            )
+            .bind(now)
+            .bind(&group_id)
+            .bind(&target_user_id)
+            .execute(pool)
+            .await
+            .map_err(api_err)?;
+        }
+        None => {
+            sqlx::query(
+                "INSERT INTO mem_group_members (group_id, user_id, role, is_active, joined_at) \
+                 VALUES (?, ?, 'member', 1, ?)",
+            )
+            .bind(&group_id)
+            .bind(&target_user_id)
+            .bind(now)
+            .execute(pool)
+            .await
+            .map_err(api_err)?;
+        }
+    }
+
+    sqlx::query("UPDATE mem_groups SET updated_at = ? WHERE group_id = ?")
+        .bind(now)
+        .bind(&group_id)
+        .execute(pool)
+        .await
+        .map_err(api_err)?;
+
+    let group = load_group(pool, &group_id).await?.ok_or((
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "group update failed".into(),
+    ))?;
+    Ok(Json(group))
+}
+
+/// DELETE /v1/groups/:group_id/members/:user_id — remove a member (owner only)
+pub async fn remove_member(
+    auth: AuthUser,
+    State(state): State<AppState>,
+    Path((group_id, target_user_id)): Path<(String, String)>,
+) -> Result<Json<GroupEntry>, (StatusCode, String)> {
+    let pool = get_shared_pool(&state)?;
+    let group = require_owner(pool, &group_id, &auth.user_id).await?;
+
+    if target_user_id == group.owner_user_id {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "Cannot remove the group owner".into(),
+        ));
+    }
+
+    let now = chrono::Utc::now().naive_utc();
+
+    // Soft-delete from mem_group_members
+    sqlx::query(
+        "UPDATE mem_group_members SET is_active = 0, removed_at = ? \
+         WHERE group_id = ? AND user_id = ? AND is_active = 1",
+    )
+    .bind(now)
+    .bind(&group_id)
+    .bind(&target_user_id)
+    .execute(pool)
+    .await
+    .map_err(api_err)?;
+
+    sqlx::query("UPDATE mem_groups SET updated_at = ? WHERE group_id = ?")
+        .bind(now)
+        .bind(&group_id)
+        .execute(pool)
+        .await
+        .map_err(api_err)?;
+
+    // Deactivate & invalidate keys for the removed user
+    let key_rows = sqlx::query(
+        "SELECT key_hash FROM mem_api_keys WHERE group_id = ? AND user_id = ? AND is_active = 1",
+    )
+    .bind(&group_id)
+    .bind(&target_user_id)
+    .fetch_all(pool)
+    .await
+    .map_err(api_err)?;
+    for row in &key_rows {
+        if let Ok(key_hash) = row.try_get::<String, _>("key_hash") {
+            state.api_key_cache.invalidate(&key_hash);
+        }
+    }
+    sqlx::query(
+        "UPDATE mem_api_keys SET is_active = 0 WHERE group_id = ? AND user_id = ? AND is_active = 1",
+    )
+    .bind(&group_id)
+    .bind(&target_user_id)
+    .execute(pool)
+    .await
+    .map_err(api_err)?;
+
+    let group = load_group(pool, &group_id).await?.ok_or((
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "group update failed".into(),
+    ))?;
+    Ok(Json(group))
+}
+
+/// DELETE /v1/groups/:group_id — soft-delete a group (owner only)
+pub async fn delete_group(
+    auth: AuthUser,
+    State(state): State<AppState>,
+    Path(group_id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let pool = get_shared_pool(&state)?;
+    let group = require_owner(pool, &group_id, &auth.user_id).await?;
+
+    let now = chrono::Utc::now().naive_utc();
+    sqlx::query("UPDATE mem_groups SET status = 'deleted', updated_at = ? WHERE group_id = ?")
+        .bind(now)
+        .bind(&group_id)
+        .execute(pool)
+        .await
+        .map_err(api_err)?;
+
+    // Deactivate all API keys for this group & invalidate cache
+    let key_rows =
+        sqlx::query("SELECT key_hash FROM mem_api_keys WHERE group_id = ? AND is_active = 1")
+            .bind(&group_id)
+            .fetch_all(pool)
+            .await
+            .map_err(api_err)?;
+    for row in &key_rows {
+        if let Ok(key_hash) = row.try_get::<String, _>("key_hash") {
+            state.api_key_cache.invalidate(&key_hash);
+        }
+    }
+    sqlx::query("UPDATE mem_api_keys SET is_active = 0 WHERE group_id = ? AND is_active = 1")
+        .bind(&group_id)
+        .execute(pool)
+        .await
+        .map_err(api_err)?;
+
+    // Drop the group database
+    let safe_db = group.db_name.replace('`', "``");
+    sqlx::query(&format!("DROP DATABASE IF EXISTS `{safe_db}`"))
+        .execute(pool)
+        .await
+        .map_err(api_err)?;
+
+    Ok(Json(serde_json::json!({
+        "group_id": group_id,
+        "status": "deleted",
+    })))
+}

--- a/memoria/crates/memoria-api/src/routes/mcp.rs
+++ b/memoria/crates/memoria-api/src/routes/mcp.rs
@@ -133,14 +133,12 @@ pub async fn mcp_handler(
                 RpcMeta::err($code),
             );
             if let Some(reporter) = &state.stats_reporter {
-                reporter.report(
-                    memoria_service::stats_reporter::StatsEvent::ApiCallLogged {
-                        user_id: auth.user_id.clone(),
-                        path: $path.to_string(),
-                        is_mcp: true,
-                        is_success: false,
-                    },
-                );
+                reporter.report(memoria_service::stats_reporter::StatsEvent::ApiCallLogged {
+                    user_id: auth.user_id.clone(),
+                    path: $path.to_string(),
+                    is_mcp: true,
+                    is_success: false,
+                });
             }
             return Json($body).into_response();
         }};
@@ -206,6 +204,7 @@ pub async fn mcp_handler(
         None
     };
     let user_id = auth.user_id.clone();
+    let scope_id = auth.scope_id.clone();
     if let Some(tool) = tracked_tool.clone() {
         state.tool_usage_batcher.mark_used(user_id.clone(), tool);
     }
@@ -235,7 +234,7 @@ pub async fn mcp_handler(
             params,
             state.service.clone(),
             state.git.clone(),
-            user_id.clone(),
+            scope_id.clone(),
         )
         .await;
         let rpc = match &dispatch_result {
@@ -244,7 +243,7 @@ pub async fn mcp_handler(
         };
         if dispatch_result.is_ok() {
             if let Some(mask) = tracked_tool.as_deref().and_then(mcp_tool_dirty_mask) {
-                spawn_metrics_dirty_mark(state.clone(), user_id.clone(), mask);
+                spawn_metrics_dirty_mark(state.clone(), scope_id.clone(), mask);
             }
         }
         // Report accurate ops metrics using the real RPC path and success flag
@@ -270,7 +269,7 @@ pub async fn mcp_handler(
         params,
         state.service.clone(),
         state.git.clone(),
-        user_id.clone(),
+        scope_id.clone(),
     )
     .await
     {
@@ -294,7 +293,7 @@ pub async fn mcp_handler(
 
     if rpc.success {
         if let Some(mask) = tracked_tool.as_deref().and_then(mcp_tool_dirty_mask) {
-            spawn_metrics_dirty_mark(state.clone(), user_id.clone(), mask);
+            spawn_metrics_dirty_mark(state.clone(), scope_id.clone(), mask);
         }
     }
 

--- a/memoria/crates/memoria-api/src/routes/memory.rs
+++ b/memoria/crates/memoria-api/src/routes/memory.rs
@@ -105,7 +105,7 @@ pub async fn health_instance(
 
 pub async fn list_memories(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Query(q): Query<ListQuery>,
 ) -> ApiResult<ListResponse> {
     let limit = q.limit.clamp(1, 500);
@@ -118,7 +118,7 @@ pub async fn list_memories(
     let mut memories = state
         .service
         .list_active_paged(
-            &user_id,
+            auth.scope_id(),
             fetch_limit,
             q.memory_type.as_deref(),
             q.session_id.as_deref(),
@@ -139,7 +139,7 @@ pub async fn list_memories(
 
 pub async fn store_memory(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<StoreRequest>,
 ) -> Result<(StatusCode, Json<MemoryResponse>), (StatusCode, String)> {
     if req.content.is_empty() {
@@ -168,16 +168,22 @@ pub async fn store_memory(
         .map(|s| chrono::DateTime::parse_from_rfc3339(s).map(|dt| dt.with_timezone(&chrono::Utc)))
         .transpose()
         .map_err(|e| (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()))?;
+    let author = if auth.group_id.is_some() {
+        Some(auth.user_id.clone())
+    } else {
+        None
+    };
     let m = state
         .service
         .store_memory(
-            &user_id,
+            auth.scope_id(),
             &req.content,
             mt,
             req.session_id,
             tier,
             observed_at,
             req.initial_confidence,
+            author,
         )
         .await
         .map_err(|e| {
@@ -191,7 +197,7 @@ pub async fn store_memory(
 
 pub async fn batch_store(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<BatchStoreRequest>,
 ) -> Result<(StatusCode, Json<Vec<MemoryResponse>>), (StatusCode, String)> {
     if req.memories.len() > 100 {
@@ -232,9 +238,14 @@ pub async fn batch_store(
         validated.push((content, mt, session_id, tier));
     }
 
+    let author = if auth.group_id.is_some() {
+        Some(auth.user_id.clone())
+    } else {
+        None
+    };
     let results = state
         .service
-        .store_batch(&user_id, validated)
+        .store_batch(auth.scope_id(), validated, author)
         .await
         .map_err(api_err)?;
     Ok((
@@ -245,7 +256,7 @@ pub async fn batch_store(
 
 pub async fn retrieve(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<RetrieveRequest>,
 ) -> ApiResult<serde_json::Value> {
     req.validate()
@@ -260,7 +271,7 @@ pub async fn retrieve(
         let (results, explain) = state
             .service
             .retrieve_explain_level_with_options(
-                &user_id,
+                auth.scope_id(),
                 &req.query,
                 top_k,
                 level,
@@ -275,7 +286,7 @@ pub async fn retrieve(
     } else {
         let results = state
             .service
-            .retrieve_with_options(&user_id, &req.query, top_k, &retrieve_options)
+            .retrieve_with_options(auth.scope_id(), &req.query, top_k, &retrieve_options)
             .await
             .map_err(api_err)?;
         let items: Vec<MemoryResponse> = results.into_iter().map(Into::into).collect();
@@ -285,7 +296,7 @@ pub async fn retrieve(
 
 pub async fn search(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<SearchRequest>,
 ) -> ApiResult<serde_json::Value> {
     req.validate()
@@ -299,7 +310,7 @@ pub async fn search(
         let (results, explain) = state
             .service
             .retrieve_explain_level_with_options(
-                &user_id,
+                auth.scope_id(),
                 &req.query,
                 top_k,
                 level,
@@ -314,7 +325,7 @@ pub async fn search(
     } else {
         let results = state
             .service
-            .retrieve_with_options(&user_id, &req.query, top_k, &retrieve_options)
+            .retrieve_with_options(auth.scope_id(), &req.query, top_k, &retrieve_options)
             .await
             .map_err(api_err)?;
         Ok(Json(serde_json::json!(results
@@ -326,19 +337,19 @@ pub async fn search(
 
 pub async fn get_memory(
     State(state): State<AppState>,
-    AuthUser { user_id, is_master }: AuthUser,
+    auth: AuthUser,
     Path(id): Path<String>,
 ) -> ApiResult<Option<MemoryResponse>> {
     let owned = state
         .service
-        .get_for_user(&user_id, &id)
+        .get_for_user(auth.scope_id(), &id)
         .await
         .map_err(api_err_typed)?;
     if let Some(memory) = owned {
         return Ok(Json(Some(memory.into())));
     }
 
-    if !is_master {
+    if !auth.is_master {
         return Ok(Json(None));
     }
 
@@ -351,26 +362,26 @@ pub async fn get_memory(
 
 pub async fn correct_memory(
     State(state): State<AppState>,
-    AuthUser { user_id, is_master }: AuthUser,
+    auth: AuthUser,
     Path(id): Path<String>,
     Json(req): Json<CorrectRequest>,
 ) -> ApiResult<MemoryResponse> {
-    let effective_user_id = if is_master {
+    let effective_user_id = if auth.is_master {
         find_memory_any_user(&state, &id)
             .await?
             .map(|(owner_id, _)| owner_id)
-            .unwrap_or_else(|| user_id.clone())
+            .unwrap_or_else(|| auth.scope_id().to_string())
     } else {
         if state
             .service
-            .get_for_user(&user_id, &id)
+            .get_for_user(auth.scope_id(), &id)
             .await
             .map_err(api_err_typed)?
             .is_none()
         {
             return Err((StatusCode::NOT_FOUND, "Memory not found".to_string()));
         }
-        user_id.clone()
+        auth.scope_id().to_string()
     };
     let m = state
         .service
@@ -382,7 +393,7 @@ pub async fn correct_memory(
 
 pub async fn correct_by_query(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<CorrectByQueryRequest>,
 ) -> ApiResult<MemoryResponse> {
     req.validate()
@@ -392,7 +403,7 @@ pub async fn correct_by_query(
         .map_err(|err| (StatusCode::UNPROCESSABLE_ENTITY, err))?;
     let results = state
         .service
-        .retrieve_with_options(&user_id, &req.query, 1, &retrieve_options)
+        .retrieve_with_options(auth.scope_id(), &req.query, 1, &retrieve_options)
         .await
         .map_err(api_err)?;
     let found = results.into_iter().next().ok_or_else(|| {
@@ -403,7 +414,7 @@ pub async fn correct_by_query(
     })?;
     let m = state
         .service
-        .correct(&user_id, &found.memory_id, &req.new_content)
+        .correct(auth.scope_id(), &found.memory_id, &req.new_content)
         .await
         .map_err(api_err)?;
     Ok(Json(m.into()))
@@ -411,25 +422,25 @@ pub async fn correct_by_query(
 
 pub async fn delete_memory(
     State(state): State<AppState>,
-    AuthUser { user_id, is_master }: AuthUser,
+    auth: AuthUser,
     Path(id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    let effective_user_id = if is_master {
+    let effective_user_id = if auth.is_master {
         find_memory_any_user(&state, &id)
             .await?
             .map(|(owner_id, _)| owner_id)
-            .unwrap_or_else(|| user_id.clone())
+            .unwrap_or_else(|| auth.scope_id().to_string())
     } else {
         if state
             .service
-            .get_for_user(&user_id, &id)
+            .get_for_user(auth.scope_id(), &id)
             .await
             .map_err(api_err_typed)?
             .is_none()
         {
             return Err((StatusCode::NOT_FOUND, "Memory not found".to_string()));
         }
-        user_id.clone()
+        auth.scope_id().to_string()
     };
     let _ = state
         .service
@@ -441,7 +452,7 @@ pub async fn delete_memory(
 
 pub async fn purge_memories(
     State(state): State<AppState>,
-    AuthUser { user_id, is_master }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<PurgeRequest>,
 ) -> ApiResult<PurgeResponse> {
     let selector = req
@@ -449,17 +460,17 @@ pub async fn purge_memories(
         .map_err(|e| (StatusCode::UNPROCESSABLE_ENTITY, e))?;
     let result = match selector {
         PurgeSelector::MemoryIds(ids) => {
-            if !is_master {
+            if !auth.is_master {
                 for id in &ids {
                     let mem = state
                         .service
-                        .get_for_user(&user_id, id)
+                        .get_for_user(auth.scope_id(), id)
                         .await
                         .map_err(api_err)?
                         .ok_or_else(|| {
                             (StatusCode::NOT_FOUND, format!("Memory not found: {id}"))
                         })?;
-                    if mem.user_id != user_id {
+                    if !auth.is_group_scoped() && mem.user_id != auth.user_id {
                         return Err((StatusCode::FORBIDDEN, format!("Not your memory: {id}")));
                     }
                 }
@@ -467,13 +478,13 @@ pub async fn purge_memories(
             let id_refs: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
             state
                 .service
-                .purge_batch(&user_id, &id_refs)
+                .purge_batch(auth.scope_id(), &id_refs)
                 .await
                 .map_err(api_err)?
         }
         PurgeSelector::Topic(topic) => state
             .service
-            .purge_by_topic(&user_id, &topic)
+            .purge_by_topic(auth.scope_id(), &topic)
             .await
             .map_err(api_err)?,
         PurgeSelector::Session {
@@ -481,7 +492,7 @@ pub async fn purge_memories(
             memory_types,
         } => state
             .service
-            .purge_by_session_id(&user_id, &session_id, memory_types.as_deref())
+            .purge_by_session_id(auth.scope_id(), &session_id, memory_types.as_deref())
             .await
             .map_err(api_err)?,
         PurgeSelector::None => memoria_service::PurgeResult {
@@ -499,12 +510,12 @@ pub async fn purge_memories(
 
 pub async fn get_profile(
     State(state): State<AppState>,
-    AuthUser { user_id, is_master }: AuthUser,
+    auth: AuthUser,
     Path(target): Path<String>,
 ) -> ApiResult<serde_json::Value> {
-    let resolved = if target == "me" || target == user_id {
-        user_id
-    } else if is_master {
+    let resolved = if target == "me" || target == auth.user_id {
+        auth.scope_id().to_string()
+    } else if auth.is_master {
         target
     } else {
         return Err((
@@ -582,12 +593,12 @@ pub struct ObserveRequest {
 /// Without LLM: stores each non-empty assistant/user message as a semantic memory.
 pub async fn observe_turn(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<ObserveRequest>,
 ) -> ApiResult<serde_json::Value> {
     let (memories, has_llm) = state
         .service
-        .observe_turn(&user_id, &req.messages, req.session_id)
+        .observe_turn(auth.scope_id(), &req.messages, req.session_id)
         .await
         .map_err(api_err)?;
 
@@ -612,17 +623,17 @@ pub async fn observe_turn(
 /// GET /v1/memories/:id/history — version chain via superseded_by links.
 pub async fn get_memory_history(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Path(id): Path<String>,
 ) -> ApiResult<serde_json::Value> {
     use sqlx::Row;
 
     let sql = state
         .service
-        .user_sql_store(&user_id)
+        .user_sql_store(auth.scope_id())
         .await
         .map_err(api_err)?;
-    let table = sql.active_table(&user_id).await.map_err(api_err)?;
+    let table = sql.active_table(auth.scope_id()).await.map_err(api_err)?;
 
     let mut chain = Vec::new();
     let mut visited = std::collections::HashSet::new();
@@ -639,7 +650,7 @@ pub async fn get_memory_history(
             table
         ))
         .bind(&cid)
-        .bind(&user_id)
+        .bind(auth.scope_id())
         .fetch_optional(sql.pool())
         .await
         .map_err(api_err)?;
@@ -678,7 +689,7 @@ pub async fn get_memory_history(
                 table
             ))
             .bind(&prev_id)
-            .bind(&user_id)
+            .bind(auth.scope_id())
             .fetch_optional(sql.pool())
             .await
             .map_err(api_err)?;
@@ -728,7 +739,7 @@ pub struct PipelineCandidate {
 
 pub async fn run_pipeline(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<PipelineRequest>,
 ) -> ApiResult<serde_json::Value> {
     use crate::models::{parse_memory_type, parse_trust_tier};
@@ -757,7 +768,7 @@ pub async fn run_pipeline(
 
     let pipeline = MemoryPipeline::new(state.service.clone(), Some(state.git.clone()));
     let result = pipeline
-        .run(&user_id, candidates, req.sandbox_query.as_deref())
+        .run(auth.scope_id(), candidates, req.sandbox_query.as_deref())
         .await;
 
     Ok(Json(serde_json::json!({
@@ -786,13 +797,18 @@ pub struct FeedbackResponse {
 /// POST /v1/memories/:id/feedback — record explicit relevance feedback.
 pub async fn record_feedback(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Path(memory_id): Path<String>,
     Json(req): Json<FeedbackRequest>,
 ) -> Result<(StatusCode, Json<FeedbackResponse>), (StatusCode, String)> {
     let feedback_id = state
         .service
-        .record_feedback(&user_id, &memory_id, &req.signal, req.context.as_deref())
+        .record_feedback(
+            auth.scope_id(),
+            &memory_id,
+            &req.signal,
+            req.context.as_deref(),
+        )
         .await
         .map_err(api_err_typed)?;
     Ok((
@@ -808,11 +824,11 @@ pub async fn record_feedback(
 /// GET /v1/feedback/stats — get feedback statistics for the user.
 pub async fn get_feedback_stats(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
 ) -> ApiResult<serde_json::Value> {
     let stats = state
         .service
-        .get_feedback_stats(&user_id)
+        .get_feedback_stats(auth.scope_id())
         .await
         .map_err(api_err)?;
     Ok(Json(serde_json::json!(stats)))
@@ -821,11 +837,11 @@ pub async fn get_feedback_stats(
 /// GET /v1/feedback/by-tier — get feedback breakdown by trust tier.
 pub async fn get_feedback_by_tier(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
 ) -> ApiResult<serde_json::Value> {
     let breakdown = state
         .service
-        .get_feedback_by_tier(&user_id)
+        .get_feedback_by_tier(auth.scope_id())
         .await
         .map_err(api_err)?;
     Ok(Json(serde_json::json!({"breakdown": breakdown})))
@@ -834,15 +850,15 @@ pub async fn get_feedback_by_tier(
 /// GET /v1/retrieval-params — get user's adaptive retrieval parameters.
 pub async fn get_retrieval_params(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
 ) -> ApiResult<serde_json::Value> {
     let sql = state
         .service
-        .user_sql_store(&user_id)
+        .user_sql_store(auth.scope_id())
         .await
         .map_err(api_err)?;
     let params = sql
-        .get_user_retrieval_params(&user_id)
+        .get_user_retrieval_params(auth.scope_id())
         .await
         .map_err(api_err)?;
     Ok(Json(serde_json::to_value(params).unwrap()))
@@ -858,17 +874,17 @@ pub struct SetRetrievalParamsRequest {
 /// PUT /v1/retrieval-params — update user's adaptive retrieval parameters.
 pub async fn set_retrieval_params(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<SetRetrievalParamsRequest>,
 ) -> ApiResult<serde_json::Value> {
     let sql = state
         .service
-        .user_sql_store(&user_id)
+        .user_sql_store(auth.scope_id())
         .await
         .map_err(api_err)?;
 
     let mut params = sql
-        .get_user_retrieval_params(&user_id)
+        .get_user_retrieval_params(auth.scope_id())
         .await
         .map_err(api_err)?;
 
@@ -891,24 +907,24 @@ pub async fn set_retrieval_params(
 /// POST /v1/retrieval-params/tune — trigger auto-tuning of retrieval parameters.
 pub async fn tune_retrieval_params(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
 ) -> ApiResult<serde_json::Value> {
     use memoria_service::scoring::{DefaultScoringPlugin, ScoringPlugin};
 
     let sql = state
         .service
-        .user_sql_store(&user_id)
+        .user_sql_store(auth.scope_id())
         .await
         .map_err(api_err)?;
 
     let old_params = sql
-        .get_user_retrieval_params(&user_id)
+        .get_user_retrieval_params(auth.scope_id())
         .await
         .map_err(api_err)?;
 
     let plugin = DefaultScoringPlugin;
     match plugin
-        .tune_params(sql.as_ref(), &user_id)
+        .tune_params(sql.as_ref(), auth.scope_id())
         .await
         .map_err(api_err)?
     {
@@ -927,15 +943,15 @@ pub async fn tune_retrieval_params(
 
 pub async fn get_tool_usage(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
 ) -> ApiResult<serde_json::Value> {
-    let mut usage = state.tool_usage_batcher.get_user_tool_usage(&user_id);
+    let mut usage = state.tool_usage_batcher.get_user_tool_usage(&auth.user_id);
     if usage.is_empty() {
         state
             .tool_usage_batcher
-            .load_user_from_db(&state.service, &user_id)
+            .load_user_from_db(&state.service, &auth.user_id)
             .await;
-        usage = state.tool_usage_batcher.get_user_tool_usage(&user_id);
+        usage = state.tool_usage_batcher.get_user_tool_usage(&auth.user_id);
     }
     let items: Vec<serde_json::Value> = usage
         .into_iter()

--- a/memoria/crates/memoria-api/src/routes/mod.rs
+++ b/memoria/crates/memoria-api/src/routes/mod.rs
@@ -1,6 +1,7 @@
 pub mod admin;
 pub mod auth;
 pub mod governance;
+pub mod groups;
 pub mod mcp;
 pub mod memory;
 pub mod metrics;

--- a/memoria/crates/memoria-api/src/routes/sessions.rs
+++ b/memoria/crates/memoria-api/src/routes/sessions.rs
@@ -86,17 +86,20 @@ fn extract_json(text: &str) -> &str {
 
 async fn generate_and_store(
     state: &AppState,
-    user_id: &str,
+    scope_id: &str,
     session_id: &str,
     mode: &str,
     focus_topics: Option<&[String]>,
 ) -> Result<(String, String, bool, serde_json::Value), String> {
     let sql = state
         .service
-        .user_sql_store(user_id)
+        .user_sql_store(scope_id)
         .await
         .map_err(|e| e.to_string())?;
-    let table = sql.active_table(user_id).await.map_err(|e| e.to_string())?;
+    let table = sql
+        .active_table(scope_id)
+        .await
+        .map_err(|e| e.to_string())?;
     let llm = state
         .service
         .llm
@@ -109,7 +112,7 @@ async fn generate_and_store(
          ORDER BY created_at ASC"
     );
     let rows = sqlx::query(&query)
-        .bind(user_id)
+        .bind(scope_id)
         .bind(session_id)
         .fetch_all(sql.pool())
         .await
@@ -163,9 +166,10 @@ async fn generate_and_store(
         let m = state
             .service
             .store_memory(
-                user_id,
+                scope_id,
                 &content,
                 memoria_core::MemoryType::Episodic,
+                None,
                 None,
                 None,
                 None,
@@ -209,9 +213,10 @@ async fn generate_and_store(
         let m = state
             .service
             .store_memory(
-                user_id,
+                scope_id,
                 &content,
                 memoria_core::MemoryType::Episodic,
+                None,
                 None,
                 None,
                 None,
@@ -227,7 +232,7 @@ async fn generate_and_store(
 
 pub async fn create_session_summary(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Path(session_id): Path<String>,
     Json(req): Json<SessionSummaryRequest>,
 ) -> Result<Json<SessionSummaryResponse>, (StatusCode, String)> {
@@ -241,7 +246,7 @@ pub async fn create_session_summary(
     if req.sync {
         let result = generate_and_store(
             &state,
-            &user_id,
+            auth.scope_id(),
             &session_id,
             &req.mode,
             req.focus_topics.as_deref(),
@@ -267,13 +272,13 @@ pub async fn create_session_summary(
 
     let task_id = uuid::Uuid::new_v4().simple().to_string();
     task_store
-        .create_task(&task_id, &state.instance_id, &user_id)
+        .create_task(&task_id, &state.instance_id, &auth.user_id)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     let state_clone = state.clone();
     let tid = task_id.clone();
-    let uid = user_id.clone();
+    let uid = auth.scope_id().to_string();
     let sid = session_id.clone();
     let mode = req.mode.clone();
     let focus = req.focus_topics.clone();
@@ -314,7 +319,7 @@ pub async fn create_session_summary(
 
 pub async fn get_task_status(
     State(state): State<AppState>,
-    AuthUser { user_id, is_master }: AuthUser,
+    auth: AuthUser,
     Path(task_id): Path<String>,
 ) -> Result<Json<TaskStatus>, (StatusCode, String)> {
     let task_store = state.task_store.as_ref().ok_or((
@@ -329,7 +334,7 @@ pub async fn get_task_status(
 
     match task {
         Some(t) => {
-            if !is_master && t.user_id != user_id {
+            if !auth.is_master && t.user_id != auth.user_id {
                 return Err((StatusCode::FORBIDDEN, "Not your task".to_string()));
             }
             Ok(Json(TaskStatus {

--- a/memoria/crates/memoria-api/src/routes/snapshots.rs
+++ b/memoria/crates/memoria-api/src/routes/snapshots.rs
@@ -40,6 +40,13 @@ pub struct DiffSnapshotQuery {
     pub limit: Option<i64>,
 }
 
+#[derive(Deserialize, Default)]
+pub struct DiffBranchItemsQuery {
+    pub limit: Option<i64>,
+}
+
+pub type ApplyBranchRequest = memoria_git::ApplySelection;
+
 /// Delegate to git_tools::call for snapshot/branch operations.
 async fn git_call_text(
     state: &AppState,
@@ -197,6 +204,124 @@ fn format_branch_list_result(branches: &[Value]) -> String {
     format!("Branches:\n{text}")
 }
 
+/// Like `branch_table_name` but returns the raw table name (no db prefix or backticks),
+/// suitable for `data branch diff` which builds its own qualified identifiers.
+async fn branch_table_name_raw(
+    sql: &Arc<memoria_storage::SqlMemoryStore>,
+    scope_id: &str,
+    branch_name: &str,
+) -> Result<String, (StatusCode, String)> {
+    if branch_name == "main" {
+        return Ok("mem_memories".to_string());
+    }
+    for (name, table_name) in sql.list_branches(scope_id).await.map_err(api_err)? {
+        if name == branch_name {
+            return Ok(table_name);
+        }
+    }
+    Err((
+        StatusCode::NOT_FOUND,
+        format!("Branch not found: {branch_name}"),
+    ))
+}
+
+async fn branch_diff_items_payload(
+    state: &AppState,
+    scope_id: &str,
+    branch_name: &str,
+    limit: i64,
+) -> Result<Value, (StatusCode, String)> {
+    let sql = user_snapshot_store(state, scope_id).await?;
+    let git = user_git_service(&sql)?;
+    let branch_table_raw = branch_table_name_raw(&sql, scope_id, branch_name).await?;
+    let limit = limit.clamp(1, 500);
+
+    // Use MatrixOne native `data branch diff` + classify (with source-aware conflict detection)
+    let raw_rows = git
+        .diff_branch_rows(&branch_table_raw, "mem_memories", scope_id, limit * 3)
+        .await
+        .map_err(api_err)?;
+    let classified = memoria_git::classify_diff_rows(raw_rows, &branch_table_raw);
+
+    let item_to_json = |item: &memoria_git::DiffItem| -> Value {
+        json!({
+            "memory_id": item.memory_id,
+            "content": item.content,
+            "memory_type": item.memory_type,
+            "author_id": item.author_id,
+        })
+    };
+
+    let added: Vec<Value> = classified
+        .added
+        .iter()
+        .take(limit as usize)
+        .map(item_to_json)
+        .collect();
+    let updated: Vec<Value> = classified
+        .updated
+        .iter()
+        .take(limit as usize)
+        .map(|pair| {
+            json!({
+                "memory_id": pair.new_memory_id,
+                "content": pair.new_content,
+                "memory_type": pair.memory_type,
+                "old_memory_id": pair.old_memory_id,
+                "old_content": pair.old_content,
+                "author_id": pair.author_id,
+            })
+        })
+        .collect();
+    let removed: Vec<Value> = classified
+        .removed
+        .iter()
+        .take(limit as usize)
+        .map(item_to_json)
+        .collect();
+    let conflicts: Vec<Value> = classified
+        .conflicts
+        .iter()
+        .take(limit as usize)
+        .map(|c| {
+            json!({
+                "memory_id": c.memory_id,
+                "branch": {
+                    "content": c.branch_side.content,
+                    "is_active": c.branch_side.is_active,
+                    "superseded_by": c.branch_side.superseded_by,
+                    "superseded_by_content": c.branch_side.superseded_by_content,
+                    "author_id": c.branch_side.author_id,
+                },
+                "main": {
+                    "content": c.main_side.content,
+                    "is_active": c.main_side.is_active,
+                    "superseded_by": c.main_side.superseded_by,
+                    "superseded_by_content": c.main_side.superseded_by_content,
+                    "author_id": c.main_side.author_id,
+                },
+            })
+        })
+        .collect();
+
+    let behind_main: Vec<Value> = classified
+        .behind_main
+        .iter()
+        .take(limit as usize)
+        .map(item_to_json)
+        .collect();
+
+    Ok(json!({
+        "branch": branch_name,
+        "against": "main",
+        "added": added,
+        "updated": updated,
+        "removed": removed,
+        "conflicts": conflicts,
+        "behind_main": behind_main,
+    }))
+}
+
 fn parse_created_snapshot_result(text: &str) -> Option<(String, String)> {
     let rest = text.strip_prefix("Snapshot '")?;
     let (name, timestamp) = rest.split_once("' created at ")?;
@@ -327,12 +452,12 @@ async fn resolve_snapshot_internal(
 
 pub async fn create_snapshot(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<CreateSnapshotRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, String)> {
     let result = git_call_text(
         &state,
-        &user_id,
+        auth.scope_id(),
         "memory_snapshot",
         json!({ "name": req.name }),
     )
@@ -349,16 +474,16 @@ pub async fn create_snapshot(
         body["created_at"] = json!(created_at.clone());
         body["timestamp"] = json!(created_at);
 
-        let sql = user_snapshot_store(&state, &user_id).await?;
+        let sql = user_snapshot_store(&state, auth.scope_id()).await?;
         let snapshots =
-            memoria_mcp::git_tools::visible_snapshots_for_user(&state.service, &user_id)
+            memoria_mcp::git_tools::visible_snapshots_for_user(&state.service, auth.scope_id())
                 .await
                 .map_err(api_err_typed)?;
         if let Some(snapshot) = snapshots
             .iter()
             .find(|snapshot| snapshot.display_name == display_name)
         {
-            body = snapshot_summary_value(&sql, &user_id, snapshot).await?;
+            body = snapshot_summary_value(&sql, auth.scope_id(), snapshot).await?;
             body["description"] = json!(req.description.clone());
             body["result"] = json!(result.clone());
         }
@@ -368,26 +493,26 @@ pub async fn create_snapshot(
 
 pub async fn list_snapshots(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Query(q): Query<ListSnapshotsQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     Ok(Json(
-        snapshot_list_payload(&state, &user_id, q.limit, q.offset).await?,
+        snapshot_list_payload(&state, auth.scope_id(), q.limit, q.offset).await?,
     ))
 }
 
 /// GET /v1/snapshots/:name — read snapshot detail with time-travel query
 pub async fn get_snapshot(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Path(name): Path<String>,
     Query(q): Query<GetSnapshotQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let sql = user_snapshot_store(&state, &user_id).await?;
+    let sql = user_snapshot_store(&state, auth.scope_id()).await?;
     let pool = sql.pool();
-    let table = sql.active_table(&user_id).await.map_err(api_err)?;
+    let table = sql.active_table(auth.scope_id()).await.map_err(api_err)?;
 
-    let snap_name = resolve_snapshot_internal(&state, &user_id, &name).await?;
+    let snap_name = resolve_snapshot_internal(&state, auth.scope_id(), &name).await?;
     let limit = q.limit.unwrap_or(50).min(500);
     let offset = q.offset.unwrap_or(0);
     let detail = q.detail.as_deref().unwrap_or("brief");
@@ -397,7 +522,7 @@ pub async fn get_snapshot(
         "SELECT COUNT(*) as cnt FROM {table} {{SNAPSHOT = '{snap_name}'}} WHERE user_id = ? AND is_active > 0"
     );
     let total: i64 = sqlx::query_scalar(&count_sql)
-        .bind(&user_id)
+        .bind(auth.scope_id())
         .fetch_one(pool)
         .await
         .map_err(api_err)?;
@@ -408,7 +533,7 @@ pub async fn get_snapshot(
          WHERE user_id = ? AND is_active > 0 GROUP BY memory_type"
     );
     let type_rows = sqlx::query(&type_sql)
-        .bind(&user_id)
+        .bind(auth.scope_id())
         .fetch_all(pool)
         .await
         .map_err(api_err)?;
@@ -432,7 +557,7 @@ pub async fn get_snapshot(
           WHERE user_id = ? AND is_active > 0 ORDER BY observed_at DESC LIMIT ? OFFSET ?"
     );
     let rows = sqlx::query(&mem_sql)
-        .bind(&user_id)
+        .bind(auth.scope_id())
         .bind(limit)
         .bind(offset)
         .fetch_all(pool)
@@ -494,26 +619,26 @@ pub async fn get_snapshot(
 /// GET /v1/snapshots/:name/diff — compare snapshot vs current state
 pub async fn diff_snapshot(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Path(name): Path<String>,
     Query(q): Query<DiffSnapshotQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let sql = user_snapshot_store(&state, &user_id).await?;
+    let sql = user_snapshot_store(&state, auth.scope_id()).await?;
     let pool = sql.pool();
-    let table = sql.active_table(&user_id).await.map_err(api_err)?;
+    let table = sql.active_table(auth.scope_id()).await.map_err(api_err)?;
 
-    let snap_name = resolve_snapshot_internal(&state, &user_id, &name).await?;
+    let snap_name = resolve_snapshot_internal(&state, auth.scope_id(), &name).await?;
     let limit = q.limit.unwrap_or(50).min(200);
 
     // Counts
     let snap_count: i64 = sqlx::query_scalar(&format!(
         "SELECT COUNT(*) FROM {table} {{SNAPSHOT = '{snap_name}'}} WHERE user_id = ? AND is_active > 0"
-    )).bind(&user_id).fetch_one(pool).await.map_err(api_err)?;
+    )).bind(auth.scope_id()).fetch_one(pool).await.map_err(api_err)?;
 
     let curr_count: i64 = sqlx::query_scalar(&format!(
         "SELECT COUNT(*) FROM {table} WHERE user_id = ? AND is_active > 0"
     ))
-    .bind(&user_id)
+    .bind(auth.scope_id())
     .fetch_one(pool)
     .await
     .map_err(api_err)?;
@@ -525,7 +650,7 @@ pub async fn diff_snapshot(
           WHERE c.user_id = ? AND c.is_active > 0 AND s.memory_id IS NULL LIMIT ?"
     );
     let added_rows = sqlx::query(&added_sql)
-        .bind(&user_id)
+        .bind(auth.scope_id())
         .bind(limit)
         .fetch_all(pool)
         .await
@@ -538,7 +663,7 @@ pub async fn diff_snapshot(
           WHERE s.user_id = ? AND s.is_active > 0 AND c.memory_id IS NULL LIMIT ?"
     );
     let removed_rows = sqlx::query(&removed_sql)
-        .bind(&user_id)
+        .bind(auth.scope_id())
         .bind(limit)
         .fetch_all(pool)
         .await
@@ -570,12 +695,12 @@ pub async fn diff_snapshot(
 
 pub async fn delete_snapshot(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Path(name): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     git_call(
         &state,
-        &user_id,
+        auth.scope_id(),
         "memory_snapshot_delete",
         json!({ "names": name }),
     )
@@ -585,37 +710,46 @@ pub async fn delete_snapshot(
 
 pub async fn delete_snapshot_bulk(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<serde_json::Value>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let r = git_call(&state, &user_id, "memory_snapshot_delete", req).await?;
+    let r = git_call(&state, auth.scope_id(), "memory_snapshot_delete", req).await?;
     Ok(Json(r))
 }
 
 pub async fn rollback(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let r = git_call(&state, &user_id, "memory_rollback", json!({ "name": name })).await?;
+    let r = git_call(
+        &state,
+        auth.scope_id(),
+        "memory_rollback",
+        json!({ "name": name }),
+    )
+    .await?;
     Ok(Json(r))
 }
 
 pub async fn list_branches(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let sql = state
         .service
-        .user_sql_store(&user_id)
+        .user_sql_store(auth.scope_id())
         .await
         .map_err(api_err)?;
-    let active_branch = sql.active_branch_name(&user_id).await.map_err(api_err)?;
+    let active_branch = sql
+        .active_branch_name(auth.scope_id())
+        .await
+        .map_err(api_err)?;
     let mut branches = vec![json!({
         "name": "main",
         "active": active_branch == "main",
     })];
-    for (name, _table_name) in sql.list_branches(&user_id).await.map_err(api_err)? {
+    for (name, _table_name) in sql.list_branches(auth.scope_id()).await.map_err(api_err)? {
         branches.push(json!({
             "name": name,
             "active": name == active_branch,
@@ -636,12 +770,12 @@ pub async fn list_branches(
 
 pub async fn create_branch(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Json(req): Json<CreateBranchRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, String)> {
     let r = git_call(
         &state,
-        &user_id,
+        auth.scope_id(),
         "memory_branch",
         json!({
             "name": req.name,
@@ -650,27 +784,39 @@ pub async fn create_branch(
         }),
     )
     .await?;
+    // MCP returns success with "already exists" text — surface as 409 Conflict
+    if let Some(text) = r["content"][0]["text"].as_str() {
+        if text.contains("already exists") {
+            return Err((StatusCode::CONFLICT, text.to_string()));
+        }
+    }
     Ok((StatusCode::CREATED, Json(r)))
 }
 
 pub async fn checkout_branch(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let r = git_call(&state, &user_id, "memory_checkout", json!({ "name": name })).await?;
+    let r = git_call(
+        &state,
+        auth.scope_id(),
+        "memory_checkout",
+        json!({ "name": name }),
+    )
+    .await?;
     Ok(Json(r))
 }
 
 pub async fn merge_branch(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Path(name): Path<String>,
     Json(req): Json<MergeRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let r = git_call(
         &state,
-        &user_id,
+        auth.scope_id(),
         "memory_merge",
         json!({ "source": name, "strategy": req.strategy }),
     )
@@ -680,21 +826,80 @@ pub async fn merge_branch(
 
 pub async fn diff_branch(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let r = git_call(&state, &user_id, "memory_diff", json!({ "source": name })).await?;
+    let r = git_call(
+        &state,
+        auth.scope_id(),
+        "memory_diff",
+        json!({ "source": name }),
+    )
+    .await?;
     Ok(Json(r))
+}
+
+pub async fn diff_branch_items(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(name): Path<String>,
+    Query(q): Query<DiffBranchItemsQuery>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    Ok(Json(
+        branch_diff_items_payload(&state, auth.scope_id(), &name, q.limit.unwrap_or(100)).await?,
+    ))
+}
+
+pub async fn apply_branch(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(name): Path<String>,
+    Json(req): Json<ApplyBranchRequest>,
+) -> Result<Json<memoria_git::ApplyResult>, (StatusCode, String)> {
+    if name == "main" {
+        return Err((StatusCode::BAD_REQUEST, "Cannot apply from main".into()));
+    }
+    let sql = user_snapshot_store(&state, auth.scope_id()).await?;
+    let git = user_git_service(&sql)?;
+    let branch_table = branch_table_name_raw(&sql, auth.scope_id(), &name).await?;
+    let response = git
+        .selective_apply(&branch_table, "mem_memories", auth.scope_id(), req)
+        .await
+        .map_err(api_err)?;
+    let payload = json!({
+        "actor_user_id": auth.user_id,
+        "group_id": auth.group_id,
+        "source_branch": name,
+        "applied_adds": response.applied_adds.clone(),
+        "applied_updates": response.applied_updates.clone(),
+        "applied_removes": response.applied_removes.clone(),
+        "applied_conflicts": response.applied_conflicts.clone(),
+        "skipped_adds": response.skipped_adds.clone(),
+        "skipped_updates": response.skipped_updates.clone(),
+        "skipped_removes": response.skipped_removes.clone(),
+        "skipped_conflicts": response.skipped_conflicts.clone(),
+    })
+    .to_string();
+    state.service.send_edit_log(
+        auth.scope_id(),
+        "branch_apply",
+        None,
+        Some(&payload),
+        "selective apply to main",
+        None,
+    );
+
+    Ok(Json(response))
 }
 
 pub async fn delete_branch(
     State(state): State<AppState>,
-    AuthUser { user_id, .. }: AuthUser,
+    auth: AuthUser,
     Path(name): Path<String>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     git_call(
         &state,
-        &user_id,
+        auth.scope_id(),
         "memory_branch_delete",
         json!({ "name": name }),
     )

--- a/memoria/crates/memoria-api/src/state.rs
+++ b/memoria/crates/memoria-api/src/state.rs
@@ -27,7 +27,14 @@ pub struct CachedMetrics {
 
 struct ApiKeyCacheEntry {
     user_id: String,
+    group_id: Option<String>,
     cached_at: Instant,
+}
+
+#[derive(Clone)]
+pub struct CachedApiKeyPrincipal {
+    pub user_id: String,
+    pub group_id: Option<String>,
 }
 
 #[derive(Clone)]
@@ -44,12 +51,15 @@ impl ApiKeyCache {
         }
     }
 
-    pub fn get(&self, key_hash: &str) -> Option<String> {
+    pub fn get(&self, key_hash: &str) -> Option<CachedApiKeyPrincipal> {
         let now = Instant::now();
         if let Ok(cache) = self.inner.read() {
             if let Some(entry) = cache.get(key_hash) {
                 if now.duration_since(entry.cached_at) < self.ttl {
-                    return Some(entry.user_id.clone());
+                    return Some(CachedApiKeyPrincipal {
+                        user_id: entry.user_id.clone(),
+                        group_id: entry.group_id.clone(),
+                    });
                 }
             }
         }
@@ -58,12 +68,13 @@ impl ApiKeyCache {
         None
     }
 
-    pub fn insert(&self, key_hash: String, user_id: String) {
+    pub fn insert(&self, key_hash: String, user_id: String, group_id: Option<String>) {
         if let Ok(mut cache) = self.inner.write() {
             cache.insert(
                 key_hash,
                 ApiKeyCacheEntry {
                     user_id,
+                    group_id,
                     cached_at: Instant::now(),
                 },
             );

--- a/memoria/crates/memoria-api/tests/api_db_verify.rs
+++ b/memoria/crates/memoria-api/tests/api_db_verify.rs
@@ -344,7 +344,9 @@ async fn test_delete_single_verify_db() {
 
     // Before delete: active
     assert_eq!(
-        db_get_memory(&server, &uid, &mid).await.get::<i8, _>("is_active"),
+        db_get_memory(&server, &uid, &mid)
+            .await
+            .get::<i8, _>("is_active"),
         1
     );
 
@@ -409,7 +411,9 @@ async fn test_purge_bulk_verify_db() {
     // DB: 3 deactivated, 1 still active
     for mid in &ids[..3] {
         assert_eq!(
-            db_get_memory(&server, &uid, mid).await.get::<i8, _>("is_active"),
+            db_get_memory(&server, &uid, mid)
+                .await
+                .get::<i8, _>("is_active"),
             0
         );
     }
@@ -2014,7 +2018,11 @@ async fn test_full_user_workflow() {
         0
     );
     assert_eq!(
-        db_opt(&db_get_memory(&server, &uid, &pref_mid).await, "superseded_by").as_deref(),
+        db_opt(
+            &db_get_memory(&server, &uid, &pref_mid).await,
+            "superseded_by"
+        )
+        .as_deref(),
         Some(new_pref_mid.as_str())
     );
     assert_eq!(

--- a/memoria/crates/memoria-api/tests/api_multi_db_purge.rs
+++ b/memoria/crates/memoria-api/tests/api_multi_db_purge.rs
@@ -28,11 +28,7 @@ fn shared_db_url() -> String {
     std::env::var("MEMORIA_SHARED_DATABASE_URL").unwrap_or_else(|_| db_url())
 }
 
-async fn spawn_server_multi_db() -> (
-    String,
-    reqwest::Client,
-    tokio::task::JoinHandle<()>,
-) {
+async fn spawn_server_multi_db() -> (String, reqwest::Client, tokio::task::JoinHandle<()>) {
     use memoria_git::GitForDataService;
     use memoria_service::MemoryService;
     use memoria_storage::{DbRouter, SqlMemoryStore};
@@ -67,7 +63,9 @@ async fn spawn_server_multi_db() -> (
         .await
         .expect("bind");
     let port = listener.local_addr().unwrap().port();
-    let handle = tokio::spawn(async move { let _ = axum::serve(listener, app).await; });
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
 
     let client = reqwest::Client::builder()
         .no_proxy()

--- a/memoria/crates/memoria-api/tests/group_collab_api.rs
+++ b/memoria/crates/memoria-api/tests/group_collab_api.rs
@@ -1,0 +1,1059 @@
+use serde_json::{json, Value};
+use serial_test::serial;
+use sqlx::Row;
+use std::sync::Arc;
+
+fn test_dim() -> usize {
+    std::env::var("EMBEDDING_DIM")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1024)
+}
+
+fn admin_db_url() -> String {
+    std::env::var("GROUP_TEST_ADMIN_DATABASE_URL")
+        .unwrap_or_else(|_| "mysql://root:111@127.0.0.1:6666/memoria".to_string())
+}
+
+fn unique_shared_db_name() -> String {
+    format!(
+        "memoria_group_test_{}",
+        &uuid::Uuid::new_v4().simple().to_string()[..12]
+    )
+}
+
+fn replace_db_name(url: &str, db_name: &str) -> String {
+    let (prefix, _) = url.rsplit_once('/').expect("db url with database name");
+    format!("{prefix}/{db_name}")
+}
+
+async fn drop_database(pool: &sqlx::MySqlPool, db_name: &str) {
+    let _ = sqlx::raw_sql(&format!(
+        "DROP DATABASE IF EXISTS `{}`",
+        db_name.replace('`', "``")
+    ))
+    .execute(pool)
+    .await;
+}
+
+struct TestServer {
+    base: String,
+    client: reqwest::Client,
+    shared_pool: sqlx::MySqlPool,
+    shared_db_name: String,
+}
+
+impl TestServer {
+    async fn cleanup(&self) {
+        let rows = sqlx::query("SELECT db_name FROM mem_groups")
+            .fetch_all(&self.shared_pool)
+            .await
+            .unwrap_or_default();
+        for row in &rows {
+            if let Ok(db_name) = row.try_get::<String, _>("db_name") {
+                drop_database(&self.shared_pool, &db_name).await;
+            }
+        }
+        drop_database(&self.shared_pool, &self.shared_db_name).await;
+    }
+}
+
+async fn spawn_server() -> TestServer {
+    use memoria_git::GitForDataService;
+    use memoria_service::MemoryService;
+    use memoria_storage::{DbRouter, SqlMemoryStore};
+
+    let admin_db = admin_db_url();
+    memoria_test_utils::wait_for_mysql_ready(&admin_db, std::time::Duration::from_secs(30)).await;
+    let admin_pool = sqlx::MySqlPool::connect(&admin_db)
+        .await
+        .expect("admin pool");
+
+    let shared_db_name = unique_shared_db_name();
+    sqlx::raw_sql(&format!(
+        "CREATE DATABASE IF NOT EXISTS `{}`",
+        shared_db_name.replace('`', "``")
+    ))
+    .execute(&admin_pool)
+    .await
+    .expect("create shared db");
+
+    let shared_db_url = replace_db_name(&admin_db, &shared_db_name);
+    let mut shared_store =
+        SqlMemoryStore::connect(&shared_db_url, test_dim(), uuid::Uuid::new_v4().to_string())
+            .await
+            .expect("connect shared store");
+    shared_store.migrate().await.expect("migrate shared store");
+
+    let router = Arc::new(
+        DbRouter::connect(&shared_db_url, test_dim(), uuid::Uuid::new_v4().to_string())
+            .await
+            .expect("connect router"),
+    );
+    let shared_pool = sqlx::MySqlPool::connect(&shared_db_url)
+        .await
+        .expect("shared pool");
+    let git = Arc::new(GitForDataService::new(shared_pool.clone(), &shared_db_name));
+    shared_store.set_db_router(router.clone());
+    let service = Arc::new(
+        MemoryService::new_sql_with_llm_and_router(
+            Arc::new(shared_store),
+            Some(router),
+            None,
+            None,
+        )
+        .await,
+    );
+    let state = memoria_api::AppState::new(service, git, "master-group-test-key".to_string())
+        .init_auth_pool(&shared_db_url, true)
+        .await
+        .expect("auth pool");
+    let app = memoria_api::build_router(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let client = reqwest::Client::builder().no_proxy().build().unwrap();
+    let base = format!("http://127.0.0.1:{port}");
+    for _ in 0..20 {
+        if client.get(format!("{base}/health")).send().await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+
+    TestServer {
+        base,
+        client,
+        shared_pool,
+        shared_db_name,
+    }
+}
+
+async fn create_group_with_payload(
+    server: &TestServer,
+    auth_header: &str,
+    owner: Option<&str>,
+    payload: Value,
+) -> Value {
+    let mut req = server
+        .client
+        .post(format!("{}/v1/groups", server.base))
+        .header("Authorization", auth_header);
+    if let Some(owner) = owner {
+        req = req.header("X-User-Id", owner);
+    }
+    let resp = req.json(&payload).send().await.expect("create group");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 201, "create group failed: {body}");
+    serde_json::from_str(&body).unwrap()
+}
+
+async fn create_group_with_members(server: &TestServer, owner: &str, members: &[&str]) -> Value {
+    create_group_with_payload(
+        server,
+        "Bearer master-group-test-key",
+        Some(owner),
+        json!({
+            "group_name": "team-a",
+            "members": members
+        }),
+    )
+    .await
+}
+
+async fn create_group(server: &TestServer, owner: &str) -> Value {
+    create_group_with_members(server, owner, &[owner]).await
+}
+
+async fn register_user(server: &TestServer, user_id: &str) {
+    let now = chrono::Utc::now().naive_utc();
+    sqlx::query(
+        "INSERT INTO mem_user_registry (user_id, db_name, status, created_at, updated_at) \
+         VALUES (?, ?, 'active', ?, ?) \
+         ON DUPLICATE KEY UPDATE status = 'active', updated_at = VALUES(updated_at)",
+    )
+    .bind(user_id)
+    .bind(&server.shared_db_name)
+    .bind(now)
+    .bind(now)
+    .execute(&server.shared_pool)
+    .await
+    .expect("register user in mem_user_registry");
+}
+
+async fn create_group_key(server: &TestServer, user_id: &str, group_id: &str) -> String {
+    let resp = server
+        .client
+        .post(format!("{}/auth/keys", server.base))
+        .header("Authorization", "Bearer master-group-test-key")
+        .header("X-User-Id", "admin")
+        .json(&json!({
+            "user_id": user_id,
+            "group_id": group_id,
+            "name": "group-key"
+        }))
+        .send()
+        .await
+        .expect("create group key");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 201, "create group key failed: {body}");
+    let body: Value = serde_json::from_str(&body).unwrap();
+    body["raw_key"].as_str().unwrap().to_string()
+}
+
+async fn create_branch(server: &TestServer, auth: &str, name: &str) {
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches", server.base))
+        .header("Authorization", auth)
+        .json(&json!({ "name": name }))
+        .send()
+        .await
+        .expect("create branch");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 201, "create branch failed: {body}");
+}
+
+async fn checkout_branch(server: &TestServer, auth: &str, name: &str) {
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/{name}/checkout", server.base))
+        .header("Authorization", auth)
+        .send()
+        .await
+        .expect("checkout branch");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 200, "checkout branch failed: {body}");
+}
+
+async fn store_memory(server: &TestServer, auth: &str, content: &str) -> Value {
+    let resp = server
+        .client
+        .post(format!("{}/v1/memories", server.base))
+        .header("Authorization", auth)
+        .json(&json!({ "content": content, "memory_type": "semantic" }))
+        .send()
+        .await
+        .expect("store memory");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 201, "store memory failed: {body}");
+    serde_json::from_str(&body).unwrap()
+}
+
+async fn correct_memory(
+    server: &TestServer,
+    auth: &str,
+    memory_id: &str,
+    new_content: &str,
+) -> Value {
+    let resp = server
+        .client
+        .put(format!("{}/v1/memories/{memory_id}/correct", server.base))
+        .header("Authorization", auth)
+        .json(&json!({ "new_content": new_content }))
+        .send()
+        .await
+        .expect("correct memory");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 200, "correct memory failed: {body}");
+    serde_json::from_str(&body).unwrap()
+}
+
+async fn delete_memory(server: &TestServer, auth: &str, memory_id: &str) {
+    let resp = server
+        .client
+        .delete(format!("{}/v1/memories/{memory_id}", server.base))
+        .header("Authorization", auth)
+        .send()
+        .await
+        .expect("delete memory");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 204, "delete memory failed: {body}");
+}
+
+async fn diff_items(server: &TestServer, auth: &str, branch: &str) -> Value {
+    let resp = server
+        .client
+        .get(format!("{}/v1/branches/{branch}/diff-items", server.base))
+        .header("Authorization", auth)
+        .send()
+        .await
+        .expect("diff items");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 200, "diff-items failed: {body}");
+    serde_json::from_str(&body).unwrap()
+}
+
+async fn apply_branch(server: &TestServer, auth: &str, branch: &str, payload: Value) -> Value {
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/{branch}/apply", server.base))
+        .header("Authorization", auth)
+        .json(&payload)
+        .send()
+        .await
+        .expect("apply branch");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 200, "apply branch failed: {body}");
+    serde_json::from_str(&body).unwrap()
+}
+
+async fn list_memories(server: &TestServer, auth: &str) -> Value {
+    let resp = server
+        .client
+        .get(format!("{}/v1/memories", server.base))
+        .header("Authorization", auth)
+        .send()
+        .await
+        .expect("list memories");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 200, "list memories failed: {body}");
+    serde_json::from_str(&body).unwrap()
+}
+
+#[tokio::test]
+#[serial]
+async fn test_group_key_main_is_read_only() {
+    let server = spawn_server().await;
+    register_user(&server, "bob").await;
+    let group = create_group_with_members(&server, "alice", &["alice", "bob"]).await;
+    let group_id = group["group_id"].as_str().unwrap();
+    let raw_key = create_group_key(&server, "alice", group_id).await;
+
+    let resp = server
+        .client
+        .post(format!("{}/v1/memories", server.base))
+        .header("Authorization", format!("Bearer {raw_key}"))
+        .json(&json!({"content": "should fail on protected main"}))
+        .send()
+        .await
+        .expect("group store");
+    assert_eq!(resp.status(), 403);
+
+    server.cleanup().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_solo_owner_group_key_can_write_on_main() {
+    let server = spawn_server().await;
+    let group = create_group(&server, "alice").await;
+    let group_id = group["group_id"].as_str().unwrap();
+    let raw_key = create_group_key(&server, "alice", group_id).await;
+    let auth = format!("Bearer {raw_key}");
+
+    let created = store_memory(&server, &auth, "solo owner main write").await;
+    assert_eq!(created["content"], "solo owner main write");
+
+    let body = list_memories(&server, &auth).await;
+    assert!(body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["content"] == "solo owner main write"));
+
+    server.cleanup().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_group_can_seed_from_personal_db() {
+    let server = spawn_server().await;
+
+    let resp = server
+        .client
+        .post(format!("{}/v1/memories", server.base))
+        .header("Authorization", "Bearer master-group-test-key")
+        .header("X-User-Id", "alice")
+        .json(&json!({"content": "personal seed memory", "memory_type": "semantic"}))
+        .send()
+        .await
+        .expect("store personal memory");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 201, "store personal memory failed: {body}");
+
+    let personal_db_name: String =
+        sqlx::query_scalar("SELECT db_name FROM mem_user_registry WHERE user_id = ?")
+            .bind("alice")
+            .fetch_one(&server.shared_pool)
+            .await
+            .expect("alice personal db");
+
+    let group = create_group_with_payload(
+        &server,
+        "Bearer master-group-test-key",
+        Some("alice"),
+        json!({
+            "group_name": "seeded-team",
+            "members": ["alice"],
+            "seed": {
+                "db_name": personal_db_name,
+                "mode": "active_only"
+            }
+        }),
+    )
+    .await;
+    let group_id = group["group_id"].as_str().unwrap();
+    let raw_key = create_group_key(&server, "alice", group_id).await;
+    let auth = format!("Bearer {raw_key}");
+
+    let body = list_memories(&server, &auth).await;
+    let item = body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["content"] == "personal seed memory")
+        .expect("seeded personal memory visible");
+    assert_eq!(item["author_id"], "alice");
+
+    server.cleanup().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_group_can_seed_from_current_group_db() {
+    let server = spawn_server().await;
+    let source_group = create_group(&server, "alice").await;
+    let source_group_id = source_group["group_id"].as_str().unwrap();
+    let source_group_db = source_group["db_name"].as_str().unwrap().to_string();
+    let source_key = create_group_key(&server, "alice", source_group_id).await;
+    let source_auth = format!("Bearer {source_key}");
+
+    create_branch(&server, &source_auth, "seed").await;
+    checkout_branch(&server, &source_auth, "seed").await;
+    let created = store_memory(&server, &source_auth, "group seed memory").await;
+    let memory_id = created["memory_id"].as_str().unwrap().to_string();
+    let _ = apply_branch(&server, &source_auth, "seed", json!({"adds": [memory_id]})).await;
+    checkout_branch(&server, &source_auth, "main").await;
+
+    let seeded_group = create_group_with_payload(
+        &server,
+        &source_auth,
+        None,
+        json!({
+            "group_name": "seeded-from-group",
+            "members": ["alice"],
+            "seed": {
+                "db_name": source_group_db,
+                "mode": "active_only"
+            }
+        }),
+    )
+    .await;
+    let seeded_group_id = seeded_group["group_id"].as_str().unwrap();
+    let seeded_key = create_group_key(&server, "alice", seeded_group_id).await;
+    let seeded_auth = format!("Bearer {seeded_key}");
+
+    let body = list_memories(&server, &seeded_auth).await;
+    assert!(body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["content"] == "group seed memory"));
+
+    server.cleanup().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_group_branch_diff_and_apply_flow() {
+    let server = spawn_server().await;
+    let group = create_group(&server, "alice").await;
+    let group_id = group["group_id"].as_str().unwrap();
+    let raw_key = create_group_key(&server, "alice", group_id).await;
+    let auth = format!("Bearer {raw_key}");
+
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches", server.base))
+        .header("Authorization", &auth)
+        .json(&json!({"name": "exp1"}))
+        .send()
+        .await
+        .expect("create branch");
+    assert_eq!(resp.status(), 201);
+
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/exp1/checkout", server.base))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .expect("checkout branch");
+    assert_eq!(resp.status(), 200);
+
+    let resp = server
+        .client
+        .post(format!("{}/v1/memories", server.base))
+        .header("Authorization", &auth)
+        .json(&json!({"content": "group branch memory", "memory_type": "semantic"}))
+        .send()
+        .await
+        .expect("store on branch");
+    assert_eq!(resp.status(), 201);
+    let created: Value = resp.json().await.unwrap();
+    let memory_id = created["memory_id"].as_str().unwrap().to_string();
+
+    let group_db_name = group["db_name"].as_str().unwrap();
+    let group_db_url = replace_db_name(&admin_db_url(), group_db_name);
+    let group_pool = sqlx::MySqlPool::connect(&group_db_url)
+        .await
+        .expect("group pool");
+    for _ in 0..60 {
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM mem_edit_log WHERE user_id = ? AND operation = 'inject'",
+        )
+        .bind(group_id)
+        .fetch_one(&group_pool)
+        .await
+        .unwrap();
+        if count > 0 {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+    let edit_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mem_edit_log WHERE user_id = ? AND operation = 'inject'",
+    )
+    .bind(group_id)
+    .fetch_one(&group_pool)
+    .await
+    .unwrap();
+    assert!(edit_count > 0, "group db should contain store audit log");
+
+    let resp = server
+        .client
+        .get(format!("{}/v1/branches/exp1/diff-items", server.base))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .expect("diff items");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 200, "diff-items failed: {body}");
+    let diff: Value = serde_json::from_str(&body).unwrap();
+    assert!(diff["added"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["memory_id"] == memory_id));
+
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/exp1/apply", server.base))
+        .header("Authorization", &auth)
+        .json(&json!({"adds": [memory_id]}))
+        .send()
+        .await
+        .expect("apply branch");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 200, "apply failed: {body}");
+    let applied: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(applied["applied_adds"].as_array().unwrap().len(), 1);
+
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/main/checkout", server.base))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .expect("checkout main");
+    assert_eq!(resp.status(), 200);
+
+    let resp = server
+        .client
+        .get(format!("{}/v1/memories", server.base))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .expect("list memories");
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["content"] == "group branch memory"));
+
+    server.cleanup().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_group_conflict_accept_branch_apply_flow() {
+    let server = spawn_server().await;
+    register_user(&server, "bob").await;
+    let group = create_group_with_members(&server, "alice", &["alice", "bob"]).await;
+    let group_id = group["group_id"].as_str().unwrap();
+    let alice_key = create_group_key(&server, "alice", group_id).await;
+    let bob_key = create_group_key(&server, "bob", group_id).await;
+    let alice_auth = format!("Bearer {alice_key}");
+    let bob_auth = format!("Bearer {bob_key}");
+
+    // Bootstrap one shared memory onto main.
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches", server.base))
+        .header("Authorization", &alice_auth)
+        .json(&json!({"name": "seed"}))
+        .send()
+        .await
+        .expect("create seed branch");
+    assert_eq!(resp.status(), 201);
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/seed/checkout", server.base))
+        .header("Authorization", &alice_auth)
+        .send()
+        .await
+        .expect("checkout seed");
+    assert_eq!(resp.status(), 200);
+    let resp = server
+        .client
+        .post(format!("{}/v1/memories", server.base))
+        .header("Authorization", &alice_auth)
+        .json(&json!({"content": "shared base memory", "memory_type": "semantic"}))
+        .send()
+        .await
+        .expect("store base memory");
+    assert_eq!(resp.status(), 201);
+    let created: Value = resp.json().await.unwrap();
+    let base_id = created["memory_id"].as_str().unwrap().to_string();
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/seed/apply", server.base))
+        .header("Authorization", &alice_auth)
+        .json(&json!({"adds": [base_id.clone()]}))
+        .send()
+        .await
+        .expect("apply seed branch");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 200, "seed apply failed: {body}");
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/main/checkout", server.base))
+        .header("Authorization", &alice_auth)
+        .send()
+        .await
+        .expect("checkout alice main");
+    assert_eq!(resp.status(), 200);
+
+    // Alice creates a stale branch from the original main.
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches", server.base))
+        .header("Authorization", &alice_auth)
+        .json(&json!({"name": "alice-exp"}))
+        .send()
+        .await
+        .expect("create alice branch");
+    assert_eq!(resp.status(), 201);
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/alice-exp/checkout", server.base))
+        .header("Authorization", &alice_auth)
+        .send()
+        .await
+        .expect("checkout alice branch");
+    assert_eq!(resp.status(), 200);
+
+    // Bob corrects the same memory and applies to main first.
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches", server.base))
+        .header("Authorization", &bob_auth)
+        .json(&json!({"name": "bob-exp"}))
+        .send()
+        .await
+        .expect("create bob branch");
+    assert_eq!(resp.status(), 201);
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/bob-exp/checkout", server.base))
+        .header("Authorization", &bob_auth)
+        .send()
+        .await
+        .expect("checkout bob branch");
+    assert_eq!(resp.status(), 200);
+    let resp = server
+        .client
+        .put(format!("{}/v1/memories/{}/correct", server.base, base_id))
+        .header("Authorization", &bob_auth)
+        .json(&json!({"new_content": "bob wins on main first"}))
+        .send()
+        .await
+        .expect("bob correct");
+    assert_eq!(resp.status(), 200);
+    let bob_corrected: Value = resp.json().await.unwrap();
+    let bob_new_id = bob_corrected["memory_id"].as_str().unwrap().to_string();
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/bob-exp/apply", server.base))
+        .header("Authorization", &bob_auth)
+        .json(&json!({
+            "updates": [{"old_id": base_id, "new_id": bob_new_id}]
+        }))
+        .send()
+        .await
+        .expect("apply bob branch");
+    assert_eq!(resp.status(), 200);
+
+    // Alice makes a different correction on her stale branch.
+    let resp = server
+        .client
+        .put(format!("{}/v1/memories/{}/correct", server.base, base_id))
+        .header("Authorization", &alice_auth)
+        .json(&json!({"new_content": "alice accept_branch target"}))
+        .send()
+        .await
+        .expect("alice correct");
+    assert_eq!(resp.status(), 200);
+    let alice_corrected: Value = resp.json().await.unwrap();
+    let alice_new_id = alice_corrected["memory_id"].as_str().unwrap().to_string();
+
+    let resp = server
+        .client
+        .get(format!("{}/v1/branches/alice-exp/diff-items", server.base))
+        .header("Authorization", &alice_auth)
+        .send()
+        .await
+        .expect("alice diff items");
+    assert_eq!(resp.status(), 200);
+    let diff: Value = resp.json().await.unwrap();
+    assert!(diff["conflicts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["memory_id"] == base_id));
+
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/alice-exp/apply", server.base))
+        .header("Authorization", &alice_auth)
+        .json(&json!({
+            "accept_branch_conflicts": [base_id]
+        }))
+        .send()
+        .await
+        .expect("apply alice conflict");
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status, 200, "accept_branch apply failed: {body}");
+    let applied: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(applied["applied_conflicts"].as_array().unwrap().len(), 1);
+
+    let resp = server
+        .client
+        .post(format!("{}/v1/branches/main/checkout", server.base))
+        .header("Authorization", &alice_auth)
+        .send()
+        .await
+        .expect("checkout alice main after apply");
+    assert_eq!(resp.status(), 200);
+    let resp = server
+        .client
+        .get(format!("{}/v1/memories", server.base))
+        .header("Authorization", &alice_auth)
+        .send()
+        .await
+        .expect("list memories after conflict apply");
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    let contents: Vec<String> = body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|item| item["content"].as_str().map(ToString::to_string))
+        .collect();
+    assert!(contents
+        .iter()
+        .any(|content| content == "alice accept_branch target"));
+    assert!(!contents
+        .iter()
+        .any(|content| content == "bob wins on main first"));
+
+    let group_db_name = group["db_name"].as_str().unwrap();
+    let group_db_url = replace_db_name(&admin_db_url(), group_db_name);
+    let group_pool = sqlx::MySqlPool::connect(&group_db_url)
+        .await
+        .expect("group pool");
+    let bob_active_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mem_memories WHERE memory_id = ? AND is_active = 1",
+    )
+    .bind(&bob_new_id)
+    .fetch_one(&group_pool)
+    .await
+    .unwrap();
+    let alice_active_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM mem_memories WHERE memory_id = ? AND is_active = 1",
+    )
+    .bind(&alice_new_id)
+    .fetch_one(&group_pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        bob_active_count, 0,
+        "bob replacement should be removed from main"
+    );
+    assert_eq!(
+        alice_active_count, 1,
+        "alice replacement should be active on main"
+    );
+
+    server.cleanup().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_group_branch_diff_and_apply_mixed_flow() {
+    let server = spawn_server().await;
+    let group = create_group(&server, "alice").await;
+    let group_id = group["group_id"].as_str().unwrap();
+    let raw_key = create_group_key(&server, "alice", group_id).await;
+    let auth = format!("Bearer {raw_key}");
+
+    create_branch(&server, &auth, "seed").await;
+    checkout_branch(&server, &auth, "seed").await;
+    let update_seed = store_memory(&server, &auth, "base update target").await;
+    let update_seed_id = update_seed["memory_id"].as_str().unwrap().to_string();
+    let remove_seed = store_memory(&server, &auth, "base remove target").await;
+    let remove_seed_id = remove_seed["memory_id"].as_str().unwrap().to_string();
+    let applied = apply_branch(
+        &server,
+        &auth,
+        "seed",
+        json!({ "adds": [update_seed_id.clone(), remove_seed_id.clone()] }),
+    )
+    .await;
+    assert_eq!(applied["applied_adds"].as_array().unwrap().len(), 2);
+    checkout_branch(&server, &auth, "main").await;
+
+    create_branch(&server, &auth, "work").await;
+    checkout_branch(&server, &auth, "work").await;
+    let added = store_memory(&server, &auth, "branch added memory").await;
+    let added_id = added["memory_id"].as_str().unwrap().to_string();
+    let corrected = correct_memory(&server, &auth, &update_seed_id, "branch updated memory").await;
+    let corrected_id = corrected["memory_id"].as_str().unwrap().to_string();
+    delete_memory(&server, &auth, &remove_seed_id).await;
+
+    let diff = diff_items(&server, &auth, "work").await;
+    assert!(diff["added"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["memory_id"] == added_id));
+    assert!(diff["updated"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["memory_id"] == corrected_id && item["old_memory_id"] == update_seed_id));
+    assert!(diff["removed"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["memory_id"] == remove_seed_id));
+
+    let applied = apply_branch(
+        &server,
+        &auth,
+        "work",
+        json!({
+            "adds": [added_id.clone()],
+            "updates": [{ "old_id": update_seed_id, "new_id": corrected_id }],
+            "removes": [remove_seed_id.clone()]
+        }),
+    )
+    .await;
+    assert_eq!(applied["applied_adds"].as_array().unwrap().len(), 1);
+    assert_eq!(applied["applied_updates"].as_array().unwrap().len(), 1);
+    assert_eq!(applied["applied_removes"].as_array().unwrap().len(), 1);
+
+    checkout_branch(&server, &auth, "main").await;
+    let body = list_memories(&server, &auth).await;
+    let contents: Vec<String> = body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|item| item["content"].as_str().map(ToString::to_string))
+        .collect();
+    assert!(contents
+        .iter()
+        .any(|content| content == "branch added memory"));
+    assert!(contents
+        .iter()
+        .any(|content| content == "branch updated memory"));
+    assert!(!contents
+        .iter()
+        .any(|content| content == "base update target"));
+    assert!(!contents
+        .iter()
+        .any(|content| content == "base remove target"));
+
+    server.cleanup().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_group_apply_skips_unchecked_conflict_and_keeps_main() {
+    let server = spawn_server().await;
+    register_user(&server, "bob").await;
+    let group = create_group_with_members(&server, "alice", &["alice", "bob"]).await;
+    let group_id = group["group_id"].as_str().unwrap();
+    let alice_key = create_group_key(&server, "alice", group_id).await;
+    let bob_key = create_group_key(&server, "bob", group_id).await;
+    let alice_auth = format!("Bearer {alice_key}");
+    let bob_auth = format!("Bearer {bob_key}");
+
+    create_branch(&server, &alice_auth, "seed").await;
+    checkout_branch(&server, &alice_auth, "seed").await;
+    let created = store_memory(&server, &alice_auth, "shared base memory").await;
+    let base_id = created["memory_id"].as_str().unwrap().to_string();
+    let applied = apply_branch(
+        &server,
+        &alice_auth,
+        "seed",
+        json!({ "adds": [base_id.clone()] }),
+    )
+    .await;
+    assert_eq!(applied["applied_adds"].as_array().unwrap().len(), 1);
+    checkout_branch(&server, &alice_auth, "main").await;
+
+    create_branch(&server, &alice_auth, "alice-exp").await;
+    checkout_branch(&server, &alice_auth, "alice-exp").await;
+    let alice_add = store_memory(
+        &server,
+        &alice_auth,
+        "alice add while conflict stays on branch",
+    )
+    .await;
+    let alice_add_id = alice_add["memory_id"].as_str().unwrap().to_string();
+
+    create_branch(&server, &bob_auth, "bob-exp").await;
+    checkout_branch(&server, &bob_auth, "bob-exp").await;
+    let bob_corrected = correct_memory(&server, &bob_auth, &base_id, "bob keeps main").await;
+    let bob_new_id = bob_corrected["memory_id"].as_str().unwrap().to_string();
+    let applied = apply_branch(
+        &server,
+        &bob_auth,
+        "bob-exp",
+        json!({
+            "updates": [{ "old_id": base_id, "new_id": bob_new_id }]
+        }),
+    )
+    .await;
+    assert_eq!(applied["applied_updates"].as_array().unwrap().len(), 1);
+
+    let alice_corrected = correct_memory(
+        &server,
+        &alice_auth,
+        &base_id,
+        "alice conflict stays on branch",
+    )
+    .await;
+    let alice_new_id = alice_corrected["memory_id"].as_str().unwrap().to_string();
+
+    let diff = diff_items(&server, &alice_auth, "alice-exp").await;
+    assert!(diff["conflicts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["memory_id"] == base_id));
+    assert!(diff["added"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["memory_id"] == alice_add_id));
+
+    let applied = apply_branch(
+        &server,
+        &alice_auth,
+        "alice-exp",
+        json!({
+            "adds": [alice_add_id.clone()]
+        }),
+    )
+    .await;
+    assert_eq!(applied["applied_adds"].as_array().unwrap().len(), 1);
+    assert!(applied["applied_conflicts"].as_array().unwrap().is_empty());
+
+    checkout_branch(&server, &alice_auth, "main").await;
+    let body = list_memories(&server, &alice_auth).await;
+    let contents: Vec<String> = body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|item| item["content"].as_str().map(ToString::to_string))
+        .collect();
+    let ids: Vec<String> = body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|item| item["memory_id"].as_str().map(ToString::to_string))
+        .collect();
+    assert!(contents
+        .iter()
+        .any(|content| content == "alice add while conflict stays on branch"));
+    assert!(contents.iter().any(|content| content == "bob keeps main"));
+    assert!(!contents
+        .iter()
+        .any(|content| content == "alice conflict stays on branch"));
+    assert!(ids.iter().any(|id| id == &bob_new_id));
+    assert!(!ids.iter().any(|id| id == &alice_new_id));
+
+    server.cleanup().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_group_diff_reports_behind_main_items() {
+    let server = spawn_server().await;
+    register_user(&server, "bob").await;
+    let group = create_group_with_members(&server, "alice", &["alice", "bob"]).await;
+    let group_id = group["group_id"].as_str().unwrap();
+    let alice_key = create_group_key(&server, "alice", group_id).await;
+    let bob_key = create_group_key(&server, "bob", group_id).await;
+    let alice_auth = format!("Bearer {alice_key}");
+    let bob_auth = format!("Bearer {bob_key}");
+
+    create_branch(&server, &alice_auth, "alice-exp").await;
+    checkout_branch(&server, &alice_auth, "main").await;
+
+    create_branch(&server, &bob_auth, "bob-exp").await;
+    checkout_branch(&server, &bob_auth, "bob-exp").await;
+    let bob_added = store_memory(&server, &bob_auth, "bob added after alice branch").await;
+    let bob_added_id = bob_added["memory_id"].as_str().unwrap().to_string();
+    let applied = apply_branch(
+        &server,
+        &bob_auth,
+        "bob-exp",
+        json!({ "adds": [bob_added_id.clone()] }),
+    )
+    .await;
+    assert_eq!(applied["applied_adds"].as_array().unwrap().len(), 1);
+
+    let diff = diff_items(&server, &alice_auth, "alice-exp").await;
+    assert!(diff["behind_main"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item["memory_id"] == bob_added_id
+            && item["content"] == "bob added after alice branch"));
+
+    server.cleanup().await;
+}

--- a/memoria/crates/memoria-api/tests/group_collab_api.rs
+++ b/memoria/crates/memoria-api/tests/group_collab_api.rs
@@ -55,6 +55,7 @@ impl TestServer {
             }
         }
         drop_database(&self.shared_pool, &self.shared_db_name).await;
+        self.shared_pool.close().await;
     }
 }
 
@@ -63,9 +64,12 @@ async fn spawn_server() -> TestServer {
     use memoria_service::MemoryService;
     use memoria_storage::{DbRouter, SqlMemoryStore};
 
+    std::env::set_var("DB_MAX_CONNECTIONS", "4");
     let admin_db = admin_db_url();
     memoria_test_utils::wait_for_mysql_ready(&admin_db, std::time::Duration::from_secs(30)).await;
-    let admin_pool = sqlx::MySqlPool::connect(&admin_db)
+    let admin_pool = sqlx::mysql::MySqlPoolOptions::new()
+        .max_connections(2)
+        .connect(&admin_db)
         .await
         .expect("admin pool");
 
@@ -77,6 +81,7 @@ async fn spawn_server() -> TestServer {
     .execute(&admin_pool)
     .await
     .expect("create shared db");
+    admin_pool.close().await;
 
     let shared_db_url = replace_db_name(&admin_db, &shared_db_name);
     let mut shared_store =
@@ -90,7 +95,9 @@ async fn spawn_server() -> TestServer {
             .await
             .expect("connect router"),
     );
-    let shared_pool = sqlx::MySqlPool::connect(&shared_db_url)
+    let shared_pool = sqlx::mysql::MySqlPoolOptions::new()
+        .max_connections(2)
+        .connect(&shared_db_url)
         .await
         .expect("shared pool");
     let git = Arc::new(GitForDataService::new(shared_pool.clone(), &shared_db_name));

--- a/memoria/crates/memoria-api/tests/group_collab_api.rs
+++ b/memoria/crates/memoria-api/tests/group_collab_api.rs
@@ -12,6 +12,7 @@ fn test_dim() -> usize {
 
 fn admin_db_url() -> String {
     std::env::var("GROUP_TEST_ADMIN_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
         .unwrap_or_else(|_| "mysql://root:111@127.0.0.1:6666/memoria".to_string())
 }
 

--- a/memoria/crates/memoria-cli/templates/claude_memory_branching.md
+++ b/memoria/crates/memoria-cli/templates/claude_memory_branching.md
@@ -78,6 +78,28 @@ memory_branch_delete(name="approach_a")
 memory_branch_delete(name="approach_b")
 ```
 
+## Pattern 4: Selective Apply
+
+When only part of a branch should land on `main`, or you want conflict-by-conflict control, prefer `memory_apply` over merging the whole branch.
+
+```
+memory_diff(source="experiment_notes")
+
+# Promote only the selected changes
+memory_apply(
+  source="experiment_notes",
+  adds=["mem_new_1"],
+  updates=[{"old_id": "mem_old_1", "new_id": "mem_new_1"}],
+  removes=["mem_delete_1"],
+  accept_branch_conflicts=["mem_conflict_1"]
+)
+```
+
+Rules:
+- Omit an item from `adds` / `updates` / `removes` to leave `main` unchanged for that item.
+- Omit a conflict from `accept_branch_conflicts` to keep the `main` version.
+- Use `memory_merge` only when the entire branch should land together.
+
 ## When to Branch
 
 - ✅ Evaluating a technology, framework, or architecture change
@@ -103,4 +125,4 @@ Always delete branches after merge or abandonment. Check with `memory_branches()
 - `replace` (default, also called `accept`): branch wins on conflicts — if the same memory exists on both main and branch, the branch version replaces main's
 - `append`: skip-on-conflict — only adds new memories from branch, never overwrites existing main memories
 
-Use `replace` when the branch contains validated corrections. Use `append` when the branch only adds new information and you want to preserve main's existing state.
+Use `replace` when the branch contains validated corrections. Use `append` when the branch only adds new information and you want to preserve main's existing state. If you only want part of a branch, use `memory_apply` instead of either merge strategy.

--- a/memoria/crates/memoria-cli/templates/claude_rule.md
+++ b/memoria/crates/memoria-cli/templates/claude_rule.md
@@ -152,7 +152,7 @@ When `memory_governance` reports snapshot_health with high auto_ratio (>50%), su
 - `memory_snapshot_delete(older_than="2026-01-01")` — remove snapshots before a date
 
 ### Branches (isolated experiments)
-Git-like workflow for memory. `memory_branch(name)` creates, `memory_checkout(name)` switches, `memory_diff(source)` previews changes, `memory_merge(source)` merges back, `memory_branch_delete(name)` cleans up. `memory_branches()` lists all.
+Git-like workflow for memory. `memory_branch(name)` creates, `memory_checkout(name)` switches, `memory_diff(source)` previews changes, `memory_apply(source, ...)` selectively promotes chosen branch items back to `main`, `memory_merge(source)` merges the whole branch back, and `memory_branch_delete(name)` cleans up. `memory_branches()` lists all.
 
 ### Entity graph
 Entity extraction is automatic — every `memory_store` triggers regex-based extraction, with LLM extraction as a fallback when configured. No manual intervention needed.

--- a/memoria/crates/memoria-cli/templates/codex_agents.md
+++ b/memoria/crates/memoria-cli/templates/codex_agents.md
@@ -144,7 +144,7 @@ When `memory_governance` reports snapshot_health with high auto_ratio (>50%), su
 - `memory_snapshot_delete(older_than="2026-01-01")` — remove snapshots before a date
 
 ### Branches (isolated experiments)
-Git-like workflow for memory. `memory_branch(name)` creates, `memory_checkout(name)` switches, `memory_diff(source)` previews changes, `memory_merge(source)` merges back, `memory_branch_delete(name)` cleans up. `memory_branches()` lists all.
+Git-like workflow for memory. `memory_branch(name)` creates, `memory_checkout(name)` switches, `memory_diff(source)` previews changes, `memory_apply(source, ...)` selectively promotes chosen branch items back to `main`, `memory_merge(source)` merges the whole branch back, and `memory_branch_delete(name)` cleans up. `memory_branches()` lists all.
 
 ### Maintenance
 | Tool | Trigger phrase | Cooldown |
@@ -372,6 +372,28 @@ memory_branch_delete(name="approach_a")
 memory_branch_delete(name="approach_b")
 ```
 
+## Pattern 4: Selective Apply
+
+When only part of a branch should land on `main`, or you want conflict-by-conflict control, prefer `memory_apply` over merging the whole branch.
+
+```
+memory_diff(source="experiment_notes")
+
+# Promote only the selected changes
+memory_apply(
+  source="experiment_notes",
+  adds=["mem_new_1"],
+  updates=[{"old_id": "mem_old_1", "new_id": "mem_new_1"}],
+  removes=["mem_delete_1"],
+  accept_branch_conflicts=["mem_conflict_1"]
+)
+```
+
+Rules:
+- Omit an item from `adds` / `updates` / `removes` to leave `main` unchanged for that item.
+- Omit a conflict from `accept_branch_conflicts` to keep the `main` version.
+- Use `memory_merge` only when the entire branch should land together.
+
 ## When to Branch
 
 - ✅ Evaluating a technology, framework, or architecture change
@@ -397,7 +419,7 @@ Always delete branches after merge or abandonment. Check with `memory_branches()
 - `replace` (default, also called `accept`): branch wins on conflicts — if the same memory exists on both main and branch, the branch version replaces main's
 - `append`: skip-on-conflict — only adds new memories from branch, never overwrites existing main memories
 
-Use `replace` when the branch contains validated corrections. Use `append` when the branch only adds new information and you want to preserve main's existing state.
+Use `replace` when the branch contains validated corrections. Use `append` when the branch only adds new information and you want to preserve main's existing state. If you only want part of a branch, use `memory_apply` instead of either merge strategy.
 
 
 # Goal-Driven Iterative Evolution via Memory

--- a/memoria/crates/memoria-cli/templates/cursor_memory_branching.md
+++ b/memoria/crates/memoria-cli/templates/cursor_memory_branching.md
@@ -84,6 +84,28 @@ memory_branch_delete(name="approach_a")
 memory_branch_delete(name="approach_b")
 ```
 
+## Pattern 4: Selective Apply
+
+When only part of a branch should land on `main`, or you want conflict-by-conflict control, prefer `memory_apply` over merging the whole branch.
+
+```
+memory_diff(source="experiment_notes")
+
+# Promote only the selected changes
+memory_apply(
+  source="experiment_notes",
+  adds=["mem_new_1"],
+  updates=[{"old_id": "mem_old_1", "new_id": "mem_new_1"}],
+  removes=["mem_delete_1"],
+  accept_branch_conflicts=["mem_conflict_1"]
+)
+```
+
+Rules:
+- Omit an item from `adds` / `updates` / `removes` to leave `main` unchanged for that item.
+- Omit a conflict from `accept_branch_conflicts` to keep the `main` version.
+- Use `memory_merge` only when the entire branch should land together.
+
 ## When to Branch
 
 - ✅ Evaluating a technology, framework, or architecture change
@@ -109,4 +131,4 @@ Always delete branches after merge or abandonment. Check with `memory_branches()
 - `replace` (default, also called `accept`): branch wins on conflicts — if the same memory exists on both main and branch, the branch version replaces main's
 - `append`: skip-on-conflict — only adds new memories from branch, never overwrites existing main memories
 
-Use `replace` when the branch contains validated corrections. Use `append` when the branch only adds new information and you want to preserve main's existing state.
+Use `replace` when the branch contains validated corrections. Use `append` when the branch only adds new information and you want to preserve main's existing state. If you only want part of a branch, use `memory_apply` instead of either merge strategy.

--- a/memoria/crates/memoria-cli/templates/cursor_rule.md
+++ b/memoria/crates/memoria-cli/templates/cursor_rule.md
@@ -161,7 +161,7 @@ When `memory_governance` reports snapshot_health with high auto_ratio (>50%), su
 - `memory_snapshot_delete(older_than="2026-01-01")` — remove snapshots before a date
 
 ### Branches (isolated experiments)
-Git-like workflow for memory. `memory_branch(name)` creates, `memory_checkout(name)` switches, `memory_diff(source)` previews changes, `memory_merge(source)` merges back, `memory_branch_delete(name)` cleans up. `memory_branches()` lists all.
+Git-like workflow for memory. `memory_branch(name)` creates, `memory_checkout(name)` switches, `memory_diff(source)` previews changes, `memory_apply(source, ...)` selectively promotes chosen branch items back to `main`, `memory_merge(source)` merges the whole branch back, and `memory_branch_delete(name)` cleans up. `memory_branches()` lists all.
 
 ### Entity graph
 Entity extraction is automatic — every `memory_store` triggers regex-based extraction, with LLM extraction as a fallback when configured. No manual intervention needed.

--- a/memoria/crates/memoria-cli/templates/gemini_memory_branching.md
+++ b/memoria/crates/memoria-cli/templates/gemini_memory_branching.md
@@ -78,6 +78,28 @@ memory_branch_delete(name="approach_a")
 memory_branch_delete(name="approach_b")
 ```
 
+## Pattern 4: Selective Apply
+
+When only part of a branch should land on `main`, or you want conflict-by-conflict control, prefer `memory_apply` over merging the whole branch.
+
+```
+memory_diff(source="experiment_notes")
+
+# Promote only the selected changes
+memory_apply(
+  source="experiment_notes",
+  adds=["mem_new_1"],
+  updates=[{"old_id": "mem_old_1", "new_id": "mem_new_1"}],
+  removes=["mem_delete_1"],
+  accept_branch_conflicts=["mem_conflict_1"]
+)
+```
+
+Rules:
+- Omit an item from `adds` / `updates` / `removes` to leave `main` unchanged for that item.
+- Omit a conflict from `accept_branch_conflicts` to keep the `main` version.
+- Use `memory_merge` only when the entire branch should land together.
+
 ## When to Branch
 
 - ✅ Evaluating a technology, framework, or architecture change
@@ -103,4 +125,4 @@ Always delete branches after merge or abandonment. Check with `memory_branches()
 - `replace` (default, also called `accept`): branch wins on conflicts — if the same memory exists on both main and branch, the branch version replaces main's
 - `append`: skip-on-conflict — only adds new memories from branch, never overwrites existing main memories
 
-Use `replace` when the branch contains validated corrections. Use `append` when the branch only adds new information and you want to preserve main's existing state.
+Use `replace` when the branch contains validated corrections. Use `append` when the branch only adds new information and you want to preserve main's existing state. If you only want part of a branch, use `memory_apply` instead of either merge strategy.

--- a/memoria/crates/memoria-cli/templates/gemini_rule.md
+++ b/memoria/crates/memoria-cli/templates/gemini_rule.md
@@ -152,7 +152,7 @@ When `memory_governance` reports snapshot_health with high auto_ratio (>50%), su
 - `memory_snapshot_delete(older_than="2026-01-01")` — remove snapshots before a date
 
 ### Branches (isolated experiments)
-Git-like workflow for memory. `memory_branch(name)` creates, `memory_checkout(name)` switches, `memory_diff(source)` previews changes, `memory_merge(source)` merges back, `memory_branch_delete(name)` cleans up. `memory_branches()` lists all.
+Git-like workflow for memory. `memory_branch(name)` creates, `memory_checkout(name)` switches, `memory_diff(source)` previews changes, `memory_apply(source, ...)` selectively promotes chosen branch items back to `main`, `memory_merge(source)` merges the whole branch back, and `memory_branch_delete(name)` cleans up. `memory_branches()` lists all.
 
 ### Entity graph
 Entity extraction is automatic — every `memory_store` triggers regex-based extraction, with LLM extraction as a fallback when configured. No manual intervention needed.

--- a/memoria/crates/memoria-cli/templates/kiro_memory_branching.md
+++ b/memoria/crates/memoria-cli/templates/kiro_memory_branching.md
@@ -84,6 +84,28 @@ memory_branch_delete(name="approach_a")
 memory_branch_delete(name="approach_b")
 ```
 
+## Pattern 4: Selective Apply
+
+When only part of a branch should land on `main`, or you want conflict-by-conflict control, prefer `memory_apply` over merging the whole branch.
+
+```
+memory_diff(source="experiment_notes")
+
+# Promote only the selected changes
+memory_apply(
+  source="experiment_notes",
+  adds=["mem_new_1"],
+  updates=[{"old_id": "mem_old_1", "new_id": "mem_new_1"}],
+  removes=["mem_delete_1"],
+  accept_branch_conflicts=["mem_conflict_1"]
+)
+```
+
+Rules:
+- Omit an item from `adds` / `updates` / `removes` to leave `main` unchanged for that item.
+- Omit a conflict from `accept_branch_conflicts` to keep the `main` version.
+- Use `memory_merge` only when the entire branch should land together.
+
 ## When to Branch
 
 - ✅ Evaluating a technology, framework, or architecture change
@@ -109,4 +131,4 @@ Always delete branches after merge or abandonment. Check with `memory_branches()
 - `replace` (default, also called `accept`): branch wins on conflicts — if the same memory exists on both main and branch, the branch version replaces main's
 - `append`: skip-on-conflict — only adds new memories from branch, never overwrites existing main memories
 
-Use `replace` when the branch contains validated corrections. Use `append` when the branch only adds new information and you want to preserve main's existing state.
+Use `replace` when the branch contains validated corrections. Use `append` when the branch only adds new information and you want to preserve main's existing state. If you only want part of a branch, use `memory_apply` instead of either merge strategy.

--- a/memoria/crates/memoria-cli/templates/kiro_steering.md
+++ b/memoria/crates/memoria-cli/templates/kiro_steering.md
@@ -156,7 +156,7 @@ When `memory_governance` reports snapshot_health with high auto_ratio (>50%), su
 - `memory_snapshot_delete(older_than="2026-01-01")` — remove snapshots before a date
 
 ### Branches (isolated experiments)
-Git-like workflow for memory. `memory_branch(name)` creates, `memory_checkout(name)` switches, `memory_diff(source)` previews changes, `memory_merge(source)` merges back, `memory_branch_delete(name)` cleans up. `memory_branches()` lists all.
+Git-like workflow for memory. `memory_branch(name)` creates, `memory_checkout(name)` switches, `memory_diff(source)` previews changes, `memory_apply(source, ...)` selectively promotes chosen branch items back to `main`, `memory_merge(source)` merges the whole branch back, and `memory_branch_delete(name)` cleans up. `memory_branches()` lists all.
 
 ### Entity graph
 Entity extraction is automatic — every `memory_store` triggers regex-based extraction, with LLM extraction as a fallback when configured. No manual intervention needed.

--- a/memoria/crates/memoria-core/src/types.rs
+++ b/memoria/crates/memoria-core/src/types.rs
@@ -125,6 +125,9 @@ impl std::str::FromStr for TrustTier {
 pub struct Memory {
     pub memory_id: String,
     pub user_id: String,
+    /// Real author in group mode (the human who created the memory).
+    /// `None` in personal mode (user_id is already the author).
+    pub author_id: Option<String>,
     pub memory_type: MemoryType,
     pub content: String,
     pub initial_confidence: f64,

--- a/memoria/crates/memoria-git/src/lib.rs
+++ b/memoria/crates/memoria-git/src/lib.rs
@@ -1,2 +1,5 @@
 pub mod service;
-pub use service::{GitForDataService, Snapshot};
+pub use service::{
+    classify_diff_rows, ApplyResult, ApplySelection, ApplyUpdatePair, ClassifiedDiff, DiffConflict,
+    DiffConflictSide, DiffItem, DiffRow, DiffUpdatedPair, GitForDataService, Snapshot,
+};

--- a/memoria/crates/memoria-git/src/service.rs
+++ b/memoria/crates/memoria-git/src/service.rs
@@ -549,6 +549,7 @@ impl GitForDataService {
         user_id: &str,
         limit: i64,
     ) -> Result<Vec<DiffRow>, MemoriaError> {
+        let limit = limit.clamp(1, 5_000);
         let safe_branch = validate_identifier(branch_table)?;
         let safe_main = validate_identifier(main_table)?;
         let db = quote_identifier(&self.db_name);

--- a/memoria/crates/memoria-git/src/service.rs
+++ b/memoria/crates/memoria-git/src/service.rs
@@ -41,10 +41,298 @@ pub struct Snapshot {
 
 #[derive(Debug, Clone)]
 pub struct DiffRow {
-    pub flag: String, // INSERT | UPDATE | DELETE
+    pub source: String, // branch table name or main table name
+    pub flag: String,   // INSERT | UPDATE | DELETE
     pub memory_id: String,
     pub content: String,
     pub memory_type: String,
+    pub is_active: i8,
+    pub superseded_by: Option<String>,
+    pub author_id: Option<String>,
+}
+
+/// Classified diff result produced by [`classify_diff_rows`].
+///
+/// Classification rules (based on MatrixOne `data branch diff` output):
+///
+/// | Scenario                        | main | branch        | flag   | is_active | superseded_by | Category    |
+/// |---------------------------------|------|---------------|--------|-----------|---------------|-------------|
+/// | New memory on branch            | ✗    | ✓ (active)    | INSERT | 1         | NULL          | **ADDED**   |
+/// | Created then deleted on branch  | ✗    | ✓ (inactive)  | INSERT | 0         | NULL          | hidden      |
+/// | Created then corrected (old)    | ✗    | ✓ (inactive)  | INSERT | 0         | new_id        | hidden      |
+/// | Created then corrected (new)    | ✗    | ✓ (active)    | INSERT | 1         | NULL          | **ADDED**   |
+/// | Deleted main memory on branch   | ✓    | ✓ (inactive)  | UPDATE | 0         | NULL          | **REMOVED** |
+/// | Corrected main memory (old)     | ✓    | ✓ (inactive)  | UPDATE | 0         | new_id        | **UPDATED** |
+/// | Corrected main memory (new)     | ✗    | ✓ (active)    | INSERT | 1         | NULL          | paired into **UPDATED** |
+#[derive(Debug, Clone, Default)]
+pub struct ClassifiedDiff {
+    pub added: Vec<DiffItem>,
+    pub updated: Vec<DiffUpdatedPair>,
+    pub removed: Vec<DiffItem>,
+    pub conflicts: Vec<DiffConflict>,
+    /// Main-only changes: rows that exist on main but not on this branch
+    /// (other users' merges that happened after this branch was created).
+    pub behind_main: Vec<DiffItem>,
+}
+
+/// A single diff item (used for ADDED and REMOVED categories).
+#[derive(Debug, Clone)]
+pub struct DiffItem {
+    pub memory_id: String,
+    pub content: String,
+    pub memory_type: String,
+    pub author_id: Option<String>,
+}
+
+/// A paired UPDATED item: old memory (on main) → new memory (on branch).
+#[derive(Debug, Clone)]
+pub struct DiffUpdatedPair {
+    pub old_memory_id: String,
+    pub old_content: String,
+    pub new_memory_id: String,
+    pub new_content: String,
+    pub memory_type: String,
+    pub author_id: Option<String>,
+}
+
+/// A conflict where branch and main diverged on the same memory_id.
+#[derive(Debug, Clone)]
+pub struct DiffConflict {
+    pub memory_id: String,
+    pub branch_side: DiffConflictSide,
+    pub main_side: DiffConflictSide,
+}
+
+/// One side of a conflict.
+#[derive(Debug, Clone)]
+pub struct DiffConflictSide {
+    pub content: String,
+    pub is_active: i8,
+    pub superseded_by: Option<String>,
+    pub superseded_by_content: Option<String>,
+    pub author_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ApplySelection {
+    #[serde(default)]
+    pub adds: Vec<String>,
+    #[serde(default)]
+    pub removes: Vec<String>,
+    #[serde(default)]
+    pub updates: Vec<ApplyUpdatePair>,
+    #[serde(default)]
+    pub accept_branch_conflicts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApplyUpdatePair {
+    pub old_id: String,
+    pub new_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ApplyResult {
+    pub applied_adds: Vec<String>,
+    pub skipped_adds: Vec<String>,
+    pub applied_updates: Vec<String>,
+    pub skipped_updates: Vec<String>,
+    pub applied_removes: Vec<String>,
+    pub skipped_removes: Vec<String>,
+    pub applied_conflicts: Vec<String>,
+    pub skipped_conflicts: Vec<String>,
+}
+
+/// Classify raw `data branch diff` rows into ADDED / UPDATED / REMOVED / CONFLICTS.
+///
+/// Each DiffRow carries a `source` field (branch table name or main table name).
+/// The `branch_table` parameter identifies which source is "ours".
+///
+/// Algorithm:
+/// 1. Separate rows into branch-side and main-side by `source`.
+/// 2. Find memory_ids that appear on BOTH sides → CONFLICT.
+/// 3. Classify remaining branch-only rows using the original INSERT/UPDATE logic.
+/// 4. Main-only rows are ignored (behind-main; informational only for now).
+pub fn classify_diff_rows(rows: Vec<DiffRow>, branch_table: &str) -> ClassifiedDiff {
+    use std::collections::{HashMap, HashSet};
+
+    let mut result = ClassifiedDiff::default();
+
+    // Step 1: Separate by source
+    let mut branch_rows: Vec<&DiffRow> = Vec::new();
+    let mut main_rows: Vec<&DiffRow> = Vec::new();
+    for r in &rows {
+        if r.source == branch_table {
+            branch_rows.push(r);
+        } else {
+            main_rows.push(r);
+        }
+    }
+
+    // Step 2: Find conflicting memory_ids (present on both sides)
+    let branch_mids: HashSet<&str> = branch_rows.iter().map(|r| r.memory_id.as_str()).collect();
+    let main_mids: HashSet<&str> = main_rows.iter().map(|r| r.memory_id.as_str()).collect();
+    let conflict_mids: HashSet<&str> = branch_mids.intersection(&main_mids).copied().collect();
+
+    // Build conflict entries
+    if !conflict_mids.is_empty() {
+        // Build a content lookup for ALL rows so we can resolve superseded_by targets
+        let all_by_mid: HashMap<(&str, &str), &DiffRow> = rows
+            .iter()
+            .map(|r| ((r.source.as_str(), r.memory_id.as_str()), r))
+            .collect();
+
+        let branch_by_mid: HashMap<&str, &DiffRow> = branch_rows
+            .iter()
+            .filter(|r| conflict_mids.contains(r.memory_id.as_str()))
+            .map(|r| (r.memory_id.as_str(), *r))
+            .collect();
+        let main_by_mid: HashMap<&str, &DiffRow> = main_rows
+            .iter()
+            .filter(|r| conflict_mids.contains(r.memory_id.as_str()))
+            .map(|r| (r.memory_id.as_str(), *r))
+            .collect();
+
+        let resolve_superseded = |row: &DiffRow, source: &str| -> Option<String> {
+            row.superseded_by.as_ref().and_then(|sid| {
+                if sid.is_empty() {
+                    return None;
+                }
+                all_by_mid
+                    .get(&(source, sid.as_str()))
+                    .map(|r| r.content.clone())
+            })
+        };
+
+        for mid in &conflict_mids {
+            if let (Some(br), Some(mr)) = (branch_by_mid.get(mid), main_by_mid.get(mid)) {
+                result.conflicts.push(DiffConflict {
+                    memory_id: mid.to_string(),
+                    branch_side: DiffConflictSide {
+                        content: br.content.clone(),
+                        is_active: br.is_active,
+                        superseded_by: br.superseded_by.clone(),
+                        superseded_by_content: resolve_superseded(br, branch_table),
+                        author_id: br.author_id.clone(),
+                    },
+                    main_side: DiffConflictSide {
+                        content: mr.content.clone(),
+                        is_active: mr.is_active,
+                        superseded_by: mr.superseded_by.clone(),
+                        superseded_by_content: resolve_superseded(mr, &mr.source),
+                        author_id: mr.author_id.clone(),
+                    },
+                });
+            }
+        }
+    }
+
+    // Step 3: Classify branch-only rows (exclude conflicting memory_ids)
+    // Also exclude memory_ids that are the "new" side of a conflict correction pair
+    // (if a conflicting old_id has superseded_by pointing to new_id, that new_id is also conflict-related)
+    let mut conflict_related: HashSet<String> =
+        conflict_mids.iter().map(|s| s.to_string()).collect();
+    for r in &branch_rows {
+        if conflict_mids.contains(r.memory_id.as_str()) {
+            if let Some(ref new_id) = r.superseded_by {
+                if !new_id.is_empty() {
+                    conflict_related.insert(new_id.clone());
+                }
+            }
+        }
+    }
+
+    let clean_branch: Vec<&DiffRow> = branch_rows
+        .iter()
+        .filter(|r| !conflict_related.contains(&r.memory_id))
+        .copied()
+        .collect();
+
+    // Build superseded map from clean branch rows
+    let mut superseded_map: HashMap<String, &DiffRow> = HashMap::new();
+    for r in &clean_branch {
+        if r.flag == "UPDATE" && r.is_active == 0 {
+            if let Some(ref new_id) = r.superseded_by {
+                if !new_id.is_empty() {
+                    superseded_map.insert(new_id.clone(), r);
+                }
+            }
+        }
+    }
+
+    // Process INSERT rows
+    for r in &clean_branch {
+        if r.flag != "INSERT" || r.is_active == 0 {
+            continue;
+        }
+        if let Some(old_row) = superseded_map.remove(&r.memory_id) {
+            result.updated.push(DiffUpdatedPair {
+                old_memory_id: old_row.memory_id.clone(),
+                old_content: old_row.content.clone(),
+                new_memory_id: r.memory_id.clone(),
+                new_content: r.content.clone(),
+                memory_type: r.memory_type.clone(),
+                author_id: r.author_id.clone(),
+            });
+        } else {
+            result.added.push(DiffItem {
+                memory_id: r.memory_id.clone(),
+                content: r.content.clone(),
+                memory_type: r.memory_type.clone(),
+                author_id: r.author_id.clone(),
+            });
+        }
+    }
+
+    // Process UPDATE rows — is_active=0 without superseded_by → REMOVED
+    for r in &clean_branch {
+        if r.flag != "UPDATE" || r.is_active != 0 {
+            continue;
+        }
+        let has_superseded = r
+            .superseded_by
+            .as_ref()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false);
+        if !has_superseded {
+            result.removed.push(DiffItem {
+                memory_id: r.memory_id.clone(),
+                content: r.content.clone(),
+                memory_type: r.memory_type.clone(),
+                author_id: r.author_id.clone(),
+            });
+        }
+    }
+
+    // Step 4: Collect main-only rows as behind_main (exclude conflict-related)
+    let mut main_conflict_related: HashSet<String> =
+        conflict_mids.iter().map(|s| s.to_string()).collect();
+    for r in &main_rows {
+        if conflict_mids.contains(r.memory_id.as_str()) {
+            if let Some(ref new_id) = r.superseded_by {
+                if !new_id.is_empty() {
+                    main_conflict_related.insert(new_id.clone());
+                }
+            }
+        }
+    }
+    for r in &main_rows {
+        if main_conflict_related.contains(&r.memory_id) {
+            continue;
+        }
+        // Only show active main-only items (new additions by others)
+        // and meaningful changes (corrections, deletions)
+        if r.is_active == 1 {
+            result.behind_main.push(DiffItem {
+                memory_id: r.memory_id.clone(),
+                content: r.content.clone(),
+                memory_type: r.memory_type.clone(),
+                author_id: r.author_id.clone(),
+            });
+        }
+    }
+
+    result
 }
 
 pub struct GitForDataService {
@@ -229,24 +517,31 @@ impl GitForDataService {
 
     /// LCA-based diff count for a specific user.
     /// Native `output count` is account-level, so we fetch rows and count in Rust.
+    /// Counts only visible changes (ADDED + UPDATED + REMOVED) after classification.
     pub async fn diff_branch_count(
         &self,
         branch_table: &str,
         main_table: &str,
         user_id: &str,
     ) -> Result<i64, MemoriaError> {
-        // Fetch a large batch and count user's rows
-        // For safety limit purposes, 5000 is the max we care about
         let rows = self
             .diff_branch_rows(branch_table, main_table, user_id, 5001)
             .await?;
-        Ok(rows.len() as i64)
+        let classified = classify_diff_rows(rows, branch_table);
+        let total = classified.added.len()
+            + classified.updated.len()
+            + classified.removed.len()
+            + classified.conflicts.len()
+            + classified.behind_main.len();
+        Ok(total as i64)
     }
 
     /// Native LCA-based diff rows, filtered by user_id.
     ///
     /// `data branch diff` is account-level (no WHERE clause supported), so we fetch
-    /// all rows and filter in Rust. This avoids exposing other users' memories.
+    /// all rows and filter in Rust. Returns raw diff rows including source, is_active,
+    /// superseded_by, and author_id.
+    /// Use [`classify_diff_rows`] to get ADDED/UPDATED/REMOVED/CONFLICTS.
     pub async fn diff_branch_rows(
         &self,
         branch_table: &str,
@@ -260,7 +555,9 @@ impl GitForDataService {
         // Fetch more than limit to account for filtering
         let fetch_limit = limit * 10 + 100;
         let sql = format!(
-            "data branch diff {db}.{safe_branch} against {db}.{safe_main} output limit {fetch_limit}"
+            "data branch diff {db}.{safe_branch} against {db}.{safe_main} \
+             columns (user_id, memory_id, content, memory_type, is_active, superseded_by, author_id) \
+             output limit {fetch_limit}"
         );
         let rows = sqlx::raw_sql(&sql)
             .fetch_all(&self.pool)
@@ -272,16 +569,403 @@ impl GitForDataService {
             if uid != user_id {
                 continue;
             }
+            // First column (index 0) is the source table name
+            let source: String = r.try_get(0usize).unwrap_or_default();
             result.push(DiffRow {
+                source,
                 flag: r.try_get("flag").map_err(db_err)?,
                 memory_id: r.try_get("memory_id").map_err(db_err)?,
                 content: r.try_get("content").map_err(db_err)?,
-                memory_type: r.try_get("memory_type").map_err(db_err)?,
+                memory_type: r
+                    .try_get("memory_type")
+                    .unwrap_or_else(|_| "semantic".into()),
+                is_active: r.try_get("is_active").unwrap_or(1),
+                superseded_by: {
+                    let val: Option<String> = r.try_get("superseded_by").unwrap_or(None);
+                    val.filter(|s| !s.is_empty())
+                },
+                author_id: {
+                    let val: Option<String> = r.try_get("author_id").unwrap_or(None);
+                    val.filter(|s| !s.is_empty())
+                },
             });
             if result.len() >= limit as usize {
                 break;
             }
         }
+        Ok(result)
+    }
+
+    pub async fn selective_apply(
+        &self,
+        branch_table: &str,
+        main_table: &str,
+        user_id: &str,
+        selection: ApplySelection,
+    ) -> Result<ApplyResult, MemoriaError> {
+        let branch_table = validate_identifier(branch_table)?.to_string();
+        let main_table = validate_identifier(main_table)?.to_string();
+        let db = quote_identifier(&self.db_name);
+        let branch_table_ref = format!("{db}.{branch_table}");
+        let main_table_ref = format!("{db}.{main_table}");
+
+        let add_ids: Vec<String> = selection
+            .adds
+            .into_iter()
+            .filter(|id| !id.is_empty())
+            .collect();
+        let update_pairs: Vec<ApplyUpdatePair> = selection
+            .updates
+            .into_iter()
+            .filter(|p| !p.old_id.is_empty() && !p.new_id.is_empty())
+            .collect();
+        let remove_ids: Vec<String> = selection
+            .removes
+            .into_iter()
+            .filter(|id| !id.is_empty())
+            .collect();
+        let conflict_ids: Vec<String> = selection
+            .accept_branch_conflicts
+            .into_iter()
+            .filter(|id| !id.is_empty())
+            .collect();
+
+        let classified = if conflict_ids.is_empty() {
+            None
+        } else {
+            // `data branch diff` cannot filter by memory_id, so fetch a generous window
+            // and re-check that each requested item is still a current conflict.
+            Some(classify_diff_rows(
+                self.diff_branch_rows(&branch_table, &main_table, user_id, 5_000)
+                    .await?,
+                &branch_table,
+            ))
+        };
+        let conflict_map: std::collections::HashMap<&str, &DiffConflict> = classified
+            .as_ref()
+            .map(|classified| {
+                classified
+                    .conflicts
+                    .iter()
+                    .map(|conflict| (conflict.memory_id.as_str(), conflict))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut result = ApplyResult::default();
+        let mut tx = self.pool.begin().await.map_err(db_err)?;
+
+        if !add_ids.is_empty() {
+            let placeholders = add_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+            let branch_sql = format!(
+                "SELECT memory_id FROM {branch_table_ref} WHERE user_id = ? AND is_active = 1 AND memory_id IN ({placeholders})"
+            );
+            let mut q = sqlx::query(&branch_sql).bind(user_id);
+            for id in &add_ids {
+                q = q.bind(id);
+            }
+            let branch_present: std::collections::HashSet<String> = q
+                .fetch_all(&mut *tx)
+                .await
+                .map_err(db_err)?
+                .iter()
+                .filter_map(|row| row.try_get::<String, _>("memory_id").ok())
+                .collect();
+
+            let main_sql = format!(
+                "SELECT memory_id FROM {main_table_ref} WHERE user_id = ? AND memory_id IN ({placeholders})"
+            );
+            let mut q = sqlx::query(&main_sql).bind(user_id);
+            for id in &add_ids {
+                q = q.bind(id);
+            }
+            let main_present: std::collections::HashSet<String> = q
+                .fetch_all(&mut *tx)
+                .await
+                .map_err(db_err)?
+                .iter()
+                .filter_map(|row| row.try_get::<String, _>("memory_id").ok())
+                .collect();
+
+            for id in &add_ids {
+                if branch_present.contains(id) && !main_present.contains(id) {
+                    result.applied_adds.push(id.clone());
+                } else {
+                    result.skipped_adds.push(id.clone());
+                }
+            }
+
+            if !result.applied_adds.is_empty() {
+                let ph = result
+                    .applied_adds
+                    .iter()
+                    .map(|_| "?")
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let insert_sql = format!(
+                    "INSERT INTO {main_table_ref} \
+                     (memory_id, user_id, memory_type, content, embedding, session_id, \
+                      source_event_ids, extra_metadata, is_active, superseded_by, \
+                      trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id) \
+                     SELECT memory_id, user_id, memory_type, content, embedding, session_id, \
+                            source_event_ids, extra_metadata, is_active, superseded_by, \
+                            trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id \
+                     FROM {branch_table_ref} WHERE user_id = ? AND is_active = 1 AND memory_id IN ({ph})"
+                );
+                let mut q = sqlx::query(&insert_sql).bind(user_id);
+                for id in &result.applied_adds {
+                    q = q.bind(id);
+                }
+                q.execute(&mut *tx).await.map_err(db_err)?;
+            }
+        }
+
+        if !update_pairs.is_empty() {
+            for pair in &update_pairs {
+                let old_exists: i64 = sqlx::query_scalar(&format!(
+                    "SELECT COUNT(*) FROM {main_table_ref} WHERE memory_id = ? AND user_id = ?"
+                ))
+                .bind(&pair.old_id)
+                .bind(user_id)
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(db_err)?;
+
+                let branch_old_exists: i64 = sqlx::query_scalar(&format!(
+                    "SELECT COUNT(*) FROM {branch_table_ref} WHERE memory_id = ? AND user_id = ?"
+                ))
+                .bind(&pair.old_id)
+                .bind(user_id)
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(db_err)?;
+                let branch_new_exists: i64 = sqlx::query_scalar(&format!(
+                    "SELECT COUNT(*) FROM {branch_table_ref} WHERE memory_id = ? AND user_id = ? AND is_active = 1"
+                ))
+                .bind(&pair.new_id)
+                .bind(user_id)
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(db_err)?;
+
+                if old_exists > 0 && branch_old_exists > 0 && branch_new_exists > 0 {
+                    sqlx::query(&format!(
+                        "DELETE FROM {main_table_ref} WHERE user_id = ? AND memory_id = ?"
+                    ))
+                    .bind(user_id)
+                    .bind(&pair.old_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(db_err)?;
+
+                    sqlx::query(&format!(
+                        "INSERT INTO {main_table_ref} \
+                         (memory_id, user_id, memory_type, content, embedding, session_id, \
+                          source_event_ids, extra_metadata, is_active, superseded_by, \
+                          trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id) \
+                         SELECT memory_id, user_id, memory_type, content, embedding, session_id, \
+                                source_event_ids, extra_metadata, is_active, superseded_by, \
+                                trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id \
+                         FROM {branch_table_ref} WHERE memory_id = ? AND user_id = ?"
+                    ))
+                    .bind(&pair.old_id)
+                    .bind(user_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(db_err)?;
+
+                    sqlx::query(&format!(
+                        "INSERT INTO {main_table_ref} \
+                         (memory_id, user_id, memory_type, content, embedding, session_id, \
+                          source_event_ids, extra_metadata, is_active, superseded_by, \
+                          trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id) \
+                         SELECT memory_id, user_id, memory_type, content, embedding, session_id, \
+                                source_event_ids, extra_metadata, is_active, superseded_by, \
+                                trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id \
+                         FROM {branch_table_ref} WHERE memory_id = ? AND user_id = ? AND is_active = 1"
+                    ))
+                    .bind(&pair.new_id)
+                    .bind(user_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(db_err)?;
+
+                    result
+                        .applied_updates
+                        .push(format!("{}→{}", pair.old_id, pair.new_id));
+                } else {
+                    result
+                        .skipped_updates
+                        .push(format!("{}→{}", pair.old_id, pair.new_id));
+                }
+            }
+        }
+
+        if !remove_ids.is_empty() {
+            let placeholders = remove_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+            let main_sql = format!(
+                "SELECT memory_id FROM {main_table_ref} WHERE user_id = ? AND is_active = 1 AND memory_id IN ({placeholders})"
+            );
+            let mut q = sqlx::query(&main_sql).bind(user_id);
+            for id in &remove_ids {
+                q = q.bind(id);
+            }
+            let main_present: std::collections::HashSet<String> = q
+                .fetch_all(&mut *tx)
+                .await
+                .map_err(db_err)?
+                .iter()
+                .filter_map(|row| row.try_get::<String, _>("memory_id").ok())
+                .collect();
+
+            let branch_sql = format!(
+                "SELECT memory_id FROM {branch_table_ref} WHERE user_id = ? AND is_active = 0 AND memory_id IN ({placeholders})"
+            );
+            let mut q = sqlx::query(&branch_sql).bind(user_id);
+            for id in &remove_ids {
+                q = q.bind(id);
+            }
+            let branch_present: std::collections::HashSet<String> = q
+                .fetch_all(&mut *tx)
+                .await
+                .map_err(db_err)?
+                .iter()
+                .filter_map(|row| row.try_get::<String, _>("memory_id").ok())
+                .collect();
+
+            for id in &remove_ids {
+                if main_present.contains(id) && branch_present.contains(id) {
+                    result.applied_removes.push(id.clone());
+                } else {
+                    result.skipped_removes.push(id.clone());
+                }
+            }
+
+            if !result.applied_removes.is_empty() {
+                let ph = result
+                    .applied_removes
+                    .iter()
+                    .map(|_| "?")
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let del_sql = format!(
+                    "DELETE FROM {main_table_ref} WHERE user_id = ? AND memory_id IN ({ph})"
+                );
+                let mut q = sqlx::query(&del_sql).bind(user_id);
+                for id in &result.applied_removes {
+                    q = q.bind(id);
+                }
+                q.execute(&mut *tx).await.map_err(db_err)?;
+
+                let ins_sql = format!(
+                    "INSERT INTO {main_table_ref} \
+                     (memory_id, user_id, memory_type, content, embedding, session_id, \
+                      source_event_ids, extra_metadata, is_active, superseded_by, \
+                      trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id) \
+                     SELECT memory_id, user_id, memory_type, content, embedding, session_id, \
+                            source_event_ids, extra_metadata, is_active, superseded_by, \
+                            trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id \
+                     FROM {branch_table_ref} WHERE user_id = ? AND is_active = 0 AND memory_id IN ({ph})"
+                );
+                let mut q = sqlx::query(&ins_sql).bind(user_id);
+                for id in &result.applied_removes {
+                    q = q.bind(id);
+                }
+                q.execute(&mut *tx).await.map_err(db_err)?;
+            }
+        }
+
+        if !conflict_ids.is_empty() {
+            for conflict_id in &conflict_ids {
+                let Some(conflict) = conflict_map.get(conflict_id.as_str()) else {
+                    result.skipped_conflicts.push(conflict_id.clone());
+                    continue;
+                };
+
+                let mut branch_ids = vec![conflict.memory_id.clone()];
+                if let Some(new_id) = conflict.branch_side.superseded_by.clone() {
+                    branch_ids.push(new_id);
+                }
+                branch_ids.sort();
+                branch_ids.dedup();
+
+                let mut main_ids = vec![conflict.memory_id.clone()];
+                if let Some(new_id) = conflict.main_side.superseded_by.clone() {
+                    main_ids.push(new_id);
+                }
+                main_ids.sort();
+                main_ids.dedup();
+
+                let branch_ph = branch_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+                let branch_exists_sql = format!(
+                    "SELECT memory_id FROM {branch_table_ref} WHERE user_id = ? AND memory_id IN ({branch_ph})"
+                );
+                let mut q = sqlx::query(&branch_exists_sql).bind(user_id);
+                for id in &branch_ids {
+                    q = q.bind(id);
+                }
+                let branch_present: std::collections::HashSet<String> = q
+                    .fetch_all(&mut *tx)
+                    .await
+                    .map_err(db_err)?
+                    .iter()
+                    .filter_map(|row| row.try_get::<String, _>("memory_id").ok())
+                    .collect();
+                if branch_present.len() != branch_ids.len() {
+                    result.skipped_conflicts.push(conflict_id.clone());
+                    continue;
+                }
+
+                let main_ph = main_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+                let main_exists_sql = format!(
+                    "SELECT memory_id FROM {main_table_ref} WHERE user_id = ? AND memory_id IN ({main_ph})"
+                );
+                let mut q = sqlx::query(&main_exists_sql).bind(user_id);
+                for id in &main_ids {
+                    q = q.bind(id);
+                }
+                let main_present: std::collections::HashSet<String> = q
+                    .fetch_all(&mut *tx)
+                    .await
+                    .map_err(db_err)?
+                    .iter()
+                    .filter_map(|row| row.try_get::<String, _>("memory_id").ok())
+                    .collect();
+                if main_present.len() != main_ids.len() {
+                    result.skipped_conflicts.push(conflict_id.clone());
+                    continue;
+                }
+
+                let del_sql = format!(
+                    "DELETE FROM {main_table_ref} WHERE user_id = ? AND memory_id IN ({main_ph})"
+                );
+                let mut q = sqlx::query(&del_sql).bind(user_id);
+                for id in &main_ids {
+                    q = q.bind(id);
+                }
+                q.execute(&mut *tx).await.map_err(db_err)?;
+
+                let ins_sql = format!(
+                    "INSERT INTO {main_table_ref} \
+                     (memory_id, user_id, memory_type, content, embedding, session_id, \
+                      source_event_ids, extra_metadata, is_active, superseded_by, \
+                      trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id) \
+                     SELECT memory_id, user_id, memory_type, content, embedding, session_id, \
+                            source_event_ids, extra_metadata, is_active, superseded_by, \
+                            trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id \
+                     FROM {branch_table_ref} WHERE user_id = ? AND memory_id IN ({branch_ph})"
+                );
+                let mut q = sqlx::query(&ins_sql).bind(user_id);
+                for id in &branch_ids {
+                    q = q.bind(id);
+                }
+                q.execute(&mut *tx).await.map_err(db_err)?;
+
+                result.applied_conflicts.push(conflict_id.clone());
+            }
+        }
+
+        tx.commit().await.map_err(db_err)?;
         Ok(result)
     }
 

--- a/memoria/crates/memoria-mcp/src/git_tools.rs
+++ b/memoria/crates/memoria-mcp/src/git_tools.rs
@@ -13,7 +13,7 @@
 
 use chrono::NaiveDateTime;
 use memoria_core::MemoriaError;
-use memoria_git::{service::DiffRow, GitForDataService};
+use memoria_git::GitForDataService;
 use memoria_service::MemoryService;
 use serde_json::{json, Value};
 use sqlx::Row;
@@ -462,6 +462,48 @@ pub fn list() -> Value {
                 },
                 "required": ["source"]
             }
+        },
+        {
+            "name": "memory_apply",
+            "description": "Selectively apply specific changes from a branch to main (cherry-pick). Use memory_diff first to see available changes, then pass the memory_ids you want to apply.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "source": {"type": "string", "description": "Branch name to apply from"},
+                    "adds": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "default": [],
+                        "description": "memory_ids to add (new in branch, absent from main)"
+                    },
+                    "updates": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "old_id": {"type": "string", "description": "Original memory_id (will be superseded)"},
+                                "new_id": {"type": "string", "description": "Corrected memory_id (active replacement)"}
+                            },
+                            "required": ["old_id", "new_id"]
+                        },
+                        "default": [],
+                        "description": "Correction pairs: old_id (superseded) → new_id (replacement)"
+                    },
+                    "removes": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "default": [],
+                        "description": "memory_ids to remove (soft-delete from main)"
+                    },
+                    "accept_branch_conflicts": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "default": [],
+                        "description": "Conflict memory_ids to resolve with branch-wins semantics. Unspecified conflicts stay on main."
+                    }
+                },
+                "required": ["source"]
+            }
         }
     ])
 }
@@ -477,6 +519,7 @@ enum GitToolCallName {
     MemoryMerge,
     MemoryBranchDelete,
     MemoryDiff,
+    MemoryApply,
     Unknown(String),
 }
 
@@ -498,6 +541,7 @@ pub async fn call(
         "memory_merge" => GitToolCallName::MemoryMerge,
         "memory_branch_delete" => GitToolCallName::MemoryBranchDelete,
         "memory_diff" => GitToolCallName::MemoryDiff,
+        "memory_apply" => GitToolCallName::MemoryApply,
         _ => GitToolCallName::Unknown(name.to_string()),
     };
     match tool {
@@ -728,10 +772,10 @@ pub async fn call(
                 )));
             }
 
-            // Duplicate name check (including deleted)
+            // Duplicate name check — only reject if an active branch with same name exists
             let branches_table = sql.t("mem_branches");
             let dup = sqlx::query(&format!(
-                "SELECT COUNT(*) as cnt FROM {branches_table} WHERE user_id = ? AND name = ?"
+                "SELECT COUNT(*) as cnt FROM {branches_table} WHERE user_id = ? AND name = ? AND status = 'active'"
             ))
             .bind(user_id)
             .bind(branch_name)
@@ -970,136 +1014,103 @@ pub async fn call(
         }
 
         GitToolCallName::MemoryDiff => {
-            let source_branch = args["source"].as_str().unwrap_or("");
-            let limit = args["limit"].as_i64().unwrap_or(50);
+            expect_tool_args(&args, "memory_diff", &["source", "limit"])?;
+            let source_branch = parse_required_string_arg(&args, "memory_diff", "source")?;
+            let limit = parse_optional_i64_arg(&args, "memory_diff", "limit", 50)?;
             let sql = svc.user_sql_store(user_id).await?;
+            let user_git = git_for_store(&sql)?;
             let branches = sql.list_branches(user_id).await?;
             let table_name = branches
                 .iter()
-                .find(|(name, _)| name == source_branch)
+                .find(|(name, _)| name == source_branch.as_str())
                 .map(|(_, t)| t.clone())
                 .ok_or_else(|| MemoriaError::NotFound(format!("Branch '{source_branch}'")))?;
-            let main_table = sql.t("mem_memories");
-            let branch_table = sql.t(&table_name);
 
-            let inserted_or_updated_sql = format!(
-                "SELECT \
-                    CASE WHEN m.memory_id IS NULL THEN 'INSERT' ELSE 'UPDATE' END AS flag, \
-                    b.memory_id, b.content, b.memory_type \
-                 FROM {branch_table} b \
-                 LEFT JOIN {main_table} m ON m.memory_id = b.memory_id \
-                 WHERE b.user_id = ? \
-                   AND (m.memory_id IS NULL \
-                        OR COALESCE(m.content, '') <> COALESCE(b.content, '') \
-                        OR COALESCE(m.is_active, 0) <> COALESCE(b.is_active, 0)) \
-                 ORDER BY b.created_at DESC \
-                 LIMIT ?"
-            );
-            let deleted_sql = format!(
-                "SELECT \
-                    'DELETE' AS flag, \
-                    m.memory_id, m.content, m.memory_type \
-                 FROM {main_table} m \
-                 LEFT JOIN {branch_table} b ON b.memory_id = m.memory_id \
-                 WHERE m.user_id = ? AND m.is_active = 1 AND b.memory_id IS NULL \
-                 ORDER BY m.created_at DESC \
-                 LIMIT ?"
-            );
-            let inserted_or_updated_count_sql = format!(
-                "SELECT COUNT(*) \
-                 FROM {branch_table} b \
-                 LEFT JOIN {main_table} m ON m.memory_id = b.memory_id \
-                 WHERE b.user_id = ? \
-                   AND (m.memory_id IS NULL \
-                        OR COALESCE(m.content, '') <> COALESCE(b.content, '') \
-                        OR COALESCE(m.is_active, 0) <> COALESCE(b.is_active, 0))"
-            );
-            let deleted_count_sql = format!(
-                "SELECT COUNT(*) \
-                 FROM {main_table} m \
-                 LEFT JOIN {branch_table} b ON b.memory_id = m.memory_id \
-                 WHERE m.user_id = ? AND m.is_active = 1 AND b.memory_id IS NULL"
-            );
-            let inserted_or_updated_total: i64 = sqlx::query_scalar(&inserted_or_updated_count_sql)
-                .bind(user_id)
-                .fetch_one(sql.pool())
-                .await
-                .map_err(db_err)?;
-            let deleted_total: i64 = sqlx::query_scalar(&deleted_count_sql)
-                .bind(user_id)
-                .fetch_one(sql.pool())
-                .await
-                .map_err(db_err)?;
+            // Use MatrixOne native `data branch diff` + classify
+            let raw_rows = user_git
+                .diff_branch_rows(&table_name, "mem_memories", user_id, limit * 3)
+                .await?;
+            let classified = memoria_git::classify_diff_rows(raw_rows, &table_name);
 
-            let mut rows: Vec<DiffRow> = sqlx::query(&inserted_or_updated_sql)
-                .bind(user_id)
-                .bind(limit)
-                .fetch_all(sql.pool())
-                .await
-                .map_err(db_err)?
-                .into_iter()
-                .map(|row| {
-                    Ok(DiffRow {
-                        flag: row.try_get("flag").map_err(db_err)?,
-                        memory_id: row.try_get("memory_id").map_err(db_err)?,
-                        content: row.try_get("content").unwrap_or_default(),
-                        memory_type: row
-                            .try_get("memory_type")
-                            .unwrap_or_else(|_| "semantic".into()),
-                    })
-                })
-                .collect::<Result<Vec<_>, MemoriaError>>()?;
-
-            let deleted_rows: Vec<DiffRow> = sqlx::query(&deleted_sql)
-                .bind(user_id)
-                .bind(limit)
-                .fetch_all(sql.pool())
-                .await
-                .map_err(db_err)?
-                .into_iter()
-                .map(|row| {
-                    Ok(DiffRow {
-                        flag: row.try_get("flag").map_err(db_err)?,
-                        memory_id: row.try_get("memory_id").map_err(db_err)?,
-                        content: row.try_get("content").unwrap_or_default(),
-                        memory_type: row
-                            .try_get("memory_type")
-                            .unwrap_or_else(|_| "semantic".into()),
-                    })
-                })
-                .collect::<Result<Vec<_>, MemoriaError>>()?;
-
-            rows.extend(deleted_rows);
-            rows.truncate(limit.max(0) as usize);
-            let shown = rows.len() as i64;
-            let total = inserted_or_updated_total + deleted_total;
+            let total = classified.added.len()
+                + classified.updated.len()
+                + classified.removed.len()
+                + classified.conflicts.len();
             if total == 0 {
                 return Ok(mcp_text(&format!(
                     "No changes in branch '{source_branch}' vs main."
                 )));
             }
-            let lines: Vec<String> = rows
-                .iter()
-                .map(|r| {
-                    let semantic = match r.flag.as_str() {
-                        "INSERT" => "new",
-                        "UPDATE" => "modified",
-                        "DELETE" => "removed",
-                        other => other,
-                    };
-                    let preview = if r.content.len() > 80 {
-                        let mut end = 80;
-                        while !r.content.is_char_boundary(end) { end -= 1; }
-                        format!("{}...", &r.content[..end])
-                    } else {
-                        r.content.clone()
-                    };
-                    format!(
-                        "[{semantic}] {}: {preview}",
-                        &r.memory_id[..8.min(r.memory_id.len())]
-                    )
-                })
-                .collect();
+
+            let preview = |content: &str| -> String {
+                if content.len() > 80 {
+                    let mut end = 80;
+                    while !content.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    format!("{}...", &content[..end])
+                } else {
+                    content.to_string()
+                }
+            };
+            let short_id = |id: &str| -> String { id[..8.min(id.len())].to_string() };
+
+            let mut lines: Vec<String> = Vec::new();
+            let limit_usize = limit.max(0) as usize;
+
+            for item in classified.added.iter().take(limit_usize) {
+                lines.push(format!(
+                    "[new] {}: {}",
+                    short_id(&item.memory_id),
+                    preview(&item.content)
+                ));
+            }
+            for pair in classified.updated.iter().take(limit_usize) {
+                lines.push(format!(
+                    "[modified] {} → {}: {}",
+                    short_id(&pair.old_memory_id),
+                    short_id(&pair.new_memory_id),
+                    preview(&pair.new_content)
+                ));
+            }
+            for item in classified.removed.iter().take(limit_usize) {
+                lines.push(format!(
+                    "[removed] {}: {}",
+                    short_id(&item.memory_id),
+                    preview(&item.content)
+                ));
+            }
+            for c in classified.conflicts.iter().take(limit_usize) {
+                let br_sup = c
+                    .branch_side
+                    .superseded_by_content
+                    .as_deref()
+                    .map(|s| format!(" →new: {}", preview(s)))
+                    .unwrap_or_default();
+                let mn_sup = c
+                    .main_side
+                    .superseded_by_content
+                    .as_deref()
+                    .map(|s| format!(" →new: {}", preview(s)))
+                    .unwrap_or_default();
+                lines.push(format!(
+                    "[CONFLICT] {}: branch({}{}), main({}{})",
+                    short_id(&c.memory_id),
+                    preview(&c.branch_side.content),
+                    br_sup,
+                    preview(&c.main_side.content),
+                    mn_sup,
+                ));
+            }
+            for item in classified.behind_main.iter().take(limit_usize) {
+                lines.push(format!(
+                    "[behind] {}: {}",
+                    short_id(&item.memory_id),
+                    preview(&item.content)
+                ));
+            }
+
+            let shown = lines.len();
             let truncated = if total > shown {
                 format!(" (showing {shown}/{total})")
             } else {
@@ -1108,6 +1119,62 @@ pub async fn call(
             Ok(mcp_text(&format!(
                 "Diff '{source_branch}' vs main{truncated}:\n{}",
                 lines.join("\n")
+            )))
+        }
+
+        GitToolCallName::MemoryApply => {
+            expect_tool_args(
+                &args,
+                "memory_apply",
+                &[
+                    "source",
+                    "adds",
+                    "updates",
+                    "removes",
+                    "accept_branch_conflicts",
+                ],
+            )?;
+            let source_branch = parse_required_string_arg(&args, "memory_apply", "source")?;
+            if source_branch == "main" {
+                return Ok(mcp_text("Cannot apply from main"));
+            }
+            let selection = memoria_git::ApplySelection {
+                adds: parse_apply_string_array(&args, "adds")?,
+                updates: parse_apply_updates(&args)?,
+                removes: parse_apply_string_array(&args, "removes")?,
+                accept_branch_conflicts: parse_apply_string_array(
+                    &args,
+                    "accept_branch_conflicts",
+                )?,
+            };
+            if selection.adds.is_empty()
+                && selection.updates.is_empty()
+                && selection.removes.is_empty()
+                && selection.accept_branch_conflicts.is_empty()
+            {
+                return Ok(mcp_text(
+                    "Nothing to apply. Provide at least one of: adds, updates, removes, accept_branch_conflicts.",
+                ));
+            }
+
+            let sql = svc.user_sql_store(user_id).await?;
+            let branches = sql.list_branches(user_id).await?;
+            let table_name = branches
+                .iter()
+                .find(|(name, _)| name == &source_branch)
+                .map(|(_, t)| t.clone())
+                .ok_or_else(|| MemoriaError::NotFound(format!("Branch '{source_branch}'")))?;
+            let branch_table_name = validate_identifier(&table_name)?.to_string();
+            let user_git = git_for_store(&sql)?;
+            let report = user_git
+                .selective_apply(&branch_table_name, "mem_memories", user_id, selection)
+                .await?;
+            Ok(mcp_text(&format!(
+                "Applied from '{source_branch}': {} added, {} updated, {} removed, {} conflicts accepted",
+                report.applied_adds.len(),
+                report.applied_updates.len(),
+                report.applied_removes.len(),
+                report.applied_conflicts.len()
             )))
         }
 
@@ -1189,9 +1256,110 @@ fn mcp_text(text: &str) -> Value {
     json!({"content": [{"type": "text", "text": text}]})
 }
 
+fn expect_tool_args<'a>(
+    args: &'a Value,
+    tool: &str,
+    allowed: &[&str],
+) -> Result<&'a serde_json::Map<String, Value>, MemoriaError> {
+    let map = args.as_object().ok_or_else(|| {
+        MemoriaError::Internal(format!("Invalid {tool} arguments: expected object"))
+    })?;
+    for key in map.keys() {
+        if !allowed.iter().any(|allowed_key| allowed_key == key) {
+            return Err(MemoriaError::Internal(format!(
+                "Invalid {tool} argument '{key}': unknown field"
+            )));
+        }
+    }
+    Ok(map)
+}
+
+fn parse_required_string_arg(
+    args: &Value,
+    tool: &str,
+    field: &str,
+) -> Result<String, MemoriaError> {
+    args.get(field)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            MemoriaError::Internal(format!(
+                "Invalid {tool} '{field}': expected non-empty string"
+            ))
+        })
+}
+
+fn parse_optional_i64_arg(
+    args: &Value,
+    tool: &str,
+    field: &str,
+    default: i64,
+) -> Result<i64, MemoriaError> {
+    match args.get(field) {
+        None => Ok(default),
+        Some(value) => value.as_i64().ok_or_else(|| {
+            MemoriaError::Internal(format!("Invalid {tool} '{field}': expected integer"))
+        }),
+    }
+}
+
+fn parse_apply_string_array(args: &Value, field: &str) -> Result<Vec<String>, MemoriaError> {
+    match args.get(field) {
+        None => Ok(Vec::new()),
+        Some(Value::Array(values)) => values
+            .iter()
+            .enumerate()
+            .map(|(idx, value)| {
+                value.as_str().map(str::to_string).ok_or_else(|| {
+                    MemoriaError::Internal(format!(
+                        "Invalid memory_apply '{field}[{idx}]': expected string"
+                    ))
+                })
+            })
+            .collect(),
+        Some(_) => Err(MemoriaError::Internal(format!(
+            "Invalid memory_apply '{field}': expected array"
+        ))),
+    }
+}
+
+fn parse_apply_updates(args: &Value) -> Result<Vec<memoria_git::ApplyUpdatePair>, MemoriaError> {
+    match args.get("updates") {
+        None => Ok(Vec::new()),
+        Some(Value::Array(values)) => values
+            .iter()
+            .enumerate()
+            .map(|(idx, value)| {
+                let old_id = value.get("old_id").and_then(Value::as_str).ok_or_else(|| {
+                    MemoriaError::Internal(format!(
+                        "Invalid memory_apply 'updates[{idx}].old_id': expected string"
+                    ))
+                })?;
+                let new_id = value.get("new_id").and_then(Value::as_str).ok_or_else(|| {
+                    MemoriaError::Internal(format!(
+                        "Invalid memory_apply 'updates[{idx}].new_id': expected string"
+                    ))
+                })?;
+                Ok(memoria_git::ApplyUpdatePair {
+                    old_id: old_id.to_string(),
+                    new_id: new_id.to_string(),
+                })
+            })
+            .collect(),
+        Some(_) => Err(MemoriaError::Internal(
+            "Invalid memory_apply 'updates': expected array".to_string(),
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{safety_prefix, snap_internal, validate_identifier, MAX_IDENTIFIER_LEN};
+    use super::{
+        expect_tool_args, parse_apply_string_array, parse_apply_updates, safety_prefix,
+        snap_internal, validate_identifier, MAX_IDENTIFIER_LEN,
+    };
+    use serde_json::json;
 
     #[test]
     fn scoped_snapshot_internal_names_stay_within_matrixone_limit() {
@@ -1220,5 +1388,33 @@ mod tests {
         assert!(validate_identifier("br_bad-name").is_err());
         assert!(validate_identifier("br bad").is_err());
         assert!(validate_identifier("br`bad").is_err());
+    }
+
+    #[test]
+    fn apply_arrays_default_to_empty_when_missing() {
+        let args = json!({"source": "feature"});
+        assert!(parse_apply_string_array(&args, "adds").unwrap().is_empty());
+        assert!(parse_apply_string_array(&args, "removes")
+            .unwrap()
+            .is_empty());
+        assert!(parse_apply_updates(&args).unwrap().is_empty());
+    }
+
+    #[test]
+    fn apply_arrays_error_on_type_mismatch() {
+        let args = json!({"source": "feature", "adds": "oops"});
+        assert!(parse_apply_string_array(&args, "adds").is_err());
+    }
+
+    #[test]
+    fn apply_updates_error_on_missing_fields() {
+        let args = json!({"source": "feature", "updates": [{"old_id": "x"}]});
+        assert!(parse_apply_updates(&args).is_err());
+    }
+
+    #[test]
+    fn tool_args_error_on_unknown_field() {
+        let args = json!({"source": "feature", "adds": [], "bogus": true});
+        assert!(expect_tool_args(&args, "memory_apply", &["source", "adds"]).is_err());
     }
 }

--- a/memoria/crates/memoria-mcp/src/git_tools.rs
+++ b/memoria/crates/memoria-mcp/src/git_tools.rs
@@ -1016,7 +1016,7 @@ pub async fn call(
         GitToolCallName::MemoryDiff => {
             expect_tool_args(&args, "memory_diff", &["source", "limit"])?;
             let source_branch = parse_required_string_arg(&args, "memory_diff", "source")?;
-            let limit = parse_optional_i64_arg(&args, "memory_diff", "limit", 50)?;
+            let limit = parse_optional_i64_arg(&args, "memory_diff", "limit", 50)?.clamp(1, 500);
             let sql = svc.user_sql_store(user_id).await?;
             let user_git = git_for_store(&sql)?;
             let branches = sql.list_branches(user_id).await?;

--- a/memoria/crates/memoria-mcp/src/remote.rs
+++ b/memoria/crates/memoria-mcp/src/remote.rs
@@ -56,6 +56,50 @@ impl RemoteClient {
         Self::mcp_text(&serde_json::to_string_pretty(v).unwrap_or_default())
     }
 
+    fn expect_tool_args<'a>(
+        args: &'a Value,
+        tool: &str,
+        allowed: &[&str],
+    ) -> Result<&'a serde_json::Map<String, Value>> {
+        let map = args
+            .as_object()
+            .ok_or_else(|| anyhow::anyhow!("Invalid {tool} arguments: expected object"))?;
+        for key in map.keys() {
+            if !allowed.iter().any(|allowed_key| allowed_key == key) {
+                anyhow::bail!("Invalid {tool} argument '{key}': unknown field");
+            }
+        }
+        Ok(map)
+    }
+
+    fn required_string_arg(args: &Value, tool: &str, field: &str) -> Result<String> {
+        args.get(field)
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| anyhow::anyhow!("Invalid {tool} '{field}': expected non-empty string"))
+    }
+
+    fn optional_i64_arg(args: &Value, tool: &str, field: &str, default: i64) -> Result<i64> {
+        match args.get(field) {
+            None => Ok(default),
+            Some(value) => value
+                .as_i64()
+                .ok_or_else(|| anyhow::anyhow!("Invalid {tool} '{field}': expected integer")),
+        }
+    }
+
+    fn json_array_arg(args: &Value, field: &str) -> Result<Value> {
+        match args.get(field) {
+            None => Ok(Value::Array(Vec::new())),
+            Some(Value::Array(values)) => Ok(Value::Array(values.clone())),
+            Some(other) => anyhow::bail!(
+                "Invalid memory_apply '{field}': expected array, got {}",
+                other
+            ),
+        }
+    }
+
     #[allow(dead_code)]
     fn mcp_err(e: impl std::fmt::Display) -> Value {
         Self::mcp_text(&format!("Error: {e}"))
@@ -569,10 +613,40 @@ impl RemoteClient {
             }
 
             "memory_diff" => {
-                let source = args["source"].as_str().unwrap_or("");
+                Self::expect_tool_args(&args, "memory_diff", &["source", "limit"])?;
+                let source = Self::required_string_arg(&args, "memory_diff", "source")?;
+                let limit = Self::optional_i64_arg(&args, "memory_diff", "limit", 50)?;
                 let r = self
                     .client
-                    .get(self.url(&format!("/v1/branches/{source}/diff")))
+                    .get(self.url(&format!("/v1/branches/{source}/diff?limit={limit}")))
+                    .send()
+                    .await?;
+                let body = Self::parse_response(r).await?;
+                Ok(Self::mcp_json(&body))
+            }
+
+            "memory_apply" => {
+                Self::expect_tool_args(
+                    &args,
+                    "memory_apply",
+                    &[
+                        "source",
+                        "adds",
+                        "updates",
+                        "removes",
+                        "accept_branch_conflicts",
+                    ],
+                )?;
+                let source = Self::required_string_arg(&args, "memory_apply", "source")?;
+                let r = self
+                    .client
+                    .post(self.url(&format!("/v1/branches/{source}/apply")))
+                    .json(&json!({
+                        "adds": Self::json_array_arg(&args, "adds")?,
+                        "updates": Self::json_array_arg(&args, "updates")?,
+                        "removes": Self::json_array_arg(&args, "removes")?,
+                        "accept_branch_conflicts": Self::json_array_arg(&args, "accept_branch_conflicts")?,
+                    }))
                     .send()
                     .await?;
                 let body = Self::parse_response(r).await?;
@@ -629,5 +703,191 @@ impl RemoteClient {
 
     pub async fn call_owned(self, name: String, args: Value) -> Result<Value> {
         self.call(&name, args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RemoteClient;
+    use axum::{
+        extract::{Path, State},
+        routing::post,
+        Json, Router,
+    };
+    use serde_json::{json, Value};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct ApplyCapture {
+        branch: Arc<Mutex<Option<String>>>,
+        body: Arc<Mutex<Option<Value>>>,
+    }
+
+    #[tokio::test]
+    async fn memory_apply_remote_call_uses_branch_apply_endpoint() {
+        let capture = ApplyCapture {
+            branch: Arc::new(Mutex::new(None)),
+            body: Arc::new(Mutex::new(None)),
+        };
+
+        let app = Router::new()
+            .route(
+                "/v1/branches/:source/apply",
+                post(
+                    |State(capture): State<ApplyCapture>,
+                     Path(source): Path<String>,
+                     Json(payload): Json<Value>| async move {
+                        *capture.branch.lock().unwrap() = Some(source);
+                        *capture.body.lock().unwrap() = Some(payload);
+                        Json(json!({
+                            "applied_adds": ["new-id"],
+                            "applied_updates": [],
+                            "applied_removes": [],
+                            "applied_conflicts": []
+                        }))
+                    },
+                ),
+            )
+            .with_state(capture.clone());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let addr = listener.local_addr().expect("local addr");
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .expect("serve test router");
+        });
+
+        let remote = RemoteClient::new(
+            &format!("http://{addr}"),
+            Some("sk-test"),
+            "default".to_string(),
+            Some("kiro"),
+        );
+        let result = remote
+            .call(
+                "memory_apply",
+                json!({
+                    "source": "feature-1",
+                    "adds": ["new-id"],
+                    "updates": [{"old_id": "old-id", "new_id": "new-id"}],
+                    "removes": ["gone-id"],
+                    "accept_branch_conflicts": ["conflict-id"],
+                }),
+            )
+            .await
+            .expect("memory_apply should succeed");
+
+        let text = result["content"][0]["text"].as_str().expect("text result");
+        assert!(text.contains("applied_adds"));
+        assert_eq!(capture.branch.lock().unwrap().as_deref(), Some("feature-1"));
+        assert_eq!(
+            capture.body.lock().unwrap().clone(),
+            Some(json!({
+                "adds": ["new-id"],
+                "updates": [{"old_id": "old-id", "new_id": "new-id"}],
+                "removes": ["gone-id"],
+                "accept_branch_conflicts": ["conflict-id"],
+            }))
+        );
+
+        let _ = shutdown_tx.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn memory_apply_remote_defaults_missing_arrays_to_empty() {
+        let capture = ApplyCapture {
+            branch: Arc::new(Mutex::new(None)),
+            body: Arc::new(Mutex::new(None)),
+        };
+
+        let app = Router::new()
+            .route(
+                "/v1/branches/:source/apply",
+                post(
+                    |State(capture): State<ApplyCapture>,
+                     Path(source): Path<String>,
+                     Json(payload): Json<Value>| async move {
+                        *capture.branch.lock().unwrap() = Some(source);
+                        *capture.body.lock().unwrap() = Some(payload);
+                        Json(json!({
+                            "applied_adds": [],
+                            "applied_updates": [],
+                            "applied_removes": [],
+                            "applied_conflicts": []
+                        }))
+                    },
+                ),
+            )
+            .with_state(capture.clone());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let addr = listener.local_addr().expect("local addr");
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .expect("serve test router");
+        });
+
+        let remote = RemoteClient::new(
+            &format!("http://{addr}"),
+            Some("sk-test"),
+            "default".to_string(),
+            Some("kiro"),
+        );
+        remote
+            .call("memory_apply", json!({"source": "feature-2"}))
+            .await
+            .expect("memory_apply should succeed with missing arrays");
+
+        assert_eq!(
+            capture.body.lock().unwrap().clone(),
+            Some(json!({
+                "adds": [],
+                "updates": [],
+                "removes": [],
+                "accept_branch_conflicts": [],
+            }))
+        );
+
+        let _ = shutdown_tx.send(());
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn memory_diff_remote_rejects_unknown_fields() {
+        let remote = RemoteClient::new(
+            "http://127.0.0.1:9",
+            Some("sk-test"),
+            "default".to_string(),
+            Some("kiro"),
+        );
+        let err = remote
+            .call(
+                "memory_diff",
+                json!({
+                    "source": "feature-3",
+                    "adds": ["unexpected"]
+                }),
+            )
+            .await
+            .expect_err("memory_diff should reject unknown fields before sending");
+
+        assert!(err
+            .to_string()
+            .contains("Invalid memory_diff argument 'adds': unknown field"));
     }
 }

--- a/memoria/crates/memoria-mcp/src/server.rs
+++ b/memoria/crates/memoria-mcp/src/server.rs
@@ -52,6 +52,24 @@ enum RpcMethod {
     Unknown(String),
 }
 
+const GIT_TOOL_NAMES: &[&str] = &[
+    "memory_snapshot",
+    "memory_snapshots",
+    "memory_snapshot_delete",
+    "memory_rollback",
+    "memory_branch",
+    "memory_branches",
+    "memory_checkout",
+    "memory_merge",
+    "memory_diff",
+    "memory_apply",
+    "memory_branch_delete",
+];
+
+fn is_git_tool(name: &str) -> bool {
+    GIT_TOOL_NAMES.contains(&name)
+}
+
 /// Dispatch a single JSON-RPC method in embedded mode.
 /// Used by the server-side Streamable HTTP MCP endpoint.
 pub async fn dispatch_http(
@@ -282,19 +300,7 @@ async fn dispatch(
             match mode {
                 Mode::Remote(client) => client.call(&name, args).await.map_err(internal_err),
                 Mode::Embedded { service, git } => {
-                    let git_tool_names = [
-                        "memory_snapshot",
-                        "memory_snapshots",
-                        "memory_snapshot_delete",
-                        "memory_rollback",
-                        "memory_branch",
-                        "memory_branches",
-                        "memory_checkout",
-                        "memory_merge",
-                        "memory_diff",
-                        "memory_branch_delete",
-                    ];
-                    if git_tool_names.contains(&name.as_str()) {
+                    if is_git_tool(&name) {
                         git_tools::call(&name, args, git, service, user_id)
                             .await
                             .map_err(|e| McpRpcError {
@@ -350,19 +356,7 @@ async fn dispatch_embedded_owned(
                 code: -32000,
                 message: e.to_string(),
             };
-            let git_tool_names = [
-                "memory_snapshot",
-                "memory_snapshots",
-                "memory_snapshot_delete",
-                "memory_rollback",
-                "memory_branch",
-                "memory_branches",
-                "memory_checkout",
-                "memory_merge",
-                "memory_diff",
-                "memory_branch_delete",
-            ];
-            if git_tool_names.contains(&name.as_str()) {
+            if is_git_tool(&name) {
                 git_tools::call_owned(name, args, git, service, user_id)
                     .await
                     .map_err(|e| McpRpcError {
@@ -380,5 +374,40 @@ async fn dispatch_embedded_owned(
             code: -32601,
             message: format!("Method not found: {method}"),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_git_tool, GIT_TOOL_NAMES};
+
+    #[test]
+    fn git_dispatch_list_includes_memory_apply() {
+        assert!(is_git_tool("memory_apply"));
+    }
+
+    #[test]
+    fn git_tool_dispatch_matches_declared_git_tools() {
+        let declared_names: Vec<String> = crate::git_tools::list()
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|tool| tool.get("name").and_then(|name| name.as_str()))
+            .map(str::to_string)
+            .collect();
+
+        for name in GIT_TOOL_NAMES {
+            assert!(
+                declared_names.iter().any(|declared| declared == name),
+                "dispatch marked '{name}' as a git tool but git_tools::list() does not declare it"
+            );
+        }
+
+        for name in declared_names {
+            assert!(
+                is_git_tool(&name),
+                "git_tools::list() declares '{name}' but server dispatch does not route it"
+            );
+        }
     }
 }

--- a/memoria/crates/memoria-mcp/src/tools.rs
+++ b/memoria/crates/memoria-mcp/src/tools.rs
@@ -302,6 +302,7 @@ pub async fn call(
                     trust_tier,
                     None,
                     None,
+                    None,
                 )
                 .await
             {
@@ -780,6 +781,7 @@ pub async fn call(
                             mt,
                             None,
                             Some(TrustTier::from_str("T4").unwrap_or(TrustTier::T4Unverified)),
+                            None,
                             None,
                             None,
                         )

--- a/memoria/crates/memoria-mcp/tests/branch_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/branch_e2e.rs
@@ -159,6 +159,83 @@ async fn test_merge_accept_alias() {
 }
 
 #[tokio::test]
+async fn test_memory_apply_accept_branch_conflict() {
+    let (svc, git, uid, _ctx) = setup().await;
+    let branch = bname("apply_conflict");
+
+    store_mem("shared conflict base", &svc, &uid).await;
+    let original = svc
+        .list_active(&uid, 10)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|memory| memory.content == "shared conflict base")
+        .expect("original memory");
+
+    gc("memory_branch", json!({"name": branch}), &git, &svc, &uid).await;
+    gc("memory_checkout", json!({"name": branch}), &git, &svc, &uid).await;
+    let branch_corrected = svc
+        .correct(&uid, &original.memory_id, "branch-side correction")
+        .await
+        .expect("branch correction");
+
+    gc("memory_checkout", json!({"name": "main"}), &git, &svc, &uid).await;
+    let main_corrected = svc
+        .correct(&uid, &original.memory_id, "main-side correction")
+        .await
+        .expect("main correction");
+
+    let diff = gc("memory_diff", json!({"source": branch}), &git, &svc, &uid).await;
+    assert!(
+        text(&diff).contains("[CONFLICT]"),
+        "expected conflict in diff, got: {}",
+        text(&diff)
+    );
+
+    let applied = gc(
+        "memory_apply",
+        json!({
+            "source": branch,
+            "accept_branch_conflicts": [original.memory_id.clone()]
+        }),
+        &git,
+        &svc,
+        &uid,
+    )
+    .await;
+    assert!(
+        text(&applied).contains("1 conflicts accepted"),
+        "expected one accepted conflict, got: {}",
+        text(&applied)
+    );
+
+    let active = svc.list_active(&uid, 10).await.unwrap();
+    let active_contents: Vec<String> = active.iter().map(|memory| memory.content.clone()).collect();
+    assert!(active_contents
+        .iter()
+        .any(|content| content == "branch-side correction"));
+    assert!(!active_contents
+        .iter()
+        .any(|content| content == "main-side correction"));
+
+    let all_ids: Vec<String> = active
+        .iter()
+        .map(|memory| memory.memory_id.clone())
+        .collect();
+    assert!(all_ids.iter().any(|id| id == &branch_corrected.memory_id));
+    assert!(!all_ids.iter().any(|id| id == &main_corrected.memory_id));
+
+    gc(
+        "memory_branch_delete",
+        json!({"name": branch}),
+        &git,
+        &svc,
+        &uid,
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn test_merge_replace_updates_conflicting_memory() {
     let (svc, git, pool, uid, ctx) = setup_with_mock_embedder().await;
     let branch = bname("replace");
@@ -382,7 +459,7 @@ async fn test_merge_unknown_strategy_rejected() {
     .await;
 }
 
-// ── 7. Duplicate branch name rejected (even after delete) ────────────────────
+// ── 7. Duplicate active branch name rejected; deleted names may be reused ────
 
 #[tokio::test]
 async fn test_duplicate_branch_name_rejected() {
@@ -396,7 +473,7 @@ async fn test_duplicate_branch_name_rejected() {
     assert!(text(&r).contains("already exists"), "got: {}", text(&r));
     println!("✅ duplicate rejected: {}", text(&r));
 
-    // Delete then try same name → still rejected (soft-deleted)
+    // Delete then try same name → allowed again
     gc(
         "memory_branch_delete",
         json!({"name": branch}),
@@ -407,11 +484,11 @@ async fn test_duplicate_branch_name_rejected() {
     .await;
     let r2 = gc("memory_branch", json!({"name": branch}), &git, &svc, &uid).await;
     assert!(
-        text(&r2).contains("already exists"),
-        "should reject reuse of deleted name, got: {}",
+        text(&r2).contains("Created"),
+        "should allow reuse of deleted name, got: {}",
         text(&r2)
     );
-    println!("✅ deleted name reuse rejected: {}", text(&r2));
+    println!("✅ deleted name reuse allowed: {}", text(&r2));
 }
 
 // ── 8. from_snapshot + from_timestamp mutual exclusion ───────────────────────
@@ -795,9 +872,7 @@ async fn test_diff_fields_complete() {
         .unwrap();
     let user_git = GitForDataService::new(
         sql.pool().clone(),
-        sql.database_name()
-            .expect("user db name")
-            .to_string(),
+        sql.database_name().expect("user db name").to_string(),
     );
 
     let rows = user_git
@@ -907,9 +982,7 @@ async fn test_diff_native_count_vs_join_rows() {
         .unwrap();
     let user_git = GitForDataService::new(
         sql.pool().clone(),
-        sql.database_name()
-            .expect("user db name")
-            .to_string(),
+        sql.database_name().expect("user db name").to_string(),
     );
 
     // Native count: >= 1 (account-level, may include other users)

--- a/memoria/crates/memoria-mcp/tests/edit_log_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/edit_log_e2e.rs
@@ -28,10 +28,7 @@ fn uid() -> String {
 }
 
 fn safety_snapshot_prefix(db_name: &str) -> String {
-    format!(
-        "mem_snap_{}_pre_",
-        compact_identifier_fragment(db_name, 21)
-    )
+    format!("mem_snap_{}_pre_", compact_identifier_fragment(db_name, 21))
 }
 
 fn sanitize_identifier_fragment(value: &str) -> String {
@@ -501,7 +498,7 @@ async fn test_store_batch_all_fields() {
             None,
         ),
     ];
-    let results = svc.store_batch(&uid, items).await.unwrap();
+    let results = svc.store_batch(&uid, items, None).await.unwrap();
     assert_eq!(results.len(), 2);
     svc.flush_edit_log().await;
 
@@ -1075,6 +1072,7 @@ async fn test_edit_id_globally_unique() {
                 None,
             ),
         ],
+        None,
     )
     .await
     .unwrap();

--- a/memoria/crates/memoria-mcp/tests/feedback_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/feedback_e2e.rs
@@ -585,7 +585,7 @@ async fn test_feedback_db_verification() {
     store
         .record_feedback(&uid, memory_id_2, "irrelevant", None)
         .await
-    .unwrap();
+        .unwrap();
 
     // 4. Verify aggregated stats via direct SQL
     let feedback_table = store.t("mem_retrieval_feedback");
@@ -1359,8 +1359,7 @@ async fn test_duplicate_instance_id_lock_is_exclusive() {
     use memoria_service::distributed::DistributedLock;
     use std::time::Duration;
 
-    let ctx =
-        support::multi_db::setup_mcp_context("feedback_lock", test_dim(), None, None).await;
+    let ctx = support::multi_db::setup_mcp_context("feedback_lock", test_dim(), None, None).await;
     let store = ctx.shared_store();
 
     let lock_key = format!("test:dup_instance:{}", uid());

--- a/memoria/crates/memoria-mcp/tests/graph_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/graph_e2e.rs
@@ -1402,6 +1402,7 @@ async fn test_governance_cleans_orphan_graph_data() {
         updated_at: None,
         access_count: 0,
         retrieval_score: None,
+        author_id: None,
     };
     let memories_table = sql.t("mem_memories");
     sql.insert_into(&memories_table, &mem)

--- a/memoria/crates/memoria-mcp/tests/graph_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/graph_e2e.rs
@@ -1125,7 +1125,10 @@ async fn test_batch_upsert_entities_user_isolation() {
 
     let entities: Vec<(&str, &str, &str)> = vec![("rust", "Rust", "tech")];
     let r1 = store.batch_upsert_entities(&uid1, &entities).await.unwrap();
-    let r2 = store2.batch_upsert_entities(&uid2, &entities).await.unwrap();
+    let r2 = store2
+        .batch_upsert_entities(&uid2, &entities)
+        .await
+        .unwrap();
 
     // Same name, different users → different entity_ids
     assert_ne!(
@@ -1401,7 +1404,9 @@ async fn test_governance_cleans_orphan_graph_data() {
         retrieval_score: None,
     };
     let memories_table = sql.t("mem_memories");
-    sql.insert_into(&memories_table, &mem).await.expect("insert");
+    sql.insert_into(&memories_table, &mem)
+        .await
+        .expect("insert");
 
     // Create graph node + entity links pointing to this memory
     let graph = sql.graph_store();

--- a/memoria/crates/memoria-mcp/tests/integration_full.rs
+++ b/memoria/crates/memoria-mcp/tests/integration_full.rs
@@ -30,7 +30,8 @@ async fn setup() -> (
     String,
     support::multi_db::McpTestContext,
 ) {
-    let ctx = support::multi_db::setup_mcp_context("integration_full", test_dim(), None, None).await;
+    let ctx =
+        support::multi_db::setup_mcp_context("integration_full", test_dim(), None, None).await;
     let uid = format!("integ_{}", &Uuid::new_v4().simple().to_string()[..8]);
     (ctx.service(), ctx.git(), uid, ctx)
 }

--- a/memoria/crates/memoria-mcp/tests/mcp_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/mcp_e2e.rs
@@ -12,7 +12,11 @@ use serde_json::{json, Value};
 use std::sync::Arc;
 use uuid::Uuid;
 
-async fn make_service() -> (Arc<MemoryService>, String, support::multi_db::McpTestContext) {
+async fn make_service() -> (
+    Arc<MemoryService>,
+    String,
+    support::multi_db::McpTestContext,
+) {
     let dim: usize = std::env::var("EMBEDDING_DIM")
         .unwrap_or_else(|_| "1024".to_string())
         .parse()

--- a/memoria/crates/memoria-mcp/tests/perf_optimizations_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/perf_optimizations_e2e.rs
@@ -30,7 +30,8 @@ async fn setup() -> (
     String,
     support::multi_db::McpTestContext,
 ) {
-    let ctx = support::multi_db::setup_mcp_context("perf_optimizations", test_dim(), None, None).await;
+    let ctx =
+        support::multi_db::setup_mcp_context("perf_optimizations", test_dim(), None, None).await;
     let uid = uid();
     let store = ctx.user_store(&uid).await;
     let pool = ctx.user_db_pool(&uid).await;
@@ -59,7 +60,11 @@ async fn test_active_table_cache_hit_and_invalidation() {
 
     // First call: cache miss → DB lookup → should return "mem_memories"
     let t1 = store.active_table(&uid).await.expect("active_table 1");
-    assert_eq!(t1, store.t("mem_memories"), "default should be mem_memories");
+    assert_eq!(
+        t1,
+        store.t("mem_memories"),
+        "default should be mem_memories"
+    );
 
     // Second call: should be cache hit (same result)
     let t2 = store.active_table(&uid).await.expect("active_table 2");
@@ -89,7 +94,11 @@ async fn test_active_table_cache_hit_and_invalidation() {
 
     // Now active_table should return the branch table
     let t3 = store.active_table(&uid).await.expect("active_table 3");
-    assert_eq!(t3, store.t(&table_name), "should return branch table after switch");
+    assert_eq!(
+        t3,
+        store.t(&table_name),
+        "should return branch table after switch"
+    );
 
     // Switch back to main
     store

--- a/memoria/crates/memoria-mcp/tests/perf_optimizations_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/perf_optimizations_e2e.rs
@@ -472,6 +472,7 @@ async fn test_batch_entity_methods() {
         observed_at: Some(chrono::Utc::now()),
         created_at: Some(chrono::Utc::now()),
         updated_at: None,
+        author_id: None,
     };
     let memories_table = store.t("mem_memories");
     store
@@ -590,6 +591,7 @@ async fn test_find_near_duplicate_single_query_same_type_preference() {
         observed_at: Some(chrono::Utc::now()),
         created_at: Some(chrono::Utc::now()),
         updated_at: None,
+        author_id: None,
     };
     let memories_table = store.t("mem_memories");
     store
@@ -618,6 +620,7 @@ async fn test_find_near_duplicate_single_query_same_type_preference() {
         observed_at: Some(chrono::Utc::now()),
         created_at: Some(chrono::Utc::now()),
         updated_at: None,
+        author_id: None,
     };
     store
         .insert_into(&memories_table, &mem_b)

--- a/memoria/crates/memoria-mcp/tests/support/multi_db.rs
+++ b/memoria/crates/memoria-mcp/tests/support/multi_db.rs
@@ -57,14 +57,8 @@ pub async fn setup_mcp_context(
     llm: Option<Arc<LlmClient>>,
 ) -> McpTestContext {
     McpTestContext {
-        inner: MultiDbTestContext::new(
-            &db_url(),
-            db_name_prefix,
-            embedding_dim,
-            embedder,
-            llm,
-        )
-        .await,
+        inner: MultiDbTestContext::new(&db_url(), db_name_prefix, embedding_dim, embedder, llm)
+            .await,
     }
 }
 

--- a/memoria/crates/memoria-service/src/pipeline.rs
+++ b/memoria/crates/memoria-service/src/pipeline.rs
@@ -94,6 +94,7 @@ impl MemoryPipeline {
                 extra_metadata: None,
                 trust_tier: tier.unwrap_or_default(),
                 retrieval_score: None,
+                author_id: None,
             });
         }
 

--- a/memoria/crates/memoria-service/src/service.rs
+++ b/memoria/crates/memoria-service/src/service.rs
@@ -1137,6 +1137,7 @@ impl MemoryService {
         trust_tier: Option<TrustTier>,
         observed_at: Option<DateTime<Utc>>,
         initial_confidence: Option<f64>,
+        author_id: Option<String>,
     ) -> Result<Memory, MemoriaError> {
         let t0 = std::time::Instant::now();
         // Sensitivity check — block HIGH tier, redact MEDIUM tier
@@ -1155,6 +1156,7 @@ impl MemoryService {
         let memory = Memory {
             memory_id: Uuid::now_v7().simple().to_string(),
             user_id: user_id.to_string(),
+            author_id,
             memory_type,
             content: content.to_string(),
             initial_confidence: initial_confidence
@@ -1833,6 +1835,7 @@ impl MemoryService {
                 is_active: true,
                 access_count: 0,
                 retrieval_score: None,
+                author_id: old.author_id.clone(),
             };
 
             sql.insert_into(&table, &new_mem).await?;
@@ -1897,6 +1900,7 @@ impl MemoryService {
                 is_active: true,
                 access_count: 0,
                 retrieval_score: None,
+                author_id: old.author_id.clone(),
             };
 
             self.store.insert(&new_mem).await?;
@@ -2208,6 +2212,7 @@ impl MemoryService {
         &self,
         user_id: &str,
         items: Vec<(String, MemoryType, Option<String>, Option<TrustTier>)>,
+        author_id: Option<String>,
     ) -> Result<Vec<Memory>, MemoriaError> {
         if items.is_empty() {
             return Ok(vec![]);
@@ -2239,6 +2244,7 @@ impl MemoryService {
             let memory = Memory {
                 memory_id: Uuid::now_v7().simple().to_string(),
                 user_id: user_id.to_string(),
+                author_id: author_id.clone(),
                 memory_type: mt,
                 content,
                 initial_confidence: effective_tier.initial_confidence(),
@@ -2386,6 +2392,7 @@ impl MemoryService {
                 extra_metadata: None,
                 trust_tier: TrustTier::T3Inferred,
                 retrieval_score: None,
+                author_id: None,
             });
         }
         result
@@ -2426,6 +2433,7 @@ impl MemoryService {
                     extra_metadata: None,
                     trust_tier: TrustTier::T1Verified,
                     retrieval_score: None,
+                    author_id: None,
                 })
             })
             .collect()
@@ -2532,6 +2540,9 @@ impl MemoryService {
 
     pub async fn user_sql_store(&self, user_id: &str) -> Result<Arc<SqlMemoryStore>, MemoriaError> {
         if let Some(router) = &self.db_router {
+            if user_id.starts_with("grp_") {
+                return router.group_store(user_id).await;
+            }
             router.user_store(user_id).await
         } else {
             self.sql_store

--- a/memoria/crates/memoria-service/src/stats_reporter.rs
+++ b/memoria/crates/memoria-service/src/stats_reporter.rs
@@ -31,10 +31,7 @@ pub enum StatsEvent {
     /// A previously deactivated memory was re-activated.
     MemoryActivated { user_id: String },
     /// An edit-log entry was written (any operation).
-    EditLogged {
-        user_id: String,
-        operation: String,
-    },
+    EditLogged { user_id: String, operation: String },
     /// One or more new entities were upserted for a user.
     EntitiesUpserted { user_id: String, count: u64 },
     /// An API or MCP call completed (used for devops/MCP tab).
@@ -151,9 +148,7 @@ async fn flush_batch(events: &[StatsEvent], pool: &MySqlPool) {
                 *metric_detail
                     .entry((user_id.clone(), "trust_tier".into(), trust_tier.clone()))
                     .or_default() += 1;
-                *daily
-                    .entry((today, "memory_stored".into()))
-                    .or_default() += 1;
+                *daily.entry((today, "memory_stored".into())).or_default() += 1;
             }
             StatsEvent::MemoryDeactivated { user_id } => {
                 let u = user_stats.entry(user_id.clone()).or_default();
@@ -193,13 +188,9 @@ async fn flush_batch(events: &[StatsEvent], pool: &MySqlPool) {
                         a.first_mcp_call = Some(chrono::Utc::now().naive_utc());
                     }
                     *mcp_paths.entry(path.clone()).or_default() += 1;
-                    *daily
-                        .entry((today, "mcp_calls".into()))
-                        .or_default() += 1;
+                    *daily.entry((today, "mcp_calls".into())).or_default() += 1;
                 }
-                *daily
-                    .entry((today, "api_calls".into()))
-                    .or_default() += 1;
+                *daily.entry((today, "api_calls".into())).or_default() += 1;
             }
         }
     }

--- a/memoria/crates/memoria-service/tests/service_unit.rs
+++ b/memoria/crates/memoria-service/tests/service_unit.rs
@@ -124,6 +124,7 @@ async fn test_store_and_retrieve() {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -146,6 +147,7 @@ async fn test_correct() {
             "u1",
             "old content",
             MemoryType::Semantic,
+            None,
             None,
             None,
             None,
@@ -174,6 +176,7 @@ async fn test_purge() {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -194,6 +197,7 @@ async fn test_list_active_excludes_deleted() {
         None,
         None,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -202,6 +206,7 @@ async fn test_list_active_excludes_deleted() {
             "u1",
             "delete this",
             MemoryType::Working,
+            None,
             None,
             None,
             None,
@@ -242,9 +247,18 @@ async fn test_purge_by_session_id_filters_memory_type() {
             Some("sess-other".to_string()),
         ),
     ] {
-        svc.store_memory("u1", content, memory_type, session_id, None, None, None)
-            .await
-            .unwrap();
+        svc.store_memory(
+            "u1",
+            content,
+            memory_type,
+            session_id,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
     }
 
     let memory_types = [MemoryType::Working];
@@ -275,6 +289,7 @@ async fn test_purge_by_session_id_fallback_is_not_capped() {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -284,6 +299,7 @@ async fn test_purge_by_session_id_fallback_is_not_capped() {
         "keep semantic",
         MemoryType::Semantic,
         Some("sess-target".to_string()),
+        None,
         None,
         None,
         None,
@@ -316,7 +332,7 @@ async fn test_memory_types() {
         MemoryType::Episodic,
     ] {
         let m = svc
-            .store_memory("u1", "content", mt.clone(), None, None, None, None)
+            .store_memory("u1", "content", mt.clone(), None, None, None, None, None)
             .await
             .unwrap();
         assert_eq!(m.memory_type, mt);
@@ -342,6 +358,7 @@ async fn test_trust_tiers() {
                 Some(tier),
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -358,6 +375,7 @@ async fn test_no_embedder_still_works() {
             "u1",
             "no embedding",
             MemoryType::Semantic,
+            None,
             None,
             None,
             None,

--- a/memoria/crates/memoria-storage/src/lib.rs
+++ b/memoria/crates/memoria-storage/src/lib.rs
@@ -23,5 +23,5 @@ pub use pool_config::{
 pub use router::{DbRouter, UserDatabaseRecord};
 pub use store::{
     FeedbackStats, MemoryFeedback, OwnedEditLogEntry, PoolHealthLevel, PoolHealthSnapshot,
-    SqlMemoryStore, TierFeedback, UserRetrievalParams,
+    SqlMemoryStore, TierFeedback, UserRetrievalParams, ACTOR_USER_ID,
 };

--- a/memoria/crates/memoria-storage/src/router.rs
+++ b/memoria/crates/memoria-storage/src/router.rs
@@ -48,6 +48,14 @@ pub struct UserDatabaseRecord {
     pub status: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct GroupDatabaseRecord {
+    pub group_id: String,
+    pub db_name: String,
+    pub owner_user_id: String,
+    pub status: String,
+}
+
 #[derive(Clone)]
 pub struct DbRouter {
     shared_pool: MySqlPool,
@@ -494,6 +502,95 @@ impl DbRouter {
         .map_err(db_err)?;
 
         Ok(())
+    }
+
+    pub async fn group_record(
+        &self,
+        group_id: &str,
+    ) -> Result<Option<GroupDatabaseRecord>, MemoriaError> {
+        let row = sqlx::query(
+            "SELECT group_id, db_name, owner_user_id, status \
+             FROM mem_groups WHERE group_id = ? LIMIT 1",
+        )
+        .bind(group_id)
+        .fetch_optional(&self.shared_pool)
+        .await
+        .map_err(db_err)?;
+
+        row.map(|row| {
+            Ok(GroupDatabaseRecord {
+                group_id: row.try_get("group_id").map_err(db_err)?,
+                db_name: row.try_get("db_name").map_err(db_err)?,
+                owner_user_id: row.try_get("owner_user_id").map_err(db_err)?,
+                status: row.try_get("status").map_err(db_err)?,
+            })
+        })
+        .transpose()
+    }
+
+    pub async fn group_db_name(&self, group_id: &str) -> Result<String, MemoriaError> {
+        let row =
+            sqlx::query("SELECT db_name FROM mem_groups WHERE group_id = ? AND status = 'active'")
+                .bind(group_id)
+                .fetch_optional(&self.shared_pool)
+                .await
+                .map_err(db_err)?;
+
+        let row = row.ok_or_else(|| MemoriaError::NotFound(format!("Group '{group_id}'")))?;
+        row.try_get("db_name").map_err(db_err)
+    }
+
+    pub async fn group_store(&self, group_id: &str) -> Result<Arc<SqlMemoryStore>, MemoriaError> {
+        let cache_key = format!("group:{group_id}");
+        if let Some(cached) = self.user_store_cache.get(&cache_key) {
+            return Ok(cached);
+        }
+
+        let db_name = self.group_db_name(group_id).await?;
+        let cache_key_owned = cache_key.clone();
+        if self.user_schema_cache.get(&cache_key_owned).is_none() {
+            let _permit = self
+                .user_init_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|_| MemoriaError::Internal("group schema init semaphore closed".into()))?;
+            if self.user_schema_cache.get(&cache_key_owned).is_none() {
+                let db_url = self.user_db_url(&db_name)?;
+                let init_result = match SqlMemoryStore::connect_routed(
+                    &db_url,
+                    self.embedding_dim,
+                    self.instance_id.clone(),
+                )
+                .await
+                {
+                    Ok(init_store) => init_store.migrate_user().await,
+                    Err(err) => Err(err),
+                };
+                init_result?;
+                self.user_schema_cache.insert(cache_key_owned.clone(), true);
+            }
+        }
+        let mut store = build_routed_store(
+            self.global_user_pool.clone(),
+            &self.shared_db_url,
+            self.embedding_dim,
+            &self.instance_id,
+            &db_name,
+        )?;
+        store.set_db_router(Arc::new(self.clone()));
+        let store = Arc::new(store);
+        self.user_store_cache.insert(cache_key, store.clone());
+        self.user_db_cache.insert(group_id.to_string(), db_name);
+        Ok(store)
+    }
+
+    pub async fn scope_store(&self, scope_id: &str) -> Result<Arc<SqlMemoryStore>, MemoriaError> {
+        if scope_id.starts_with("grp_") {
+            self.group_store(scope_id).await
+        } else {
+            self.user_store(scope_id).await
+        }
     }
 }
 

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -12,6 +12,16 @@ use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+tokio::task_local! {
+    /// Real user ID for per-user state (active branch).
+    /// In group mode the "user_id" flowing through the service layer is the
+    /// group's scope_id (e.g. "grp_xxx").  The task-local carries the **real**
+    /// human user so that `active_branch_name` / `set_active_branch` key on
+    /// the individual, not the group.  In non-group mode this is never set and
+    /// the functions fall back to the passed `user_id`.
+    pub static ACTOR_USER_ID: String;
+}
+
 pub(crate) fn db_err(e: sqlx::Error) -> MemoriaError {
     if let Some(kind) = detect_connection_anomaly(&e) {
         record_connection_anomaly(kind);
@@ -1080,6 +1090,7 @@ impl SqlMemoryStore {
             r#"CREATE TABLE IF NOT EXISTS {memories_table} (
                 memory_id       VARCHAR(64)  PRIMARY KEY,
                 user_id         VARCHAR(64)  NOT NULL,
+                author_id       VARCHAR(64)  DEFAULT NULL,
                 memory_type     VARCHAR(20)  NOT NULL,
                 content         TEXT         NOT NULL,
                 embedding       vecf32({dim}),
@@ -1096,6 +1107,7 @@ impl SqlMemoryStore {
                 INDEX idx_user_active (user_id, is_active, memory_type),
                 INDEX idx_user_session (user_id, session_id),
                 INDEX idx_memories_user_observed (user_id, observed_at),
+                INDEX idx_author (author_id),
                 FULLTEXT INDEX ft_content (content) WITH PARSER ngram -- MO#23861: breaks on concurrent snapshot restore
             )"#,
             memories_table = memories_table,
@@ -1517,6 +1529,18 @@ impl SqlMemoryStore {
         .execute(pool)
         .await;
 
+        // author_id column — tracks the real human author in group mode
+        let _ = sqlx::query(&format!(
+            "ALTER TABLE {memories_table} ADD COLUMN author_id VARCHAR(64) DEFAULT NULL AFTER user_id"
+        ))
+        .execute(pool)
+        .await;
+        let _ = sqlx::query(&format!(
+            "ALTER TABLE {memories_table} ADD INDEX idx_author (author_id)"
+        ))
+        .execute(pool)
+        .await;
+
         Ok(())
     }
 
@@ -1573,6 +1597,7 @@ impl SqlMemoryStore {
             r#"CREATE TABLE IF NOT EXISTS mem_api_keys (
                 key_id       VARCHAR(36)  NOT NULL,
                 user_id      VARCHAR(64)  NOT NULL,
+                group_id     VARCHAR(64)  DEFAULT NULL,
                 name         VARCHAR(100) NOT NULL,
                 key_hash     VARCHAR(64)  NOT NULL,
                 key_prefix   VARCHAR(12)  NOT NULL,
@@ -1582,7 +1607,47 @@ impl SqlMemoryStore {
                 last_used_at DATETIME(6)  DEFAULT NULL,
                 PRIMARY KEY (key_id),
                 KEY idx_key_hash (key_hash),
-                KEY idx_user_active (user_id, is_active)
+                KEY idx_user_active (user_id, is_active),
+                KEY idx_group_active (group_id, is_active)
+            )"#,
+        )
+        .execute(&mut *conn)
+        .await
+        .map_err(db_err)?;
+
+        let key_group_col_exists: Option<i64> = sqlx::query_scalar(
+            "SELECT 1 FROM information_schema.columns \
+             WHERE table_schema = DATABASE() AND table_name = 'mem_api_keys' AND column_name = 'group_id' \
+             LIMIT 1",
+        )
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(db_err)?;
+        if key_group_col_exists.is_none() {
+            let alter = sqlx::query(
+                "ALTER TABLE mem_api_keys ADD COLUMN group_id VARCHAR(64) DEFAULT NULL",
+            );
+            if let Err(e) = alter.execute(&mut *conn).await {
+                if !is_duplicate_column(&e) {
+                    return Err(db_err(e));
+                }
+            }
+            let alter_idx = sqlx::query(
+                "ALTER TABLE mem_api_keys ADD KEY idx_group_active (group_id, is_active)",
+            );
+            let _ = alter_idx.execute(&mut *conn).await;
+        }
+
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS mem_groups (
+                group_id      VARCHAR(64)  PRIMARY KEY,
+                group_name    VARCHAR(128) NOT NULL,
+                db_name       VARCHAR(128) NOT NULL UNIQUE,
+                owner_user_id VARCHAR(64)  NOT NULL,
+                status        VARCHAR(20)  NOT NULL DEFAULT 'active',
+                created_at    DATETIME(6)  NOT NULL,
+                updated_at    DATETIME(6)  NOT NULL,
+                KEY idx_group_status (status)
             )"#,
         )
         .execute(&mut *conn)
@@ -1834,6 +1899,23 @@ impl SqlMemoryStore {
         .await
         .map_err(db_err)?;
 
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS mem_group_members (
+                group_id     VARCHAR(64)  NOT NULL,
+                user_id      VARCHAR(64)  NOT NULL,
+                display_name VARCHAR(128) DEFAULT NULL,
+                role         VARCHAR(20)  NOT NULL DEFAULT 'member',
+                is_active    TINYINT(1)   NOT NULL DEFAULT 1,
+                joined_at    DATETIME(6)  NOT NULL,
+                removed_at   DATETIME(6)  DEFAULT NULL,
+                PRIMARY KEY (group_id, user_id),
+                INDEX idx_user_active (user_id, is_active)
+            )"#,
+        )
+        .execute(&mut *conn)
+        .await
+        .map_err(db_err)?;
+
         Ok(())
     }
 
@@ -1956,7 +2038,7 @@ impl SqlMemoryStore {
             }
         }
         if let Some(router) = self.db_router.clone() {
-            match router.routed_store_for_user(user_id) {
+            match router.scope_store(user_id).await {
                 Ok(store) => {
                     let _ = store
                         .insert_edit_log_direct(
@@ -2054,7 +2136,7 @@ impl SqlMemoryStore {
             let mut first_err = None;
             let mut flushed_any = false;
             for (user_id, user_entries) in by_user {
-                match router.routed_store_for_user(user_id) {
+                match router.scope_store(user_id).await {
                     Ok(store) => match store.flush_edit_log_batch_direct(&user_entries).await {
                         Ok(()) => flushed_any = true,
                         Err(err) => {
@@ -2145,12 +2227,22 @@ impl SqlMemoryStore {
 
     // ── Branch state ──────────────────────────────────────────────────────────
 
+    /// Resolve the user ID for per-user state (active branch).
+    /// In group mode `ACTOR_USER_ID` carries the real human user;
+    /// in personal mode the task-local is unset and we fall back to `scope_id`.
+    fn state_user<'a>(&self, scope_id: &'a str) -> Cow<'a, str> {
+        ACTOR_USER_ID
+            .try_with(|id| Cow::Owned(id.clone()))
+            .unwrap_or(Cow::Borrowed(scope_id))
+    }
+
     pub async fn active_branch_name(&self, user_id: &str) -> Result<String, MemoriaError> {
+        let state_user = self.state_user(user_id);
         let user_state_table = self.t("mem_user_state");
         let row = sqlx::query(&format!(
             "SELECT active_branch FROM {user_state_table} WHERE user_id = ?"
         ))
-        .bind(user_id)
+        .bind(state_user.as_ref())
         .fetch_optional(&self.pool)
         .await
         .map_err(db_err)?;
@@ -2162,8 +2254,11 @@ impl SqlMemoryStore {
     }
 
     /// Returns the active table name for a user: "mem_memories" or branch table name.
+    /// Uses `ACTOR_USER_ID` (task-local) for the per-user active-branch state,
+    /// and `user_id` (the scope) for looking up the branch's table in `mem_branches`.
     pub async fn active_table(&self, user_id: &str) -> Result<String, MemoriaError> {
-        if let Some(cached) = self.active_table_cache.get(user_id) {
+        let cache_key = self.state_user(user_id);
+        if let Some(cached) = self.active_table_cache.get(cache_key.as_ref()) {
             return Ok(cached);
         }
 
@@ -2172,10 +2267,11 @@ impl SqlMemoryStore {
         if branch == "main" {
             let table = self.t("mem_memories");
             self.active_table_cache
-                .insert(user_id.to_string(), table.clone());
+                .insert(cache_key.into_owned(), table.clone());
             return Ok(table);
         }
 
+        // Branch metadata is owned by the scope (group_id or user_id), not the actor.
         let branches_table = self.t("mem_branches");
         let branch_row = sqlx::query(&format!(
             "SELECT table_name FROM {branches_table} WHERE user_id = ? AND name = ? AND status = 'active'"
@@ -2190,20 +2286,21 @@ impl SqlMemoryStore {
             Some(r) => {
                 let table = self.t(&r.try_get::<String, _>("table_name").map_err(db_err)?);
                 self.active_table_cache
-                    .insert(user_id.to_string(), table.clone());
+                    .insert(cache_key.into_owned(), table.clone());
                 Ok(table)
             }
             None => {
                 self.set_active_branch(user_id, "main").await?;
                 let table = self.t("mem_memories");
                 self.active_table_cache
-                    .insert(user_id.to_string(), table.clone());
+                    .insert(cache_key.into_owned(), table.clone());
                 Ok(table)
             }
         }
     }
 
     pub async fn set_active_branch(&self, user_id: &str, branch: &str) -> Result<(), MemoriaError> {
+        let state_user = self.state_user(user_id);
         let user_state_table = self.t("mem_user_state");
         let now = Utc::now().naive_utc();
         sqlx::query(&format!(
@@ -2211,7 +2308,7 @@ impl SqlMemoryStore {
                VALUES (?, ?, ?)
                ON DUPLICATE KEY UPDATE active_branch = ?, updated_at = ?"#,
         ))
-        .bind(user_id)
+        .bind(state_user.as_ref())
         .bind(branch)
         .bind(now)
         .bind(branch)
@@ -2219,12 +2316,17 @@ impl SqlMemoryStore {
         .execute(&self.pool)
         .await
         .map_err(db_err)?;
-        self.active_table_cache.invalidate(user_id);
+        self.active_table_cache.invalidate(state_user.as_ref());
         Ok(())
     }
 
     pub async fn invalidate_user_caches(&self, user_id: &str) {
+        // Invalidate both the scope key and (if different) the actor key
         self.active_table_cache.invalidate(user_id);
+        let state_user = self.state_user(user_id);
+        if state_user.as_ref() != user_id {
+            self.active_table_cache.invalidate(state_user.as_ref());
+        }
 
         // Keep rollback reconciliation scoped to the known per-user governance cooldowns.
         for operation in [
@@ -4139,7 +4241,7 @@ impl SqlMemoryStore {
         for chunk in ids.chunks(500) {
             let ph = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
             let sql = format!(
-                "SELECT memory_id, user_id, memory_type, content, \
+                "SELECT memory_id, user_id, author_id, memory_type, content, \
                  embedding AS emb_str, session_id, \
                  CAST(source_event_ids AS CHAR) AS src_ids, \
                  CAST(extra_metadata AS CHAR) AS extra_meta, \
@@ -4317,7 +4419,7 @@ impl SqlMemoryStore {
         memory_id: &str,
     ) -> Result<Option<Memory>, MemoriaError> {
         let row = sqlx::query(&format!(
-            "SELECT memory_id, user_id, memory_type, content, \
+            "SELECT memory_id, user_id, author_id, memory_type, content, \
              embedding AS emb_str, session_id, \
              CAST(source_event_ids AS CHAR) AS src_ids, \
              CAST(extra_metadata AS CHAR) AS extra_meta, \
@@ -4371,13 +4473,14 @@ impl SqlMemoryStore {
 
         sqlx::query(&format!(
             r#"INSERT INTO {table}
-               (memory_id, user_id, memory_type, content, embedding, session_id,
+               (memory_id, user_id, author_id, memory_type, content, embedding, session_id,
                 source_event_ids, extra_metadata, is_active, superseded_by,
                 trust_tier, initial_confidence, observed_at, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)"#
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)"#
         ))
         .bind(&memory.memory_id)
         .bind(&memory.user_id)
+        .bind(memory.author_id.as_deref())
         .bind(memory.memory_type.to_string())
         .bind(&memory.content)
         .bind(embedding)
@@ -4410,12 +4513,12 @@ impl SqlMemoryStore {
         for chunk in memories.chunks(50) {
             let placeholders = chunk
                 .iter()
-                .map(|_| "(?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)")
+                .map(|_| "(?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)")
                 .collect::<Vec<_>>()
                 .join(", ");
             let sql = format!(
                 "INSERT INTO {table} \
-                 (memory_id, user_id, memory_type, content, embedding, session_id, \
+                 (memory_id, user_id, author_id, memory_type, content, embedding, session_id, \
                   source_event_ids, extra_metadata, is_active, superseded_by, \
                   trust_tier, initial_confidence, observed_at, created_at, updated_at) \
                  VALUES {placeholders}"
@@ -4440,6 +4543,7 @@ impl SqlMemoryStore {
                 q = q
                     .bind(m.memory_id.clone())
                     .bind(m.user_id.clone())
+                    .bind(m.author_id.clone())
                     .bind(m.memory_type.to_string())
                     .bind(m.content.clone())
                     .bind(embedding)
@@ -4465,7 +4569,7 @@ impl SqlMemoryStore {
         limit: i64,
     ) -> Result<Vec<Memory>, MemoriaError> {
         let rows = sqlx::query(&format!(
-            "SELECT memory_id, user_id, memory_type, content, \
+            "SELECT memory_id, user_id, author_id, memory_type, content, \
              embedding AS emb_str, session_id, \
              CAST(source_event_ids AS CHAR) AS src_ids, \
              CAST(extra_metadata AS CHAR) AS extra_meta, \
@@ -4483,6 +4587,10 @@ impl SqlMemoryStore {
         .await
         .map_err(db_err)?;
         rows.iter().map(row_to_memory).collect()
+    }
+
+    pub fn qualified_table(&self, table: &str) -> String {
+        self.t(table)
     }
 
     /// Lightweight list for API responses — skips embedding, source_event_ids,
@@ -4514,7 +4622,7 @@ impl SqlMemoryStore {
         inner.push_str(" ORDER BY memory_id DESC LIMIT ?");
 
         let sql = format!(
-            "SELECT memory_id, user_id, memory_type, content, \
+            "SELECT memory_id, user_id, author_id, memory_type, content, \
              session_id, is_active, superseded_by, trust_tier, \
              initial_confidence, observed_at, created_at, updated_at \
              FROM {table} WHERE memory_id IN ({inner}) \
@@ -4658,7 +4766,7 @@ impl SqlMemoryStore {
         // Use OR semantics (no + prefix) — AND is too strict for natural language queries
         // because stopwords are removed from the index but +stopword still requires a match.
         let sql = format!(
-            "SELECT memory_id, user_id, memory_type, content, \
+            "SELECT memory_id, user_id, author_id, memory_type, content, \
              embedding AS emb_str, session_id, \
              CAST(source_event_ids AS CHAR) AS src_ids, \
              CAST(extra_metadata AS CHAR) AS extra_meta, \
@@ -4767,7 +4875,7 @@ impl SqlMemoryStore {
                 None => format!("LIMIT {limit}"),
             };
             format!(
-                "SELECT memory_id, user_id, memory_type, content, \
+                "SELECT memory_id, user_id, author_id, memory_type, content, \
                  session_id, \
                  CAST(source_event_ids AS CHAR) AS src_ids, \
                  CAST(extra_metadata AS CHAR) AS extra_meta, \
@@ -5395,7 +5503,7 @@ impl MemoryStore for SqlMemoryStore {
     async fn get(&self, memory_id: &str) -> Result<Option<Memory>, MemoriaError> {
         let table = self.t("mem_memories");
         let row = sqlx::query(&format!(
-            "SELECT memory_id, user_id, memory_type, content, \
+            "SELECT memory_id, user_id, author_id, memory_type, content, \
              embedding AS emb_str, session_id, \
              CAST(source_event_ids AS CHAR) AS src_ids, \
              CAST(extra_metadata AS CHAR) AS extra_meta, \
@@ -5503,6 +5611,9 @@ fn row_to_memory_base(row: &sqlx::mysql::MySqlRow) -> Result<Memory, MemoriaErro
     Ok(Memory {
         memory_id: row.try_get("memory_id").map_err(db_err)?,
         user_id: row.try_get("user_id").map_err(db_err)?,
+        author_id: row
+            .try_get::<Option<String>, _>("author_id")
+            .unwrap_or(None),
         memory_type: MemoryType::from_str(&memory_type_str)?,
         content: row.try_get("content").map_err(db_err)?,
         initial_confidence: row

--- a/memoria/crates/memoria-storage/tests/branch_ops.rs
+++ b/memoria/crates/memoria-storage/tests/branch_ops.rs
@@ -66,6 +66,7 @@ async fn create_branch_table(pool: &sqlx::MySqlPool, table: &str, dim: usize) {
             observed_at     DATETIME(6)  NOT NULL,
             created_at      DATETIME(6)  NOT NULL,
             updated_at      DATETIME(6),
+            author_id       VARCHAR(64),
             INDEX idx_user_active (user_id, is_active, memory_type)
         )"#
     );

--- a/memoria/crates/memoria-storage/tests/branch_ops.rs
+++ b/memoria/crates/memoria-storage/tests/branch_ops.rs
@@ -37,6 +37,7 @@ fn make_memory(user_id: &str, content: &str) -> Memory {
         observed_at: None,
         created_at: None,
         updated_at: None,
+        author_id: None,
     }
 }
 

--- a/memoria/crates/memoria-storage/tests/branch_ops.rs
+++ b/memoria/crates/memoria-storage/tests/branch_ops.rs
@@ -507,8 +507,9 @@ async fn test_merge_not_insert_ignore_select_star() {
     assert_eq!(rows[0].content, "memory with embedding");
     println!("✅ regression: merge with vecf32 embedding inserts correctly");
 
-    // Document the broken pattern: INSERT IGNORE correctly skips rows with duplicate
-    // memory_id (PK conflict). The fix (NOT EXISTS) is equivalent but more explicit.
+    // Document the broken pattern: INSERT IGNORE SELECT * can fail due to column
+    // order mismatch (e.g. vecf32 cast error) or silently skip PK conflicts.
+    // The correct approach always uses explicit column lists (as above).
     let broken_sql =
         format!("INSERT IGNORE INTO mem_memories SELECT * FROM {branch_table} WHERE user_id = ?");
     sqlx::query("DELETE FROM mem_memories WHERE user_id = ?")
@@ -516,17 +517,21 @@ async fn test_merge_not_insert_ignore_select_star() {
         .execute(store.pool())
         .await
         .ok();
-    let broken_res = sqlx::query(&broken_sql)
+    match sqlx::query(&broken_sql)
         .bind(&user)
         .execute(store.pool())
         .await
-        .expect("broken merge");
-    // INSERT IGNORE works here because there's no PK conflict (fresh delete above).
-    // The production issue was memory_id already existing in main (stored before checkout).
-    println!(
-        "ℹ️  INSERT IGNORE SELECT * rowcount={} (correct fix uses NOT EXISTS instead)",
-        broken_res.rows_affected()
-    );
+    {
+        Ok(broken_res) => {
+            println!(
+                "ℹ️  INSERT IGNORE SELECT * rowcount={} (correct fix uses NOT EXISTS instead)",
+                broken_res.rows_affected()
+            );
+        }
+        Err(e) => {
+            println!("ℹ️  INSERT IGNORE SELECT * failed as expected: {e}");
+        }
+    }
 
     // Cleanup
     sqlx::raw_sql(&format!("DROP TABLE IF EXISTS {branch_table}"))

--- a/memoria/crates/memoria-storage/tests/router_multi_db.rs
+++ b/memoria/crates/memoria-storage/tests/router_multi_db.rs
@@ -53,6 +53,7 @@ fn make_memory(id: &str, content: &str, user_id: &str) -> Memory {
         extra_metadata: None,
         trust_tier: TrustTier::T3Inferred,
         retrieval_score: None,
+        author_id: None,
     }
 }
 

--- a/memoria/crates/memoria-storage/tests/store_crud.rs
+++ b/memoria/crates/memoria-storage/tests/store_crud.rs
@@ -54,6 +54,7 @@ fn make_memory(id: &str, content: &str, user_id: &str) -> Memory {
         extra_metadata: None,
         trust_tier: TrustTier::T3Inferred,
         retrieval_score: None,
+        author_id: None,
     }
 }
 
@@ -426,6 +427,7 @@ async fn test_all_fields_round_trip() {
         extra_metadata: Some(meta),
         trust_tier: TrustTier::T1Verified,
         retrieval_score: None,
+        author_id: None,
     };
     store.insert(&m).await.expect("insert");
 
@@ -532,6 +534,7 @@ async fn test_null_optional_fields() {
         extra_metadata: None, // NULL JSON
         trust_tier: TrustTier::T3Inferred,
         retrieval_score: None,
+        author_id: None,
     };
     store.insert(&m).await.expect("insert with nulls");
 


### PR DESCRIPTION
## Summary

- Add group CRUD, membership management, and scoped memory access via `AuthUser::scope_id()`
- Implement per-member branch isolation with native MatrixOne data branch diff for conflict detection
- Add `memory_apply` MCP tool for selective branch promotion (cherry-pick style)
- Update agent rule templates across all platforms (Claude, Cursor, Gemini, Kiro, Codex) with apply guidance

## Design

See `docs/specs/2026-04-12-group-collaboration-api.md` for the full spec.

Each group member operates on an isolated data branch. Changes are surfaced via `memory_diff` and selectively promoted to the group's main branch using `memory_apply`, avoiding full-merge conflicts.

## Test plan

- [ ] `cargo test -p memoria-api --test group_collab_api` — group lifecycle, membership, scoped reads/writes
- [ ] `cargo test -p memoria-mcp --test branch_e2e` — apply tool integration
- [ ] Verify existing tests pass (`cargo test --workspace`)
- [ ] Manual: create group, add member, write on member branch, diff, apply to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)