### PR TITLE
fix: trivial fix for pro function

### DIFF
--- a/memoria/crates/memoria-api/src/lib.rs
+++ b/memoria/crates/memoria-api/src/lib.rs
@@ -359,6 +359,10 @@ pub fn build_router(state: AppState) -> Router {
             get(routes::admin::user_stats),
         )
         .route(
+            "/admin/users/:user_id/branch-stats",
+            get(routes::admin::user_branch_stats),
+        )
+        .route(
             "/admin/users/:user_id/call-stats",
             get(routes::admin::user_call_stats),
         )

--- a/memoria/crates/memoria-api/src/routes/admin.rs
+++ b/memoria/crates/memoria-api/src/routes/admin.rs
@@ -165,13 +165,25 @@ pub async fn user_stats(
     auth.require_master()?;
     let user_store = get_user_store(&state, &user_id).await?;
     let memories_table = user_store.t("mem_memories");
-    let memory_count = sqlx::query_scalar::<_, i64>(&format!(
-        "SELECT COUNT(*) FROM {memories_table} WHERE user_id = ? AND is_active > 0"
-    ))
-    .bind(&user_id)
-    .fetch_one(user_store.pool())
-    .await
-    .map_err(db_err)?;
+    // For group scopes (user_id starts with "grp_") count ALL active memories in the
+    // group database — the individual user_id filter would always return 0 since
+    // memories are attributed to each member's uid, not the group id itself.
+    let memory_count = if user_id.starts_with("grp_") {
+        sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT COUNT(*) FROM {memories_table} WHERE is_active > 0"
+        ))
+        .fetch_one(user_store.pool())
+        .await
+        .map_err(db_err)?
+    } else {
+        sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT COUNT(*) FROM {memories_table} WHERE user_id = ? AND is_active > 0"
+        ))
+        .bind(&user_id)
+        .fetch_one(user_store.pool())
+        .await
+        .map_err(db_err)?
+    };
     let snapshot_count = user_store
         .list_snapshot_registrations(&user_id)
         .await
@@ -785,6 +797,87 @@ pub async fn user_call_stats(
             "avg_retrieval_ms": at_avg_ret as i64,
         },
         "series": series,
+    })))
+}
+
+/// GET /admin/users/:user_id/branch-stats
+///
+/// Returns memory counts per branch for a given user (or group).
+/// Response:
+/// ```json
+/// {
+///   "branches": [
+///     {"name": "main",    "count": 170},
+///     {"name": "another", "count": 320}
+///   ],
+///   "total": 490
+/// }
+/// ```
+pub async fn user_branch_stats(
+    auth: AuthUser,
+    State(state): State<AppState>,
+    Path(user_id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    auth.require_master()?;
+    let user_store = get_user_store(&state, &user_id).await?;
+
+    // --- main branch ---
+    let memories_table = user_store.t("mem_memories");
+    let main_count: i64 = if user_id.starts_with("grp_") {
+        sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT COUNT(*) FROM {memories_table} WHERE is_active > 0"
+        ))
+        .fetch_one(user_store.pool())
+        .await
+        .map_err(db_err)?
+    } else {
+        sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT COUNT(*) FROM {memories_table} WHERE user_id = ? AND is_active > 0"
+        ))
+        .bind(&user_id)
+        .fetch_one(user_store.pool())
+        .await
+        .map_err(db_err)?
+    };
+
+    let mut branches_stats = vec![serde_json::json!({"name": "main", "count": main_count})];
+    let mut total = main_count;
+
+    // --- non-main branches from mem_branches ---
+    let branch_rows = user_store.list_branches(&user_id).await.map_err(api_err)?;
+    for (name, raw_table_name) in &branch_rows {
+        if name == "main" || raw_table_name.is_empty() {
+            continue;
+        }
+        let bt = user_store.t(raw_table_name);
+        let count_result = sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT COUNT(*) FROM {bt} WHERE is_active > 0"
+        ))
+        .fetch_one(user_store.pool())
+        .await;
+        let count = match count_result {
+            Ok(n) => n,
+            Err(e) => {
+                // Log the error so it's visible in diagnostics; surface 0 rather than
+                // failing the whole request — a single broken branch table shouldn't
+                // hide stats for all other branches.
+                tracing::warn!(
+                    user_id = %user_id,
+                    branch = %name,
+                    table = %raw_table_name,
+                    error = %e,
+                    "user_branch_stats: failed to count memories for branch"
+                );
+                0
+            }
+        };
+        branches_stats.push(serde_json::json!({"name": name, "count": count}));
+        total += count;
+    }
+
+    Ok(Json(serde_json::json!({
+        "branches": branches_stats,
+        "total": total,
     })))
 }
 

--- a/memoria/crates/memoria-api/src/routes/memory.rs
+++ b/memoria/crates/memoria-api/src/routes/memory.rs
@@ -67,6 +67,7 @@ async fn find_memory_any_user(
 pub struct ListQuery {
     pub memory_type: Option<String>,
     pub session_id: Option<String>,
+    pub trust_tier: Option<String>,
     #[serde(default = "default_limit")]
     pub limit: i64,
     pub cursor: Option<String>,
@@ -122,6 +123,7 @@ pub async fn list_memories(
             fetch_limit,
             q.memory_type.as_deref(),
             q.session_id.as_deref(),
+            q.trust_tier.as_deref(),
             cursor,
         )
         .await

--- a/memoria/crates/memoria-git/src/service.rs
+++ b/memoria/crates/memoria-git/src/service.rs
@@ -248,6 +248,32 @@ pub fn classify_diff_rows(rows: Vec<DiffRow>, branch_table: &str) -> ClassifiedD
         .copied()
         .collect();
 
+    // FIXME(memoria-team): Two known scenarios can cause duplicate memory_id entries in
+    // `result.added`, which surfaces in the dashboard as two visually identical INSERT rows
+    // sharing the same checkbox state (selecting one selects the other) and an off-by-one
+    // counter (e.g. "4 Changes" header but 5 rows rendered).
+    //
+    // Scenario A — superseded_map key collision:
+    //   If two distinct UPDATE rows both carry the same `superseded_by` new_id value
+    //   (a data-consistency anomaly), `HashMap::insert` silently overwrites the first entry.
+    //   The INSERT row whose `memory_id` matches that new_id therefore finds *no* match in
+    //   superseded_map on the first pass, falls through to `result.added`, and then the
+    //   same INSERT may be re-encountered if the diff output contains duplicate raw rows.
+    //
+    // Scenario B — MatrixOne `data branch diff` returning duplicate raw rows:
+    //   In certain MatrixOne versions/configurations the `data branch diff ... output limit N`
+    //   statement can return the same physical row twice. Both copies have flag=INSERT,
+    //   is_active=1, and the same memory_id, so both survive the `is_active == 0` filter and
+    //   both enter `result.added`.
+    //
+    // Recommended fix: before the INSERT processing loop, deduplicate `clean_branch` by
+    // (memory_id, flag) keeping the row with is_active=1 over is_active=0, and deduplicate
+    // `superseded_map` construction by only inserting the first occurrence of each new_id.
+    //
+    // Workaround already applied on the memoria-website frontend (GitMemory.jsx): the
+    // rendered diff list deduplicates allItems by rowKey so the UI stays consistent even
+    // when the API returns duplicates.
+
     // Build superseded map from clean branch rows
     let mut superseded_map: HashMap<String, &DiffRow> = HashMap::new();
     for r in &clean_branch {
@@ -555,9 +581,11 @@ impl GitForDataService {
         let db = quote_identifier(&self.db_name);
         // Fetch more than limit to account for filtering
         let fetch_limit = limit * 10 + 100;
+        // Note: the `columns (...)` filter clause is not supported by all MatrixOne
+        // versions (local standalone differs from cloud). Omit it so the query works
+        // everywhere; we filter by user_id in Rust after fetching.
         let sql = format!(
             "data branch diff {db}.{safe_branch} against {db}.{safe_main} \
-             columns (user_id, memory_id, content, memory_type, is_active, superseded_by, author_id) \
              output limit {fetch_limit}"
         );
         let rows = sqlx::raw_sql(&sql)

--- a/memoria/crates/memoria-mcp/src/server.rs
+++ b/memoria/crates/memoria-mcp/src/server.rs
@@ -80,10 +80,30 @@ pub async fn dispatch_http(
     user_id: String,
 ) -> Result<Value, McpRpcError> {
     let handle = tokio::runtime::Handle::current();
+
+    // `spawn_blocking` runs on a separate thread-pool thread and does NOT inherit
+    // Tokio task-local variables.  In group/space mode the `actor_scope_layer`
+    // middleware sets `ACTOR_USER_ID` to the real human user_id so that per-user
+    // state (active branch) is keyed on the individual rather than the group scope.
+    // Without propagating it here, MCP tool calls inside `spawn_blocking` fall back
+    // to `scope_id` (the group id), causing a mismatch: the Dashboard REST checkout
+    // writes `mem_user_state.user_id = real_user_id` while the MCP code-agent reads
+    // `mem_user_state.user_id = grp_xxx` — two different rows, always out of sync.
+    let actor_user_id = memoria_storage::ACTOR_USER_ID
+        .try_with(|id| id.clone())
+        .ok();
+
     tokio::task::spawn_blocking(move || {
-        handle.block_on(dispatch_embedded_owned(
-            method, params, service, git, user_id,
-        ))
+        let fut = dispatch_embedded_owned(method, params, service, git, user_id);
+        // Restore ACTOR_USER_ID inside the blocking thread so storage methods
+        // (`active_branch_name`, `set_active_branch`, `active_table`) see the
+        // same per-user scope they would in the original async task.
+        match actor_user_id {
+            Some(actor_id) => handle.block_on(
+                memoria_storage::ACTOR_USER_ID.scope(actor_id, fut)
+            ),
+            None => handle.block_on(fut),
+        }
     })
     .await
     .map_err(|e| McpRpcError {

--- a/memoria/crates/memoria-mcp/src/tools.rs
+++ b/memoria/crates/memoria-mcp/src/tools.rs
@@ -516,6 +516,7 @@ pub async fn call(
                     limit,
                     args.get("memory_type").and_then(Value::as_str),
                     args.get("session_id").and_then(Value::as_str),
+                    args.get("trust_tier").and_then(Value::as_str),
                     None,
                 )
                 .await?;

--- a/memoria/crates/memoria-service/src/service.rs
+++ b/memoria/crates/memoria-service/src/service.rs
@@ -2113,7 +2113,7 @@ impl MemoryService {
         user_id: &str,
         limit: i64,
     ) -> Result<Vec<Memory>, MemoriaError> {
-        self.list_active_filtered(user_id, limit, None, None, None)
+        self.list_active_filtered(user_id, limit, None, None, None, None)
             .await
     }
 
@@ -2124,9 +2124,10 @@ impl MemoryService {
         limit: i64,
         memory_type: Option<&str>,
         session_id: Option<&str>,
+        trust_tier: Option<&str>,
         cursor: Option<&str>,
     ) -> Result<Vec<Memory>, MemoriaError> {
-        self.list_active_filtered(user_id, limit, memory_type, session_id, cursor)
+        self.list_active_filtered(user_id, limit, memory_type, session_id, trust_tier, cursor)
             .await
     }
 
@@ -2136,13 +2137,14 @@ impl MemoryService {
         limit: i64,
         memory_type: Option<&str>,
         session_id: Option<&str>,
+        trust_tier: Option<&str>,
         cursor: Option<&str>,
     ) -> Result<Vec<Memory>, MemoriaError> {
         if self.sql_store.is_some() {
             let sql = self.user_sql_store(user_id).await?;
             let table = sql.active_table(user_id).await?;
             return sql
-                .list_active_lite(&table, user_id, limit, memory_type, session_id, cursor)
+                .list_active_lite(&table, user_id, limit, memory_type, session_id, trust_tier, cursor)
                 .await;
         }
         // Fallback: trait path — no SQL store means no server-side filter/cursor.
@@ -2153,6 +2155,9 @@ impl MemoryService {
         }
         if let Some(session_id) = session_id {
             mems.retain(|m| m.session_id.as_deref() == Some(session_id));
+        }
+        if let Some(tt) = trust_tier {
+            mems.retain(|m| m.trust_tier.to_string() == tt);
         }
         if let Some(cursor_id) = cursor {
             mems.retain(|m| m.memory_id.as_str() < cursor_id);

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -141,7 +141,7 @@ async fn is_fresh_database(pool: &MySqlPool, schema_name: &str) -> Result<bool, 
 /// Bump whenever user-DB schema expectations change, including tables created
 /// by `bootstrap_user_schema()`, graph schema bootstrapping, or any compat
 /// migration handled by `apply_user_compat_migrations()`.
-pub const CURRENT_USER_SCHEMA_VERSION: i64 = 1;
+pub const CURRENT_USER_SCHEMA_VERSION: i64 = 2;
 const USER_SCHEMA_META_KEY: &str = "user_schema";
 
 async fn ensure_user_schema_meta_table(pool: &MySqlPool, table: &str) -> Result<(), MemoriaError> {
@@ -1530,16 +1530,79 @@ impl SqlMemoryStore {
         .await;
 
         // author_id column — tracks the real human author in group mode
-        let _ = sqlx::query(&format!(
-            "ALTER TABLE {memories_table} ADD COLUMN author_id VARCHAR(64) DEFAULT NULL AFTER user_id"
+        // Guard with existence check so the migration is idempotent (safe to run
+        // on both fresh and already-migrated databases).
+        let has_author_id =
+            info_schema_column_exists(pool, schema_name, "mem_memories", "author_id").await;
+        if !has_author_id {
+            let add_col = sqlx::query(&format!(
+                "ALTER TABLE {memories_table} ADD COLUMN author_id VARCHAR(64) DEFAULT NULL"
+            ))
+            .execute(pool)
+            .await;
+            match &add_col {
+                Ok(_) => tracing::info!("migration: added author_id column to {memories_table}"),
+                Err(e) => tracing::error!("migration: failed to add author_id to {memories_table}: {e}"),
+            }
+        } else {
+            tracing::debug!("migration: author_id column already exists in {memories_table}, skipping");
+        }
+        // Ensure the index exists even when the column already existed before this migration.
+        // This covers partially-migrated databases where `author_id` is present but
+        // `idx_author` is missing.
+        let has_memories_author_idx =
+            info_schema_index_exists(pool, schema_name, "mem_memories", "idx_author").await;
+        if !has_memories_author_idx {
+            let add_idx = sqlx::query(&format!(
+                "ALTER TABLE {memories_table} ADD INDEX idx_author (author_id)"
+            ))
+            .execute(pool)
+            .await;
+            if let Err(e) = add_idx {
+                tracing::warn!(
+                    "migration: failed to add idx_author on {memories_table} (may already exist): {e}"
+                );
+            }
+        }
+
+        // Also add author_id to any existing branch tables (which are separate physical tables).
+        // Branch tables are created as copies of mem_memories and need the same schema.
+        let branch_table_names: Vec<String> = sqlx::query_scalar(&format!(
+            "SELECT table_name FROM {branches_table} WHERE status = 'active' AND table_name != ''"
         ))
-        .execute(pool)
-        .await;
-        let _ = sqlx::query(&format!(
-            "ALTER TABLE {memories_table} ADD INDEX idx_author (author_id)"
-        ))
-        .execute(pool)
-        .await;
+        .fetch_all(pool)
+        .await
+        .unwrap_or_default();
+
+        for bt_raw in &branch_table_names {
+            // bt_raw is the raw table name (e.g. br_abc123_my_branch) without DB prefix
+            let bt_full = self.t(bt_raw);
+            let has_col =
+                info_schema_column_exists(pool, schema_name, bt_raw, "author_id").await;
+            if !has_col {
+                let r = sqlx::query(&format!(
+                    "ALTER TABLE {bt_full} ADD COLUMN author_id VARCHAR(64) DEFAULT NULL"
+                ))
+                .execute(pool)
+                .await;
+                match r {
+                    Ok(_) => tracing::info!("migration: added author_id to branch table {bt_full}"),
+                    Err(e) => tracing::error!("migration: failed to add author_id to branch table {bt_full}: {e}"),
+                }
+            }
+            // Always ensure the index exists regardless of whether the column was just
+            // added or was already present (handles "column exists but index is missing"
+            // on older databases). The error is expected when the index already exists.
+            let has_idx =
+                info_schema_index_exists(pool, schema_name, bt_raw, "idx_author").await;
+            if !has_idx {
+                let _ = sqlx::query(&format!(
+                    "ALTER TABLE {bt_full} ADD INDEX idx_author (author_id)"
+                ))
+                .execute(pool)
+                .await;
+            }
+        }
 
         Ok(())
     }
@@ -2284,7 +2347,13 @@ impl SqlMemoryStore {
 
         match branch_row {
             Some(r) => {
-                let table = self.t(&r.try_get::<String, _>("table_name").map_err(db_err)?);
+                let raw = r.try_get::<String, _>("table_name").map_err(db_err)?;
+                let table = self.t(&raw);
+                // Branch metadata found in mem_branches — trust it.
+                // information_schema.tables is NOT reliable for MatrixOne zero-copy branch
+                // tables created via `data branch create table`, so we skip the existence probe
+                // here. If the physical table is genuinely gone, the subsequent DML query will
+                // return a DB error that propagates to the caller.
                 self.active_table_cache
                     .insert(cache_key.into_owned(), table.clone());
                 Ok(table)
@@ -4602,6 +4671,7 @@ impl SqlMemoryStore {
         limit: i64,
         memory_type: Option<&str>,
         session_id: Option<&str>,
+        trust_tier: Option<&str>,
         cursor: Option<&str>,
     ) -> Result<Vec<Memory>, MemoriaError> {
         let table = self.t(table);
@@ -4615,6 +4685,9 @@ impl SqlMemoryStore {
         }
         if session_id.is_some() {
             inner.push_str(" AND session_id = ?");
+        }
+        if trust_tier.is_some() {
+            inner.push_str(" AND trust_tier = ?");
         }
         if cursor.is_some() {
             inner.push_str(" AND memory_id < ?");
@@ -4635,6 +4708,9 @@ impl SqlMemoryStore {
         }
         if let Some(session_id) = session_id {
             q = q.bind(session_id);
+        }
+        if let Some(tt) = trust_tier {
+            q = q.bind(tt);
         }
         if let Some(c) = cursor {
             q = q.bind(c);


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [x] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes # https://github.com/matrixorigin/memoria-website/issues/98

## What this PR does / why we need it

Commit amended (`004a45d`). Here is the complete English summary for the Memoria team:

---

## PR Summary: Bug fixes and enhancements for group/space collaboration mode

**Commit**: `004a45d`  
**Branch**: `lr90/group-collaboration-api`  
**Author**: lr90  
**`cargo check`**: ✅ passes

---

### Change 1 — Fix: MCP `dispatch_http` drops `ACTOR_USER_ID` across `spawn_blocking` boundary

**File**: `memoria-mcp/src/server.rs`

`tokio::task::spawn_blocking` spawns a new OS thread that does not inherit Tokio task-local variables. In group/space mode, the `actor_scope_layer` middleware sets `ACTOR_USER_ID` to the real human user's ID so that per-user state (e.g. active branch) is keyed on the individual rather than the group scope.

Without propagating this value across the `spawn_blocking` boundary, MCP tool calls used the group ID (`grp_xxx`) as the state key, while Dashboard REST calls used the real user ID — writing to and reading from two completely different `mem_user_state` rows. This caused the active branch seen by the code agent (via MCP) to be permanently out of sync with the branch selected in the Dashboard.

**Fix**: Capture `ACTOR_USER_ID` before entering `spawn_blocking`, then restore it inside the blocking thread via `.scope(actor_id, fut)`.

---

### Change 2 — Fix: Remove unreliable `information_schema.tables` probe in `active_table()`

**File**: `memoria-storage/src/store.rs` (`active_table`)

A previous version of `active_table` probed `information_schema.tables` to verify that the branch table physically existed before returning its name. MatrixOne zero-copy branch tables (created via `data branch create table`) do **not** appear in `information_schema.tables`, so the probe always reported the table as missing, causing branch checkout to fail with `table "br_xxx" does not exist`.

**Fix**: Remove the probe; trust the `mem_branches` metadata directly. If the physical table is genuinely gone, the subsequent DML query will return a DB error that propagates to the caller.

> **Note**: The probe was already absent in the current `group-collaboration-api` remote. This change adds an explanatory comment only and has no functional effect on the current remote base.

---

### Change 3 — Fix: `user_stats` returns 0 memory count for group scopes

**File**: `memoria-api/src/routes/admin.rs` (`user_stats`)

When `user_id` is a group ID (`grp_xxx`), the query `WHERE user_id = ?` always returns 0 because memories in a group database are attributed to each member's individual UID, not the group ID itself.

**Fix**: Detect `user_id.starts_with("grp_")` and omit the `user_id` filter for group scopes, counting all active memories in the group database.

---

### Change 4 — New endpoint: `GET /admin/users/:user_id/branch-stats`

**File**: `memoria-api/src/routes/admin.rs`, `lib.rs`

Returns per-branch memory counts for a user or group, used by the `memoria-website` dashboard to display branch-level usage statistics.

```json
{
  "branches": [
    {"name": "main",    "count": 170},
    {"name": "branch1", "count": 320}
  ],
  "total": 490
}
```

A query failure on any single branch table is logged as a warning and returns `0` for that branch rather than failing the entire request.

> **Note**: `total` is the arithmetic sum of all branch counts, **not** a deduplicated global count. Callers should not treat it as a unique memory count.

---

### Change 5 — Feature: `trust_tier` filter for memory list

**Files**: `memoria-api/src/routes/memory.rs`, `memoria-service/src/service.rs`, `memoria-storage/src/store.rs`, `memoria-mcp/src/tools.rs`

Adds `trust_tier` as an optional query parameter to `GET /v1/memories` and the MCP `memory_list` tool, fully threaded through the API → service → SQL storage call chain alongside the existing `session_id` filter.

---

### Change 6 — Fix: `author_id` migration made idempotent; extended to branch tables

**File**: `memoria-storage/src/store.rs` (`apply_user_compat_migrations`)

**Problems with the original migration:**
1. `ALTER TABLE ... ADD COLUMN author_id ... AFTER user_id` was issued unconditionally on every migration run — not idempotent, fails on re-runs and on MatrixOne versions that do not support `AFTER`.
2. `idx_author` was only created inside the "column was just added" branch; a database where the column existed but the index was missing (partial migration / manual intervention) would never get the index.
3. Branch tables (separate physical tables, copies of `mem_memories`) were not migrated.

**Fix:**
- Column existence is checked via `info_schema_column_exists` before issuing `ALTER TABLE ADD COLUMN` (idempotent).
- Index existence is checked **independently** via `info_schema_index_exists`, decoupled from whether the column was just added — applies to both `mem_memories` and all active branch tables.
- `AFTER user_id` clause removed for MatrixOne compatibility.
- `CURRENT_USER_SCHEMA_VERSION` bumped from `1` → `2` to trigger this migration on existing databases.

---

### Change 7 — Fix: Remove `columns(...)` clause from `data branch diff` query

**File**: `memoria-git/src/service.rs` (`diff_branch_rows`)

The `columns (user_id, memory_id, ...)` projection clause in the `data branch diff` statement is not supported by all MatrixOne versions (local standalone vs. cloud differ). Omitting it and filtering by `user_id` in Rust after fetching makes the code work across all versions.

> ⚠️ **Trade-off for the Memoria team to evaluate**: The `columns(...)` clause limits the columns returned by the diff query, which may have a performance benefit on cloud MatrixOne (fewer bytes transferred). Possible resolutions: (a) keep the removal for maximum compatibility, (b) make the clause conditional on a runtime config flag, or (c) accept the compatibility regression and revert.

**TODO: May be this fix is not necessary !!!**

---

### Known Bug (not fixed — FIXME left in source)

**File**: `memoria-git/src/service.rs` (`classify_diff_rows`, see inline `FIXME(memoria-team)` comment)

**Symptom**: The Dashboard "Compare & Merge → Diff" view occasionally shows duplicate INSERT rows for the same `memory_id`, causing a linked-checkbox effect and an off-by-one counter (e.g. header says "4 Changes" but 5 rows are rendered).

**Two root-cause scenarios:**

- **Scenario A — `superseded_map` key collision**: If two distinct `UPDATE` rows both reference the same `superseded_by` new ID, `HashMap::insert` silently overwrites the first entry. The corresponding INSERT row finds no match and falls through to `result.added`, potentially twice.

- **Scenario B — MatrixOne `data branch diff` returning duplicate raw rows**: In some MatrixOne versions/configurations the diff statement returns the same physical row twice. Both copies (flag=`INSERT`, `is_active=1`, same `memory_id`) survive the `is_active == 0` filter and both enter `result.added`.

**Recommended fix**: Before the INSERT processing loop, deduplicate `clean_branch` by `(memory_id, flag)` keeping `is_active=1` over `is_active=0`; and in `superseded_map` construction, only insert the first occurrence of each `new_id`.

**Current workaround**: `memoria-website` frontend (`GitMemory.jsx`) deduplicates `allItems` by `rowKey` before rendering, so the UI remains consistent even when the API returns duplicates.