### PR TITLE
fix: trivial fix for pro function

### DIFF
--- a/memoria/crates/memoria-api/src/auth.rs
+++ b/memoria/crates/memoria-api/src/auth.rs
@@ -83,7 +83,7 @@ async fn cached_or_db_principal(token: &str, state: &AppState) -> Option<CachedA
     Some(principal)
 }
 
-async fn group_main_write_allowed_for_solo_owner(
+pub(crate) async fn group_main_write_allowed_for_solo_owner(
     state: &AppState,
     group_id: &str,
     user_id: &str,

--- a/memoria/crates/memoria-api/src/lib.rs
+++ b/memoria/crates/memoria-api/src/lib.rs
@@ -359,6 +359,10 @@ pub fn build_router(state: AppState) -> Router {
             get(routes::admin::user_stats),
         )
         .route(
+            "/admin/users/:user_id/branch-stats",
+            get(routes::admin::user_branch_stats),
+        )
+        .route(
             "/admin/users/:user_id/call-stats",
             get(routes::admin::user_call_stats),
         )

--- a/memoria/crates/memoria-api/src/routes/admin.rs
+++ b/memoria/crates/memoria-api/src/routes/admin.rs
@@ -845,6 +845,7 @@ pub async fn user_branch_stats(
 
     let mut branches_stats = vec![serde_json::json!({"name": "main", "count": main_count})];
     let mut total = main_count;
+    let mut degraded_branches: Vec<String> = Vec::new();
 
     // --- non-main branches from mem_branches ---
     // Branch tables are per-user physical tables (created via `data branch create table`),
@@ -864,9 +865,6 @@ pub async fn user_branch_stats(
         let count = match count_result {
             Ok(n) => n,
             Err(e) => {
-                // Log the error so it's visible in diagnostics; surface 0 rather than
-                // failing the whole request — a single broken branch table shouldn't
-                // hide stats for all other branches.
                 tracing::warn!(
                     user_id = %user_id,
                     branch = %name,
@@ -874,6 +872,8 @@ pub async fn user_branch_stats(
                     error = %e,
                     "user_branch_stats: failed to count memories for branch"
                 );
+                // Record degraded branch so the caller knows the total is unreliable.
+                degraded_branches.push(name.clone());
                 0
             }
         };
@@ -884,6 +884,11 @@ pub async fn user_branch_stats(
     Ok(Json(serde_json::json!({
         "branches": branches_stats,
         "total": total,
+        // `degraded` is true when at least one branch table could not be counted.
+        // In that case `total` is a lower bound and `degraded_branches` lists the
+        // affected branches — callers should treat the numbers as approximate.
+        "degraded": !degraded_branches.is_empty(),
+        "degraded_branches": degraded_branches,
     })))
 }
 

--- a/memoria/crates/memoria-api/src/routes/admin.rs
+++ b/memoria/crates/memoria-api/src/routes/admin.rs
@@ -165,13 +165,25 @@ pub async fn user_stats(
     auth.require_master()?;
     let user_store = get_user_store(&state, &user_id).await?;
     let memories_table = user_store.t("mem_memories");
-    let memory_count = sqlx::query_scalar::<_, i64>(&format!(
-        "SELECT COUNT(*) FROM {memories_table} WHERE user_id = ? AND is_active > 0"
-    ))
-    .bind(&user_id)
-    .fetch_one(user_store.pool())
-    .await
-    .map_err(db_err)?;
+    // For group scopes (user_id starts with "grp_") count ALL active memories in the
+    // group database — the individual user_id filter would always return 0 since
+    // memories are attributed to each member's uid, not the group id itself.
+    let memory_count = if user_id.starts_with("grp_") {
+        sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT COUNT(*) FROM {memories_table} WHERE is_active > 0"
+        ))
+        .fetch_one(user_store.pool())
+        .await
+        .map_err(db_err)?
+    } else {
+        sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT COUNT(*) FROM {memories_table} WHERE user_id = ? AND is_active > 0"
+        ))
+        .bind(&user_id)
+        .fetch_one(user_store.pool())
+        .await
+        .map_err(db_err)?
+    };
     let snapshot_count = user_store
         .list_snapshot_registrations(&user_id)
         .await
@@ -785,6 +797,93 @@ pub async fn user_call_stats(
             "avg_retrieval_ms": at_avg_ret as i64,
         },
         "series": series,
+    })))
+}
+
+/// GET /admin/users/:user_id/branch-stats
+///
+/// Returns memory counts per branch for a given user (or group).
+/// Response:
+/// ```json
+/// {
+///   "branches": [
+///     {"name": "main",    "count": 170},
+///     {"name": "another", "count": 320}
+///   ],
+///   "total": 490
+/// }
+/// ```
+pub async fn user_branch_stats(
+    auth: AuthUser,
+    State(state): State<AppState>,
+    Path(user_id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    auth.require_master()?;
+    let user_store = get_user_store(&state, &user_id).await?;
+
+    // --- main branch ---
+    // Personal users have rows from multiple users in mem_memories (shared table), so
+    // we filter by user_id. Group users own an isolated per-group database where
+    // mem_memories contains only group data, so no user_id filter is needed there.
+    let memories_table = user_store.t("mem_memories");
+    let main_count: i64 = if user_id.starts_with("grp_") {
+        sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT COUNT(*) FROM {memories_table} WHERE is_active > 0"
+        ))
+        .fetch_one(user_store.pool())
+        .await
+        .map_err(db_err)?
+    } else {
+        sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT COUNT(*) FROM {memories_table} WHERE user_id = ? AND is_active > 0"
+        ))
+        .bind(&user_id)
+        .fetch_one(user_store.pool())
+        .await
+        .map_err(db_err)?
+    };
+
+    let mut branches_stats = vec![serde_json::json!({"name": "main", "count": main_count})];
+    let mut total = main_count;
+
+    // --- non-main branches from mem_branches ---
+    // Branch tables are per-user physical tables (created via `data branch create table`),
+    // so they only contain data belonging to the owning user/group. No user_id filter is
+    // required — this is consistent with the group-scoped main count above.
+    let branch_rows = user_store.list_branches(&user_id).await.map_err(api_err)?;
+    for (name, raw_table_name, _created_at) in &branch_rows {
+        if name == "main" || raw_table_name.is_empty() {
+            continue;
+        }
+        let bt = user_store.t(raw_table_name);
+        let count_result = sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT COUNT(*) FROM {bt} WHERE is_active > 0"
+        ))
+        .fetch_one(user_store.pool())
+        .await;
+        let count = match count_result {
+            Ok(n) => n,
+            Err(e) => {
+                // Log the error so it's visible in diagnostics; surface 0 rather than
+                // failing the whole request — a single broken branch table shouldn't
+                // hide stats for all other branches.
+                tracing::warn!(
+                    user_id = %user_id,
+                    branch = %name,
+                    table = %raw_table_name,
+                    error = %e,
+                    "user_branch_stats: failed to count memories for branch"
+                );
+                0
+            }
+        };
+        branches_stats.push(serde_json::json!({"name": name, "count": count}));
+        total += count;
+    }
+
+    Ok(Json(serde_json::json!({
+        "branches": branches_stats,
+        "total": total,
     })))
 }
 

--- a/memoria/crates/memoria-api/src/routes/admin.rs
+++ b/memoria/crates/memoria-api/src/routes/admin.rs
@@ -856,6 +856,16 @@ pub async fn user_branch_stats(
         if name == "main" || raw_table_name.is_empty() {
             continue;
         }
+        if !raw_table_name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            tracing::warn!(
+                user_id = %user_id,
+                branch = %name,
+                table = %raw_table_name,
+                "user_branch_stats: skipping branch with invalid table identifier"
+            );
+            degraded_branches.push(name.clone());
+            continue;
+        }
         let bt = user_store.t(raw_table_name);
         let count_result = sqlx::query_scalar::<_, i64>(&format!(
             "SELECT COUNT(*) FROM {bt} WHERE is_active > 0"

--- a/memoria/crates/memoria-api/src/routes/mcp.rs
+++ b/memoria/crates/memoria-api/src/routes/mcp.rs
@@ -76,6 +76,25 @@ fn tracking_path(method: &str, params: Option<&serde_json::Value>) -> String {
     format!("/mcp/{sanitized}")
 }
 
+/// MCP write tools that mutate the active memory table.
+/// These are blocked when the caller is group-scoped and checked out on `main`,
+/// mirroring the REST `group_main_write_guard` middleware.
+///
+/// Read-only tools, branch-management tools (`memory_checkout`, `memory_branch`,
+/// `memory_branch_delete`), and snapshot ops are intentionally excluded.
+const GROUP_MAIN_WRITE_BLOCKED: &[&str] = &[
+    "memory_store",
+    "memory_correct",
+    "memory_purge",
+    "memory_observe",
+    "memory_governance",
+    "memory_consolidate",
+    "memory_reflect",
+    "memory_extract_entities",
+    "memory_link_entities",
+    "memory_rollback",
+];
+
 fn mcp_tool_dirty_mask(tool: &str) -> Option<crate::metrics_summary::DirtyMask> {
     use crate::metrics_summary::DirtyMask;
     match tool {
@@ -226,9 +245,74 @@ pub async fn mcp_handler(
         }
     };
 
+    // ── Group main-write guard (computed once, shared by both code paths) ─────
+    // Resolved here — before the Notification early-return — so that
+    // Notification-form write calls to `main` are also blocked instead of
+    // silently bypassing the restriction.
+    //
+    // Returns Some(tool_name) when the call must be blocked, None otherwise.
+    let blocked_tool: Option<String> = if let Some(gid) = &auth.group_id {
+        if let Some(tool) = tracked_tool.as_deref() {
+            if GROUP_MAIN_WRITE_BLOCKED.contains(&tool) {
+                // ACTOR_USER_ID is already set by the global actor_scope_layer.
+                let maybe_blocked = state
+                    .service
+                    .user_sql_store(gid)
+                    .await
+                    .ok()
+                    .map(|sql| {
+                        let gid_owned = gid.clone();
+                        memoria_storage::ACTOR_USER_ID
+                            .scope(auth.user_id.clone(), async move {
+                                sql.active_branch_name(&gid_owned).await
+                            })
+                    });
+                if let Some(fut) = maybe_blocked {
+                    if let Ok(branch) = fut.await {
+                        let is_solo_owner =
+                            crate::auth::group_main_write_allowed_for_solo_owner(
+                                &state,
+                                gid,
+                                &auth.user_id,
+                            )
+                            .await;
+                        if branch == "main" && !is_solo_owner {
+                            Some(tool.to_string())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     // JSON-RPC 2.0: a Notification is a *valid* Request without an "id" member.
     // The server MUST NOT reply to Notifications.
     if req.get("id").is_none() {
+        // Write guard: per JSON-RPC 2.0 the server MUST NOT reply to Notifications,
+        // so we silently drop blocked writes without dispatching.
+        if blocked_tool.is_some() {
+            state.call_log_batcher.record_rpc(
+                user_id,
+                "POST".to_string(),
+                track_path,
+                204,
+                t.elapsed().as_millis() as u32,
+                RpcMeta::err(-32001),
+            );
+            return StatusCode::NO_CONTENT.into_response();
+        }
         let dispatch_result = memoria_mcp::dispatch_http(
             method.clone(),
             params,
@@ -261,6 +345,36 @@ pub async fn mcp_handler(
     }
 
     let id = req["id"].clone();
+
+    // Use the pre-computed write-guard decision (see above).
+    if let Some(tool) = &blocked_tool {
+        let err_body = Json(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": {
+                "code": -32001,
+                "message": format!(
+                    "Cannot call '{}' on 'main' in a shared space — \
+                     main is read-only in collaboration mode. \
+                     Your active branch is currently 'main'. \
+                     Call memory_checkout with a branch name \
+                     (e.g. {{\"name\": \"my-branch\"}}) to switch \
+                     to your own branch, then retry.",
+                    tool
+                )
+            }
+        }));
+        report_stats(&track_path, false);
+        state.call_log_batcher.record_rpc(
+            user_id,
+            "POST".to_string(),
+            track_path,
+            200,
+            t.elapsed().as_millis() as u32,
+            RpcMeta::err(-32001),
+        );
+        return err_body.into_response();
+    }
 
     // JSON-RPC spec: the HTTP response is always 200 OK, even for RPC errors.
     // Business-level error tracking uses rpc_success / rpc_error_code in the call log.

--- a/memoria/crates/memoria-api/src/routes/mcp.rs
+++ b/memoria/crates/memoria-api/src/routes/mcp.rs
@@ -303,6 +303,7 @@ pub async fn mcp_handler(
         // Write guard: per JSON-RPC 2.0 the server MUST NOT reply to Notifications,
         // so we silently drop blocked writes without dispatching.
         if blocked_tool.is_some() {
+            report_stats(&track_path, false);
             state.call_log_batcher.record_rpc(
                 user_id,
                 "POST".to_string(),

--- a/memoria/crates/memoria-api/src/routes/memory.rs
+++ b/memoria/crates/memoria-api/src/routes/memory.rs
@@ -67,6 +67,7 @@ async fn find_memory_any_user(
 pub struct ListQuery {
     pub memory_type: Option<String>,
     pub session_id: Option<String>,
+    pub trust_tier: Option<String>,
     #[serde(default = "default_limit")]
     pub limit: i64,
     pub cursor: Option<String>,
@@ -122,6 +123,7 @@ pub async fn list_memories(
             fetch_limit,
             q.memory_type.as_deref(),
             q.session_id.as_deref(),
+            q.trust_tier.as_deref(),
             cursor,
         )
         .await

--- a/memoria/crates/memoria-api/src/routes/memory.rs
+++ b/memoria/crates/memoria-api/src/routes/memory.rs
@@ -115,6 +115,9 @@ pub async fn list_memories(
         .cursor
         .as_deref()
         .filter(|c| c.len() == 32 && c.chars().all(|ch| ch.is_ascii_hexdigit()));
+    if let Some(tier) = q.trust_tier.as_deref() {
+        parse_trust_tier(tier).map_err(|e| (StatusCode::UNPROCESSABLE_ENTITY, e))?;
+    }
     let fetch_limit = limit + 1;
     let mut memories = state
         .service

--- a/memoria/crates/memoria-api/src/routes/snapshots.rs
+++ b/memoria/crates/memoria-api/src/routes/snapshots.rs
@@ -214,7 +214,7 @@ async fn branch_table_name_raw(
     if branch_name == "main" {
         return Ok("mem_memories".to_string());
     }
-    for (name, table_name) in sql.list_branches(scope_id).await.map_err(api_err)? {
+    for (name, table_name, _created_at) in sql.list_branches(scope_id).await.map_err(api_err)? {
         if name == branch_name {
             return Ok(table_name);
         }
@@ -749,10 +749,12 @@ pub async fn list_branches(
         "name": "main",
         "active": active_branch == "main",
     })];
-    for (name, _table_name) in sql.list_branches(auth.scope_id()).await.map_err(api_err)? {
+    for (name, _table_name, created_at) in sql.list_branches(auth.scope_id()).await.map_err(api_err)? {
+        let created_at_str = created_at.map(|dt| dt.format("%Y-%m-%dT%H:%M:%S").to_string());
         branches.push(json!({
             "name": name,
             "active": name == active_branch,
+            "created_at": created_at_str,
         }));
     }
     if !branches

--- a/memoria/crates/memoria-api/src/routes/snapshots.rs
+++ b/memoria/crates/memoria-api/src/routes/snapshots.rs
@@ -241,7 +241,26 @@ async fn branch_diff_items_payload(
         .diff_branch_rows(&branch_table_raw, "mem_memories", scope_id, limit * 3)
         .await
         .map_err(api_err)?;
-    let classified = memoria_git::classify_diff_rows(raw_rows, &branch_table_raw);
+    let mut classified = memoria_git::classify_diff_rows(raw_rows, &branch_table_raw);
+
+    // classify_diff_rows cannot distinguish "deleted from main on branch" from
+    // "created-then-deleted on branch" without querying the main table (because
+    // data branch diff only returns the branch-side row for deletions). Resolve
+    // now: ghost removes (never in main) move to classified.ghost_removes.
+    git.resolve_ghost_removes(&mut classified, "mem_memories", scope_id)
+        .await
+        .map_err(api_err)?;
+
+    tracing::debug!(
+        branch = %branch_name,
+        added = classified.added.len(),
+        updated = classified.updated.len(),
+        removed = classified.removed.len(),
+        ghost_removes = classified.ghost_removes.len(),
+        conflicts = classified.conflicts.len(),
+        behind_main = classified.behind_main.len(),
+        "branch_diff_items_payload: classified result"
+    );
 
     let item_to_json = |item: &memoria_git::DiffItem| -> Value {
         json!({
@@ -750,7 +769,7 @@ pub async fn list_branches(
         "active": active_branch == "main",
     })];
     for (name, _table_name, created_at) in sql.list_branches(auth.scope_id()).await.map_err(api_err)? {
-        let created_at_str = created_at.map(|dt| dt.format("%Y-%m-%dT%H:%M:%S").to_string());
+        let created_at_str = format_snapshot_timestamp(created_at);
         branches.push(json!({
             "name": name,
             "active": name == active_branch,

--- a/memoria/crates/memoria-git/Cargo.toml
+++ b/memoria/crates/memoria-git/Cargo.toml
@@ -11,8 +11,8 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 memoria-storage = { path = "../memoria-storage" }
-tokio = { workspace = true }
 uuid = { workspace = true }

--- a/memoria/crates/memoria-git/src/service.rs
+++ b/memoria/crates/memoria-git/src/service.rs
@@ -2,16 +2,62 @@ use chrono::NaiveDateTime;
 use memoria_core::MemoriaError;
 use serde::{Deserialize, Serialize};
 use sqlx::{mysql::MySqlPool, Row};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 fn db_err(e: sqlx::Error) -> MemoriaError {
     MemoriaError::Database(e.to_string())
 }
 
+/// Returns true when the error is MatrixOne's "txn need retry in rc mode, def changed"
+/// (error code 20631). This is a transient conflict that arises when a DDL operation
+/// runs concurrently with another DDL that modifies the same table's definition (e.g.
+/// an ALTER TABLE migration overlapping with `data branch merge`). The caller should
+/// back off briefly and retry the statement.
+fn is_mo_retry_error(e: &sqlx::Error) -> bool {
+    let msg = e.to_string();
+    msg.contains("20631") || msg.contains("txn need retry")
+}
+
+/// Returns true when the error indicates a SQL parse / unsupported-syntax failure.
+/// Used to detect that the connected MatrixOne build does not support `columns (...)`
+/// in `data branch diff` so we can fall back gracefully (Option B runtime downgrade).
+fn is_mo_syntax_error(e: &sqlx::Error) -> bool {
+    let msg = e.to_string().to_lowercase();
+    // MySQL/MatrixOne error 1064 = "You have an error in your SQL syntax".
+    // Also match plain-text parse-error messages from newer MO builds.
+    msg.contains("1064") || msg.contains("parse error") || msg.contains("syntax error")
+}
+
 /// Execute a DDL statement without prepared statement protocol.
-/// MatrixOne does not support PREPARE for DDL (CREATE SNAPSHOT, data branch, etc.)
+/// MatrixOne does not support PREPARE for DDL (CREATE SNAPSHOT, data branch, etc.).
+///
+/// Automatically retries up to 3 times on MatrixOne error 20631
+/// ("txn need retry in rc mode, def changed"), which is a transient conflict that can
+/// occur when concurrent DDL operations (e.g. schema migrations adding columns to branch
+/// tables) race with `data branch merge` or similar commands.
 async fn exec_ddl(pool: &MySqlPool, sql: &str) -> Result<(), MemoriaError> {
-    sqlx::raw_sql(sql).execute(pool).await.map_err(db_err)?;
-    Ok(())
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut attempt = 0u32;
+    loop {
+        match sqlx::raw_sql(sql).execute(pool).await {
+            Ok(_) => return Ok(()),
+            Err(e) if attempt < MAX_ATTEMPTS - 1 && is_mo_retry_error(&e) => {
+                attempt += 1;
+                let backoff_ms = 50u64 * (1 << attempt); // 100 ms, 200 ms
+                tracing::warn!(
+                    attempt,
+                    backoff_ms,
+                    error = %e,
+                    "exec_ddl: MatrixOne 20631 retry",
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+            }
+            Err(e) => return Err(db_err(e)),
+        }
+    }
 }
 
 /// Validate identifier — alphanumeric + underscore only, prevents SQL injection in DDL.
@@ -248,6 +294,32 @@ pub fn classify_diff_rows(rows: Vec<DiffRow>, branch_table: &str) -> ClassifiedD
         .copied()
         .collect();
 
+    // FIXME(memoria-team): Two known scenarios can cause duplicate memory_id entries in
+    // `result.added`, which surfaces in the dashboard as two visually identical INSERT rows
+    // sharing the same checkbox state (selecting one selects the other) and an off-by-one
+    // counter (e.g. "4 Changes" header but 5 rows rendered).
+    //
+    // Scenario A — superseded_map key collision:
+    //   If two distinct UPDATE rows both carry the same `superseded_by` new_id value
+    //   (a data-consistency anomaly), `HashMap::insert` silently overwrites the first entry.
+    //   The INSERT row whose `memory_id` matches that new_id therefore finds *no* match in
+    //   superseded_map on the first pass, falls through to `result.added`, and then the
+    //   same INSERT may be re-encountered if the diff output contains duplicate raw rows.
+    //
+    // Scenario B — MatrixOne `data branch diff` returning duplicate raw rows:
+    //   In certain MatrixOne versions/configurations the `data branch diff ... output limit N`
+    //   statement can return the same physical row twice. Both copies have flag=INSERT,
+    //   is_active=1, and the same memory_id, so both survive the `is_active == 0` filter and
+    //   both enter `result.added`.
+    //
+    // Recommended fix: before the INSERT processing loop, deduplicate `clean_branch` by
+    // (memory_id, flag) keeping the row with is_active=1 over is_active=0, and deduplicate
+    // `superseded_map` construction by only inserting the first occurrence of each new_id.
+    //
+    // Workaround already applied on the memoria-website frontend (GitMemory.jsx): the
+    // rendered diff list deduplicates allItems by rowKey so the UI stays consistent even
+    // when the API returns duplicates.
+
     // Build superseded map from clean branch rows
     let mut superseded_map: HashMap<String, &DiffRow> = HashMap::new();
     for r in &clean_branch {
@@ -338,6 +410,15 @@ pub fn classify_diff_rows(rows: Vec<DiffRow>, branch_table: &str) -> ClassifiedD
 pub struct GitForDataService {
     pool: MySqlPool,
     db_name: String,
+    /// Whether the connected MatrixOne build supports the `columns (...)` projection
+    /// clause in `data branch diff`. Starts `true`; automatically flipped to `false`
+    /// the first time a parse/unsupported-syntax error is observed, after which all
+    /// diff calls in this process skip the projection (Option B runtime downgrade).
+    ///
+    /// Using `columns (...)` is strongly preferred: without it, MatrixOne ships every
+    /// column of the source table over the wire — including embedding vectors and
+    /// extra_metadata JSON — even though only 7 fields are read.
+    supports_diff_columns: Arc<AtomicBool>,
 }
 
 impl GitForDataService {
@@ -345,6 +426,7 @@ impl GitForDataService {
         Self {
             pool,
             db_name: db_name.into(),
+            supports_diff_columns: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -542,6 +624,18 @@ impl GitForDataService {
     /// all rows and filter in Rust. Returns raw diff rows including source, is_active,
     /// superseded_by, and author_id.
     /// Use [`classify_diff_rows`] to get ADDED/UPDATED/REMOVED/CONFLICTS.
+    ///
+    /// ## Column projection
+    /// The preferred query includes `columns (user_id, memory_id, ...)` to avoid
+    /// shipping embedding vectors and extra_metadata JSON over the wire. If this MO
+    /// build does not support that clause (parse/syntax error), the flag
+    /// `supports_diff_columns` is set to `false` for the lifetime of the process and
+    /// all subsequent calls fall back to the full-row query (Option B runtime downgrade).
+    ///
+    /// In both query forms, MatrixOne prepends an implicit source column (the table
+    /// name the row originated from) as column index 0 in the result set, so ordinal
+    /// access `r.try_get(0usize)` reliably retrieves it regardless of whether the
+    /// projection clause is active.
     pub async fn diff_branch_rows(
         &self,
         branch_table: &str,
@@ -553,24 +647,59 @@ impl GitForDataService {
         let safe_branch = validate_identifier(branch_table)?;
         let safe_main = validate_identifier(main_table)?;
         let db = quote_identifier(&self.db_name);
-        // Fetch more than limit to account for filtering
+        // Fetch more rows than requested to account for user_id filtering in Rust.
         let fetch_limit = limit * 10 + 100;
-        let sql = format!(
+
+        // Projected query: only retrieve the 7 fields we actually read. Avoids shipping
+        // embedding vectors and extra_metadata JSON over the wire on every diff call.
+        const DIFF_COLS: &str =
+            "columns (user_id, memory_id, content, memory_type, is_active, superseded_by, author_id)";
+
+        let sql_projected = format!(
             "data branch diff {db}.{safe_branch} against {db}.{safe_main} \
-             columns (user_id, memory_id, content, memory_type, is_active, superseded_by, author_id) \
+             {DIFF_COLS} output limit {fetch_limit}"
+        );
+        let sql_full = format!(
+            "data branch diff {db}.{safe_branch} against {db}.{safe_main} \
              output limit {fetch_limit}"
         );
-        let rows = sqlx::raw_sql(&sql)
-            .fetch_all(&self.pool)
-            .await
-            .map_err(db_err)?;
+
+        let rows = if self.supports_diff_columns.load(Ordering::Relaxed) {
+            match sqlx::raw_sql(&sql_projected).fetch_all(&self.pool).await {
+                Ok(rows) => rows,
+                Err(e) if is_mo_syntax_error(&e) => {
+                    // This MO build does not support columns (...) — disable for this
+                    // process lifetime and retry with the full-row query.
+                    self.supports_diff_columns.store(false, Ordering::Relaxed);
+                    tracing::warn!(
+                        error = %e,
+                        "data branch diff: `columns (...)` unsupported on this MatrixOne \
+                         build; falling back to full-row fetch. Consider upgrading to \
+                         MatrixOne ≥ 3.0-dev or aligning your cloud build."
+                    );
+                    sqlx::raw_sql(&sql_full)
+                        .fetch_all(&self.pool)
+                        .await
+                        .map_err(db_err)?
+                }
+                Err(e) => return Err(db_err(e)),
+            }
+        } else {
+            sqlx::raw_sql(&sql_full)
+                .fetch_all(&self.pool)
+                .await
+                .map_err(db_err)?
+        };
+
         let mut result = Vec::new();
         for r in &rows {
             let uid: String = r.try_get("user_id").map_err(db_err)?;
             if uid != user_id {
                 continue;
             }
-            // First column (index 0) is the source table name
+            // Column index 0 is the implicit source column that MatrixOne prepends to
+            // `data branch diff` output — it holds the originating table name and is
+            // present in both the projected and full-row query forms.
             let source: String = r.try_get(0usize).unwrap_or_default();
             result.push(DiffRow {
                 source,

--- a/memoria/crates/memoria-git/src/service.rs
+++ b/memoria/crates/memoria-git/src/service.rs
@@ -99,26 +99,51 @@ pub struct DiffRow {
 
 /// Classified diff result produced by [`classify_diff_rows`].
 ///
-/// Classification rules (based on MatrixOne `data branch diff` output):
+/// ## Classification rules
 ///
-/// | Scenario                        | main | branch        | flag   | is_active | superseded_by | Category    |
-/// |---------------------------------|------|---------------|--------|-----------|---------------|-------------|
-/// | New memory on branch            | ✗    | ✓ (active)    | INSERT | 1         | NULL          | **ADDED**   |
-/// | Created then deleted on branch  | ✗    | ✓ (inactive)  | INSERT | 0         | NULL          | hidden      |
-/// | Created then corrected (old)    | ✗    | ✓ (inactive)  | INSERT | 0         | new_id        | hidden      |
-/// | Created then corrected (new)    | ✗    | ✓ (active)    | INSERT | 1         | NULL          | **ADDED**   |
-/// | Deleted main memory on branch   | ✓    | ✓ (inactive)  | UPDATE | 0         | NULL          | **REMOVED** |
-/// | Corrected main memory (old)     | ✓    | ✓ (inactive)  | UPDATE | 0         | new_id        | **UPDATED** |
-/// | Corrected main memory (new)     | ✗    | ✓ (active)    | INSERT | 1         | NULL          | paired into **UPDATED** |
+/// Classification uses only `is_active` and `superseded_by`; the `flag` field is
+/// intentionally ignored.  MatrixOne's `data branch diff` flag values are not stable
+/// across versions:
+///   * Older builds: flag=INSERT for newly-inserted branch rows, flag=UPDATE for modified/deleted.
+///   * MatrixOne ≥ 3.0.11: flag=UPDATE for **all** diff rows regardless of DML operation.
+///
+/// Using flag for classification caused all newly-added branch memories to disappear
+/// from diff results on MatrixOne ≥ 3.0.11 (they were `flag=UPDATE, is_active=1` which
+/// matched neither the INSERT-processing nor the UPDATE-processing branch).
+///
+/// | Scenario                        | main | branch        | is_active | superseded_by | Category    |
+/// |---------------------------------|------|---------------|-----------|---------------|-------------|
+/// | New memory on branch            | ✗    | ✓ (active)    | 1         | NULL          | **ADDED**   |
+/// | Created then corrected (old)    | ✗    | ✓ (inactive)  | 0         | new_id        | hidden (part of UPDATED pair) |
+/// | Created then corrected (new)    | ✗    | ✓ (active)    | 1         | NULL          | **ADDED**   |
+/// | Deleted main memory on branch   | ✓    | ✓ (inactive)  | 0         | NULL          | **REMOVED** |
+/// | Created then deleted on branch  | ✗    | ✓ (inactive)  | 0         | NULL          | **REMOVED** (was hidden; see note below) |
+/// | Corrected main memory (old)     | ✓    | ✓ (inactive)  | 0         | new_id        | **UPDATED** |
+/// | Corrected main memory (new)     | ✗    | ✓ (active)    | 1         | NULL          | paired into **UPDATED** |
+///
+/// Note: "created then deleted on branch" rows initially land in `removed`, but
+/// `resolve_ghost_removes` moves them to `ghost_removes` (hidden) after verifying
+/// they are absent (or already inactive) in main — keeping `removed` aligned with
+/// what `selective_apply` can actually merge.
 #[derive(Debug, Clone, Default)]
 pub struct ClassifiedDiff {
     pub added: Vec<DiffItem>,
     pub updated: Vec<DiffUpdatedPair>,
+    /// Memories that are **active in main** (`is_active = 1`) and were deleted on
+    /// this branch. Initially populated by `classify_diff_rows` for all branch-only
+    /// inactive rows, then refined by `resolve_ghost_removes` which moves items that
+    /// are absent (or already inactive) in main into `ghost_removes`.
     pub removed: Vec<DiffItem>,
     pub conflicts: Vec<DiffConflict>,
     /// Main-only changes: rows that exist on main but not on this branch
     /// (other users' merges that happened after this branch was created).
     pub behind_main: Vec<DiffItem>,
+    /// Branch-only inactive rows with no superseded_by: the memory was
+    /// created AND deleted entirely within this branch — it never existed
+    /// in main. These are NOT shown as diffs; merging them is always a
+    /// no-op (the selective_apply remove guard requires main to have the
+    /// memory, which it doesn't).
+    pub ghost_removes: Vec<DiffItem>,
 }
 
 /// A single diff item (used for ADDED and REMOVED categories).
@@ -204,15 +229,36 @@ pub fn classify_diff_rows(rows: Vec<DiffRow>, branch_table: &str) -> ClassifiedD
 
     let mut result = ClassifiedDiff::default();
 
-    // Step 1: Separate by source
+    // Step 1: Separate by source.
+    // DiffRow.source was already normalized to the unqualified table name in diff_branch_rows,
+    // so this comparison should be stable regardless of MatrixOne version.
     let mut branch_rows: Vec<&DiffRow> = Vec::new();
     let mut main_rows: Vec<&DiffRow> = Vec::new();
     for r in &rows {
-        if r.source == branch_table {
+        // MatrixOne returns identifiers in lowercase regardless of how they were created,
+        // so use case-insensitive comparison to avoid misclassifying all branch rows as
+        // main-side when the branch name contains uppercase letters.
+        if r.source.eq_ignore_ascii_case(branch_table) {
             branch_rows.push(r);
         } else {
             main_rows.push(r);
         }
+    }
+    tracing::debug!(
+        total = rows.len(),
+        branch_side = branch_rows.len(),
+        main_side = main_rows.len(),
+        branch_table = %branch_table,
+        "classify_diff_rows: source split"
+    );
+    for r in &branch_rows {
+        tracing::debug!(
+            memory_id = %r.memory_id,
+            flag = %r.flag,
+            is_active = r.is_active,
+            superseded_by = ?r.superseded_by,
+            "classify_diff_rows: branch row"
+        );
     }
 
     // Step 2: Find conflicting memory_ids (present on both sides)
@@ -320,10 +366,16 @@ pub fn classify_diff_rows(rows: Vec<DiffRow>, branch_table: &str) -> ClassifiedD
     // rendered diff list deduplicates allItems by rowKey so the UI stays consistent even
     // when the API returns duplicates.
 
-    // Build superseded map from clean branch rows
+    // Classification no longer depends on `flag` because MatrixOne versions differ
+    // in what they return: older builds use flag=INSERT for newly inserted branch rows,
+    // while newer builds (≥ 3.0.11) return flag=UPDATE for all diff rows regardless of
+    // the actual DML operation. We therefore use only `is_active` and `superseded_by`
+    // to drive the three-way classification.
+
+    // Build superseded map: inactive branch rows that point to a replacement memory_id.
     let mut superseded_map: HashMap<String, &DiffRow> = HashMap::new();
     for r in &clean_branch {
-        if r.flag == "UPDATE" && r.is_active == 0 {
+        if r.is_active == 0 {
             if let Some(ref new_id) = r.superseded_by {
                 if !new_id.is_empty() {
                     superseded_map.insert(new_id.clone(), r);
@@ -332,9 +384,9 @@ pub fn classify_diff_rows(rows: Vec<DiffRow>, branch_table: &str) -> ClassifiedD
         }
     }
 
-    // Process INSERT rows
+    // Active rows (is_active=1): ADDED, or the "new" side of an UPDATED pair.
     for r in &clean_branch {
-        if r.flag != "INSERT" || r.is_active == 0 {
+        if r.is_active != 1 {
             continue;
         }
         if let Some(old_row) = superseded_map.remove(&r.memory_id) {
@@ -356,9 +408,24 @@ pub fn classify_diff_rows(rows: Vec<DiffRow>, branch_table: &str) -> ClassifiedD
         }
     }
 
-    // Process UPDATE rows — is_active=0 without superseded_by → REMOVED
+    // Branch-only inactive rows without superseded_by.
+    //
+    // `data branch diff` only returns the branch-side row for deletions — it
+    // does NOT return the main-side row — so every such row here is branch-only.
+    // There are two distinct scenarios that look identical at this point:
+    //
+    //   A. "Deleted from main on branch": memory_id exists in main (active).
+    //      → User-visible REMOVED; should propagate on merge.
+    //
+    //   B. "Created-then-deleted on branch": memory_id NEVER existed in main.
+    //      → Ghost/no-op; hide from diff (merge would skip anyway).
+    //
+    // We cannot distinguish A from B without querying the main table. The
+    // initial classification puts ALL of them into `removed`. Callers that have
+    // DB access should call `resolve_ghost_removes` afterwards to move bucket-B
+    // items from `removed` into `ghost_removes`.
     for r in &clean_branch {
-        if r.flag != "UPDATE" || r.is_active != 0 {
+        if r.is_active != 0 {
             continue;
         }
         let has_superseded = r
@@ -691,6 +758,23 @@ impl GitForDataService {
                 .map_err(db_err)?
         };
 
+        tracing::debug!(
+            branch_table = %branch_table,
+            main_table = %main_table,
+            raw_row_count = rows.len(),
+            "diff_branch_rows: raw rows from data branch diff"
+        );
+
+        // Log the first row's source column to diagnose qualified vs unqualified naming.
+        if let Some(first) = rows.first() {
+            let sample_source: String = first.try_get(0usize).unwrap_or_default();
+            tracing::debug!(
+                sample_source = %sample_source,
+                branch_table = %branch_table,
+                "diff_branch_rows: source column sample (col 0)"
+            );
+        }
+
         let mut result = Vec::new();
         for r in &rows {
             let uid: String = r.try_get("user_id").map_err(db_err)?;
@@ -700,7 +784,15 @@ impl GitForDataService {
             // Column index 0 is the implicit source column that MatrixOne prepends to
             // `data branch diff` output — it holds the originating table name and is
             // present in both the projected and full-row query forms.
-            let source: String = r.try_get(0usize).unwrap_or_default();
+            //
+            // Depending on the MatrixOne version, column 0 may be qualified ("db.table")
+            // or unqualified ("table"). We normalize to the unqualified form so that
+            // classify_diff_rows can reliably compare against the bare table name.
+            let source_raw: String = r.try_get(0usize).unwrap_or_default();
+            let source = source_raw
+                .rsplit_once('.')
+                .map(|(_, t)| t.to_string())
+                .unwrap_or(source_raw);
             result.push(DiffRow {
                 source,
                 flag: r.try_get("flag").map_err(db_err)?,
@@ -723,6 +815,11 @@ impl GitForDataService {
                 break;
             }
         }
+        tracing::debug!(
+            filtered_row_count = result.len(),
+            branch_table = %branch_table,
+            "diff_branch_rows: rows after user_id filter"
+        );
         Ok(result)
     }
 
@@ -794,44 +891,73 @@ impl GitForDataService {
             for id in &add_ids {
                 q = q.bind(id);
             }
+            // Use pool directly for the read-only branch-table probe.
+            // MatrixOne zero-copy branch tables may not be readable within an open
+            // write transaction on the same connection, causing the branch check to
+            // return empty and silently skip all adds.
             let branch_present: std::collections::HashSet<String> = q
-                .fetch_all(&mut *tx)
+                .fetch_all(&self.pool)
                 .await
                 .map_err(db_err)?
                 .iter()
                 .filter_map(|row| row.try_get::<String, _>("memory_id").ok())
                 .collect();
 
+            // Query main for ALL rows with these memory_ids (regardless of is_active),
+            // to check for existing records (active or inactive) that would conflict.
             let main_sql = format!(
-                "SELECT memory_id FROM {main_table_ref} WHERE user_id = ? AND memory_id IN ({placeholders})"
+                "SELECT memory_id, is_active FROM {main_table_ref} WHERE user_id = ? AND memory_id IN ({placeholders})"
             );
             let mut q = sqlx::query(&main_sql).bind(user_id);
             for id in &add_ids {
                 q = q.bind(id);
             }
-            let main_present: std::collections::HashSet<String> = q
-                .fetch_all(&mut *tx)
-                .await
-                .map_err(db_err)?
+            let main_rows = q.fetch_all(&self.pool).await.map_err(db_err)?;
+            let main_present_all: std::collections::HashSet<String> = main_rows
                 .iter()
                 .filter_map(|row| row.try_get::<String, _>("memory_id").ok())
                 .collect();
+            let main_active: std::collections::HashSet<String> = main_rows
+                .iter()
+                .filter(|row| row.try_get::<i8, _>("is_active").unwrap_or(0) == 1)
+                .filter_map(|row| row.try_get::<String, _>("memory_id").ok())
+                .collect();
 
+            tracing::debug!(
+                add_ids = add_ids.len(),
+                branch_present = branch_present.len(),
+                main_present_all = main_present_all.len(),
+                main_active = main_active.len(),
+                "selective_apply: add check"
+            );
+
+            // Classify adds into three buckets:
+            // - new_adds:     not in main at all → INSERT
+            // - restore_adds: in main but inactive (is_active=0, e.g. previously deleted)
+            //                 → DELETE stale row + INSERT branch version
+            // - skip:         already active in main → no-op
+            let mut new_adds: Vec<String> = Vec::new();
+            let mut restore_adds: Vec<String> = Vec::new();
             for id in &add_ids {
-                if branch_present.contains(id) && !main_present.contains(id) {
+                if !branch_present.contains(id) {
+                    result.skipped_adds.push(id.clone());
+                } else if main_active.contains(id) {
+                    // Already active in main — already merged.
+                    result.skipped_adds.push(id.clone());
+                } else if main_present_all.contains(id) {
+                    // Exists in main but inactive (deleted). Restore from branch.
+                    restore_adds.push(id.clone());
                     result.applied_adds.push(id.clone());
                 } else {
-                    result.skipped_adds.push(id.clone());
+                    // Genuinely new — not in main at all.
+                    new_adds.push(id.clone());
+                    result.applied_adds.push(id.clone());
                 }
             }
 
-            if !result.applied_adds.is_empty() {
-                let ph = result
-                    .applied_adds
-                    .iter()
-                    .map(|_| "?")
-                    .collect::<Vec<_>>()
-                    .join(",");
+            // INSERT genuinely new memories
+            if !new_adds.is_empty() {
+                let ph = new_adds.iter().map(|_| "?").collect::<Vec<_>>().join(",");
                 let insert_sql = format!(
                     "INSERT INTO {main_table_ref} \
                      (memory_id, user_id, memory_type, content, embedding, session_id, \
@@ -843,10 +969,45 @@ impl GitForDataService {
                      FROM {branch_table_ref} WHERE user_id = ? AND is_active = 1 AND memory_id IN ({ph})"
                 );
                 let mut q = sqlx::query(&insert_sql).bind(user_id);
-                for id in &result.applied_adds {
+                for id in &new_adds {
                     q = q.bind(id);
                 }
                 q.execute(&mut *tx).await.map_err(db_err)?;
+            }
+
+            // Restore inactive-in-main memories: delete stale row, then insert branch version.
+            // Cannot use INSERT...ON DUPLICATE KEY UPDATE because MatrixOne branch tables are
+            // read-only views in some builds. Instead: DELETE + INSERT.
+            if !restore_adds.is_empty() {
+                let ph = restore_adds.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+                let delete_sql = format!(
+                    "DELETE FROM {main_table_ref} WHERE user_id = ? AND memory_id IN ({ph})"
+                );
+                let mut q = sqlx::query(&delete_sql).bind(user_id);
+                for id in &restore_adds {
+                    q = q.bind(id);
+                }
+                q.execute(&mut *tx).await.map_err(db_err)?;
+
+                let insert_sql = format!(
+                    "INSERT INTO {main_table_ref} \
+                     (memory_id, user_id, memory_type, content, embedding, session_id, \
+                      source_event_ids, extra_metadata, is_active, superseded_by, \
+                      trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id) \
+                     SELECT memory_id, user_id, memory_type, content, embedding, session_id, \
+                            source_event_ids, extra_metadata, is_active, superseded_by, \
+                            trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id \
+                     FROM {branch_table_ref} WHERE user_id = ? AND is_active = 1 AND memory_id IN ({ph})"
+                );
+                let mut q = sqlx::query(&insert_sql).bind(user_id);
+                for id in &restore_adds {
+                    q = q.bind(id);
+                }
+                q.execute(&mut *tx).await.map_err(db_err)?;
+                tracing::info!(
+                    count = restore_adds.len(),
+                    "selective_apply: restored inactive-in-main memories from branch"
+                );
             }
         }
 
@@ -861,12 +1022,14 @@ impl GitForDataService {
                 .await
                 .map_err(db_err)?;
 
+                // Read branch table via pool (not tx) to avoid MatrixOne zero-copy
+                // visibility issues when reading branch tables inside an active transaction.
                 let branch_old_exists: i64 = sqlx::query_scalar(&format!(
                     "SELECT COUNT(*) FROM {branch_table_ref} WHERE memory_id = ? AND user_id = ?"
                 ))
                 .bind(&pair.old_id)
                 .bind(user_id)
-                .fetch_one(&mut *tx)
+                .fetch_one(&self.pool)
                 .await
                 .map_err(db_err)?;
                 let branch_new_exists: i64 = sqlx::query_scalar(&format!(
@@ -874,7 +1037,7 @@ impl GitForDataService {
                 ))
                 .bind(&pair.new_id)
                 .bind(user_id)
-                .fetch_one(&mut *tx)
+                .fetch_one(&self.pool)
                 .await
                 .map_err(db_err)?;
 
@@ -948,6 +1111,7 @@ impl GitForDataService {
                 .filter_map(|row| row.try_get::<String, _>("memory_id").ok())
                 .collect();
 
+            // Read branch table via pool (not tx) — same reason as update path above.
             let branch_sql = format!(
                 "SELECT memory_id FROM {branch_table_ref} WHERE user_id = ? AND is_active = 0 AND memory_id IN ({placeholders})"
             );
@@ -956,7 +1120,7 @@ impl GitForDataService {
                 q = q.bind(id);
             }
             let branch_present: std::collections::HashSet<String> = q
-                .fetch_all(&mut *tx)
+                .fetch_all(&self.pool)
                 .await
                 .map_err(db_err)?
                 .iter()
@@ -1034,8 +1198,11 @@ impl GitForDataService {
                 for id in &branch_ids {
                     q = q.bind(id);
                 }
+                // Read branch table via pool (not tx) — same reason as add/remove paths:
+                // MatrixOne zero-copy branch tables may not be visible inside an open
+                // write transaction on the same connection.
                 let branch_present: std::collections::HashSet<String> = q
-                    .fetch_all(&mut *tx)
+                    .fetch_all(&self.pool)
                     .await
                     .map_err(db_err)?
                     .iter()
@@ -1097,6 +1264,69 @@ impl GitForDataService {
 
         tx.commit().await.map_err(db_err)?;
         Ok(result)
+    }
+
+    /// Refine a [`ClassifiedDiff`] by querying the main table to distinguish
+    /// two cases that are indistinguishable from the raw `data branch diff` output:
+    ///
+    /// - **Real remove** (`memory_id` is **active** in main, `is_active = 1`): stays in `removed`.
+    ///   This matches the guard in `selective_apply`'s remove path so that every item
+    ///   shown as REMOVED in the UI is actually mergeable.
+    /// - **Ghost remove** (`memory_id` never existed in main, or already inactive):
+    ///   moved to `ghost_removes` (not shown to user).
+    ///
+    /// Must be called after [`classify_diff_rows`] when the caller has DB access.
+    /// If `classified.removed` is empty the method is a no-op.
+    pub async fn resolve_ghost_removes(
+        &self,
+        classified: &mut ClassifiedDiff,
+        main_table: &str,
+        user_id: &str,
+    ) -> Result<(), MemoriaError> {
+        if classified.removed.is_empty() {
+            return Ok(());
+        }
+        let main_table = validate_identifier(main_table)?;
+        let db = quote_identifier(&self.db_name);
+        let main_table_ref = format!("{db}.{main_table}");
+        let remove_ids: Vec<String> = classified
+            .removed
+            .iter()
+            .map(|r| r.memory_id.clone())
+            .collect();
+        let ph = remove_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        // Use is_active = 1 to match the exact guard in selective_apply's remove path
+        // (L1098: "is_active = 1"). A memory that is already inactive in main would
+        // never pass that guard, so showing it as REMOVED in the diff is a false-positive:
+        // the user sees a deletable item that the merge silently skips.
+        let sql = format!(
+            "SELECT memory_id FROM {main_table_ref} WHERE user_id = ? AND is_active = 1 AND memory_id IN ({ph})"
+        );
+        let mut q = sqlx::query_scalar(&sql).bind(user_id);
+        for id in &remove_ids {
+            q = q.bind(id);
+        }
+        let main_has: std::collections::HashSet<String> = q
+            .fetch_all(&self.pool)
+            .await
+            .map_err(db_err)?
+            .into_iter()
+            .collect();
+
+        let old_removed = std::mem::take(&mut classified.removed);
+        for item in old_removed {
+            if main_has.contains(&item.memory_id) {
+                classified.removed.push(item);
+            } else {
+                classified.ghost_removes.push(item);
+            }
+        }
+        tracing::debug!(
+            real_removes = classified.removed.len(),
+            ghost_removes = classified.ghost_removes.len(),
+            "resolve_ghost_removes: filtered removed bucket"
+        );
+        Ok(())
     }
 
     /// Count rows in a table at a given snapshot (for diff/validation).

--- a/memoria/crates/memoria-mcp/src/git_tools.rs
+++ b/memoria/crates/memoria-mcp/src/git_tools.rs
@@ -830,7 +830,7 @@ pub async fn call(
             };
             let text = branches
                 .iter()
-                .map(|(name, _table)| {
+                .map(|(name, _table, _created_at)| {
                     let marker = if *name == active_branch {
                         " ← active"
                     } else {
@@ -851,7 +851,7 @@ pub async fn call(
                 return Ok(mcp_text("Switched to branch 'main'"));
             }
             let branches = sql.list_branches(user_id).await?;
-            if !branches.iter().any(|(name, _)| name == branch) {
+            if !branches.iter().any(|(name, _, _)| name == branch) {
                 return Err(MemoriaError::NotFound(format!("Branch '{branch}'")));
             }
             sql.set_active_branch(user_id, branch).await?;
@@ -879,8 +879,8 @@ pub async fn call(
             let branches = sql.list_branches(user_id).await?;
             let table_name = branches
                 .iter()
-                .find(|(name, _)| name == source_branch)
-                .map(|(_, t)| t.clone())
+                .find(|(name, _, _)| name == source_branch)
+                .map(|(_, t, _)| t.clone())
                 .ok_or_else(|| MemoriaError::NotFound(format!("Branch '{source_branch}'")))?;
             let branch_table_name = validate_identifier(&table_name)?.to_string();
             let branch_table = sql.t(&branch_table_name);
@@ -1000,7 +1000,7 @@ pub async fn call(
             let sql = svc.user_sql_store(user_id).await?;
             let git = git_for_store(&sql)?;
             let branches = sql.list_branches(user_id).await?;
-            if let Some((_, table_name)) = branches.iter().find(|(name, _)| name == branch) {
+            if let Some((_, table_name, _)) = branches.iter().find(|(name, _, _)| name == branch) {
                 let was_active = sql.active_branch_name(user_id).await? == branch;
                 if was_active {
                     sql.set_active_branch(user_id, "main").await?;
@@ -1022,8 +1022,8 @@ pub async fn call(
             let branches = sql.list_branches(user_id).await?;
             let table_name = branches
                 .iter()
-                .find(|(name, _)| name == source_branch.as_str())
-                .map(|(_, t)| t.clone())
+                .find(|(name, _, _)| name == source_branch.as_str())
+                .map(|(_, t, _)| t.clone())
                 .ok_or_else(|| MemoriaError::NotFound(format!("Branch '{source_branch}'")))?;
 
             // Use MatrixOne native `data branch diff` + classify
@@ -1161,8 +1161,8 @@ pub async fn call(
             let branches = sql.list_branches(user_id).await?;
             let table_name = branches
                 .iter()
-                .find(|(name, _)| name == &source_branch)
-                .map(|(_, t)| t.clone())
+                .find(|(name, _, _)| name == &source_branch)
+                .map(|(_, t, _)| t.clone())
                 .ok_or_else(|| MemoriaError::NotFound(format!("Branch '{source_branch}'")))?;
             let branch_table_name = validate_identifier(&table_name)?.to_string();
             let user_git = git_for_store(&sql)?;

--- a/memoria/crates/memoria-mcp/src/git_tools.rs
+++ b/memoria/crates/memoria-mcp/src/git_tools.rs
@@ -1030,7 +1030,11 @@ pub async fn call(
             let raw_rows = user_git
                 .diff_branch_rows(&table_name, "mem_memories", user_id, limit * 3)
                 .await?;
-            let classified = memoria_git::classify_diff_rows(raw_rows, &table_name);
+            let mut classified = memoria_git::classify_diff_rows(raw_rows, &table_name);
+            // Resolve ghost removes (created-then-deleted on branch, never in main)
+            user_git
+                .resolve_ghost_removes(&mut classified, "mem_memories", user_id)
+                .await?;
 
             let total = classified.added.len()
                 + classified.updated.len()

--- a/memoria/crates/memoria-mcp/src/server.rs
+++ b/memoria/crates/memoria-mcp/src/server.rs
@@ -80,10 +80,30 @@ pub async fn dispatch_http(
     user_id: String,
 ) -> Result<Value, McpRpcError> {
     let handle = tokio::runtime::Handle::current();
+
+    // `spawn_blocking` runs on a separate thread-pool thread and does NOT inherit
+    // Tokio task-local variables.  In group/space mode the `actor_scope_layer`
+    // middleware sets `ACTOR_USER_ID` to the real human user_id so that per-user
+    // state (active branch) is keyed on the individual rather than the group scope.
+    // Without propagating it here, MCP tool calls inside `spawn_blocking` fall back
+    // to `scope_id` (the group id), causing a mismatch: the Dashboard REST checkout
+    // writes `mem_user_state.user_id = real_user_id` while the MCP code-agent reads
+    // `mem_user_state.user_id = grp_xxx` — two different rows, always out of sync.
+    let actor_user_id = memoria_storage::ACTOR_USER_ID
+        .try_with(|id| id.clone())
+        .ok();
+
     tokio::task::spawn_blocking(move || {
-        handle.block_on(dispatch_embedded_owned(
-            method, params, service, git, user_id,
-        ))
+        let fut = dispatch_embedded_owned(method, params, service, git, user_id);
+        // Restore ACTOR_USER_ID inside the blocking thread so storage methods
+        // (`active_branch_name`, `set_active_branch`, `active_table`) see the
+        // same per-user scope they would in the original async task.
+        match actor_user_id {
+            Some(actor_id) => handle.block_on(
+                memoria_storage::ACTOR_USER_ID.scope(actor_id, fut)
+            ),
+            None => handle.block_on(fut),
+        }
     })
     .await
     .map_err(|e| McpRpcError {

--- a/memoria/crates/memoria-mcp/src/tools.rs
+++ b/memoria/crates/memoria-mcp/src/tools.rs
@@ -516,6 +516,7 @@ pub async fn call(
                     limit,
                     args.get("memory_type").and_then(Value::as_str),
                     args.get("session_id").and_then(Value::as_str),
+                    args.get("trust_tier").and_then(Value::as_str),
                     None,
                 )
                 .await?;

--- a/memoria/crates/memoria-mcp/tests/branch_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/branch_e2e.rs
@@ -258,8 +258,8 @@ async fn test_merge_replace_updates_conflicting_memory() {
         .await
         .unwrap()
         .into_iter()
-        .find(|(name, _)| name == &branch)
-        .map(|(_, table)| table)
+        .find(|(name, _, _)| name == &branch)
+        .map(|(_, table, _)| table)
         .expect("branch table");
 
     let branch_memory_id = Uuid::new_v4().simple().to_string();
@@ -867,8 +867,8 @@ async fn test_diff_fields_complete() {
     let branches = sql.list_branches(&uid).await.unwrap();
     let table = branches
         .iter()
-        .find(|(n, _)| n == &branch)
-        .map(|(_, t)| t.clone())
+        .find(|(n, _, _)| n == &branch)
+        .map(|(_, t, _)| t.clone())
         .unwrap();
     let user_git = GitForDataService::new(
         sql.pool().clone(),
@@ -977,8 +977,8 @@ async fn test_diff_native_count_vs_join_rows() {
     let branches = sql.list_branches(&uid).await.unwrap();
     let table = branches
         .iter()
-        .find(|(n, _)| n == &branch)
-        .map(|(_, t)| t.clone())
+        .find(|(n, _, _)| n == &branch)
+        .map(|(_, t, _)| t.clone())
         .unwrap();
     let user_git = GitForDataService::new(
         sql.pool().clone(),

--- a/memoria/crates/memoria-mcp/tests/integration_full.rs
+++ b/memoria/crates/memoria-mcp/tests/integration_full.rs
@@ -373,8 +373,8 @@ async fn test_full_stack_all_fields() {
     let branches = sql_store.list_branches(&uid).await.unwrap();
     let branch_table = branches
         .iter()
-        .find(|(n, _)| n == &branch)
-        .map(|(_, t)| t.clone())
+        .find(|(n, _, _)| n == &branch)
+        .map(|(_, t, _)| t.clone())
         .unwrap();
 
     let branch_row = db_row(&pool, &branch_table, &mid_branch).await;

--- a/memoria/crates/memoria-service/src/service.rs
+++ b/memoria/crates/memoria-service/src/service.rs
@@ -2113,7 +2113,7 @@ impl MemoryService {
         user_id: &str,
         limit: i64,
     ) -> Result<Vec<Memory>, MemoriaError> {
-        self.list_active_filtered(user_id, limit, None, None, None)
+        self.list_active_filtered(user_id, limit, None, None, None, None)
             .await
     }
 
@@ -2124,9 +2124,10 @@ impl MemoryService {
         limit: i64,
         memory_type: Option<&str>,
         session_id: Option<&str>,
+        trust_tier: Option<&str>,
         cursor: Option<&str>,
     ) -> Result<Vec<Memory>, MemoriaError> {
-        self.list_active_filtered(user_id, limit, memory_type, session_id, cursor)
+        self.list_active_filtered(user_id, limit, memory_type, session_id, trust_tier, cursor)
             .await
     }
 
@@ -2136,13 +2137,14 @@ impl MemoryService {
         limit: i64,
         memory_type: Option<&str>,
         session_id: Option<&str>,
+        trust_tier: Option<&str>,
         cursor: Option<&str>,
     ) -> Result<Vec<Memory>, MemoriaError> {
         if self.sql_store.is_some() {
             let sql = self.user_sql_store(user_id).await?;
             let table = sql.active_table(user_id).await?;
             return sql
-                .list_active_lite(&table, user_id, limit, memory_type, session_id, cursor)
+                .list_active_lite(&table, user_id, limit, memory_type, session_id, trust_tier, cursor)
                 .await;
         }
         // Fallback: trait path — no SQL store means no server-side filter/cursor.
@@ -2153,6 +2155,9 @@ impl MemoryService {
         }
         if let Some(session_id) = session_id {
             mems.retain(|m| m.session_id.as_deref() == Some(session_id));
+        }
+        if let Some(tt) = trust_tier {
+            mems.retain(|m| m.trust_tier.to_string() == tt);
         }
         if let Some(cursor_id) = cursor {
             mems.retain(|m| m.memory_id.as_str() < cursor_id);

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -46,6 +46,41 @@ fn is_duplicate_column(e: &sqlx::Error) -> bool {
         .unwrap_or(false)
 }
 
+/// Returns true for MatrixOne's transient "txn need retry in rc mode, def changed"
+/// error (code 20631). This can occur when a DDL statement (e.g. ALTER TABLE on a
+/// branch table) races with a concurrent `data branch merge` that also modifies the
+/// same table definition.
+fn is_mo_retry_error(e: &sqlx::Error) -> bool {
+    let msg = e.to_string();
+    msg.contains("20631") || msg.contains("txn need retry")
+}
+
+/// Execute a raw DDL string, retrying up to 3 times on MatrixOne error 20631
+/// ("txn need retry in rc mode, def changed") with exponential backoff.
+/// Used for ALTER TABLE statements that may race with concurrent DDL in migrations.
+async fn exec_ddl_with_retry(pool: &sqlx::mysql::MySqlPool, sql: &str) -> Result<(), sqlx::Error> {
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut attempt = 0u32;
+    loop {
+        match sqlx::query(sql).execute(pool).await {
+            Ok(_) => return Ok(()),
+            Err(e) if attempt < MAX_ATTEMPTS - 1 && is_mo_retry_error(&e) => {
+                attempt += 1;
+                let backoff_ms = 50u64 * (1 << attempt); // 100 ms, 200 ms
+                tracing::warn!(
+                    attempt,
+                    backoff_ms,
+                    error = %e,
+                    sql = sql,
+                    "exec_ddl_with_retry: MatrixOne 20631 — retrying migration DDL",
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 fn normalized_count_sql(sql: &str) -> String {
     sql.trim()
         .trim_end_matches(';')
@@ -141,7 +176,7 @@ async fn is_fresh_database(pool: &MySqlPool, schema_name: &str) -> Result<bool, 
 /// Bump whenever user-DB schema expectations change, including tables created
 /// by `bootstrap_user_schema()`, graph schema bootstrapping, or any compat
 /// migration handled by `apply_user_compat_migrations()`.
-pub const CURRENT_USER_SCHEMA_VERSION: i64 = 1;
+pub const CURRENT_USER_SCHEMA_VERSION: i64 = 2;
 const USER_SCHEMA_META_KEY: &str = "user_schema";
 
 async fn ensure_user_schema_meta_table(pool: &MySqlPool, table: &str) -> Result<(), MemoriaError> {
@@ -1530,16 +1565,83 @@ impl SqlMemoryStore {
         .await;
 
         // author_id column — tracks the real human author in group mode
-        let _ = sqlx::query(&format!(
-            "ALTER TABLE {memories_table} ADD COLUMN author_id VARCHAR(64) DEFAULT NULL AFTER user_id"
+        // Guard with existence check so the migration is idempotent (safe to run
+        // on both fresh and already-migrated databases).
+        let has_author_id =
+            info_schema_column_exists(pool, schema_name, "mem_memories", "author_id").await;
+        if !has_author_id {
+            let add_col = sqlx::query(&format!(
+                "ALTER TABLE {memories_table} ADD COLUMN author_id VARCHAR(64) DEFAULT NULL"
+            ))
+            .execute(pool)
+            .await;
+            match &add_col {
+                Ok(_) => tracing::info!("migration: added author_id column to {memories_table}"),
+                Err(e) => tracing::error!("migration: failed to add author_id to {memories_table}: {e}"),
+            }
+        } else {
+            tracing::debug!("migration: author_id column already exists in {memories_table}, skipping");
+        }
+        // Ensure the index exists even when the column already existed before this migration.
+        // This covers partially-migrated databases where `author_id` is present but
+        // `idx_author` is missing.
+        let has_memories_author_idx =
+            info_schema_index_exists(pool, schema_name, "mem_memories", "idx_author").await;
+        if !has_memories_author_idx {
+            let add_idx = sqlx::query(&format!(
+                "ALTER TABLE {memories_table} ADD INDEX idx_author (author_id)"
+            ))
+            .execute(pool)
+            .await;
+            if let Err(e) = add_idx {
+                tracing::warn!(
+                    "migration: failed to add idx_author on {memories_table} (may already exist): {e}"
+                );
+            }
+        }
+
+        // Also add author_id to any existing branch tables (which are separate physical tables).
+        // Branch tables are created as copies of mem_memories and need the same schema.
+        let branch_table_names: Vec<String> = sqlx::query_scalar(&format!(
+            "SELECT table_name FROM {branches_table} WHERE status = 'active' AND table_name != ''"
         ))
-        .execute(pool)
-        .await;
-        let _ = sqlx::query(&format!(
-            "ALTER TABLE {memories_table} ADD INDEX idx_author (author_id)"
-        ))
-        .execute(pool)
-        .await;
+        .fetch_all(pool)
+        .await
+        .unwrap_or_default();
+
+        // Branch tables are physically separate copies of mem_memories; they need
+        // the same author_id column/index. ALTER TABLE here can race with a concurrent
+        // `data branch merge` (MatrixOne 20631 "def changed"), so we use a retrying
+        // helper instead of plain sqlx::query().execute().
+        for bt_raw in &branch_table_names {
+            // bt_raw is the raw table name (e.g. br_abc123_my_branch) without DB prefix
+            let bt_full = self.t(bt_raw);
+            let has_col =
+                info_schema_column_exists(pool, schema_name, bt_raw, "author_id").await;
+            if !has_col {
+                let r = exec_ddl_with_retry(
+                    pool,
+                    &format!("ALTER TABLE {bt_full} ADD COLUMN author_id VARCHAR(64) DEFAULT NULL"),
+                )
+                .await;
+                match r {
+                    Ok(_) => tracing::info!("migration: added author_id to branch table {bt_full}"),
+                    Err(e) => tracing::error!("migration: failed to add author_id to branch table {bt_full}: {e}"),
+                }
+            }
+            // Always ensure the index exists regardless of whether the column was just
+            // added or was already present (handles "column exists but index is missing"
+            // on older databases). The error is expected when the index already exists.
+            let has_idx =
+                info_schema_index_exists(pool, schema_name, bt_raw, "idx_author").await;
+            if !has_idx {
+                let _ = exec_ddl_with_retry(
+                    pool,
+                    &format!("ALTER TABLE {bt_full} ADD INDEX idx_author (author_id)"),
+                )
+                .await;
+            }
+        }
 
         Ok(())
     }
@@ -2284,7 +2386,13 @@ impl SqlMemoryStore {
 
         match branch_row {
             Some(r) => {
-                let table = self.t(&r.try_get::<String, _>("table_name").map_err(db_err)?);
+                let raw = r.try_get::<String, _>("table_name").map_err(db_err)?;
+                let table = self.t(&raw);
+                // Branch metadata found in mem_branches — trust it.
+                // information_schema.tables is NOT reliable for MatrixOne zero-copy branch
+                // tables created via `data branch create table`, so we skip the existence probe
+                // here. If the physical table is genuinely gone, the subsequent DML query will
+                // return a DB error that propagates to the caller.
                 self.active_table_cache
                     .insert(cache_key.into_owned(), table.clone());
                 Ok(table)
@@ -2386,10 +2494,14 @@ impl SqlMemoryStore {
     pub async fn list_branches(
         &self,
         user_id: &str,
-    ) -> Result<Vec<(String, String)>, MemoriaError> {
+    ) -> Result<Vec<(String, String, Option<chrono::NaiveDateTime>)>, MemoriaError> {
         let branches_table = self.t("mem_branches");
+        // ORDER BY: NULL created_at (legacy rows) sort last via IS NULL trick;
+        // tie-break by name for stable output when timestamps collide.
         let rows = sqlx::query(&format!(
-            "SELECT name, table_name FROM {branches_table} WHERE user_id = ? AND status = 'active'"
+            "SELECT name, table_name, created_at FROM {branches_table} \
+             WHERE user_id = ? AND status = 'active' \
+             ORDER BY created_at IS NULL ASC, created_at ASC, name ASC"
         ))
         .bind(user_id)
         .fetch_all(&self.pool)
@@ -2400,6 +2512,7 @@ impl SqlMemoryStore {
                 Ok((
                     r.try_get::<String, _>("name").map_err(db_err)?,
                     r.try_get::<String, _>("table_name").map_err(db_err)?,
+                    r.try_get::<Option<chrono::NaiveDateTime>, _>("created_at").ok().flatten(),
                 ))
             })
             .collect()
@@ -4595,6 +4708,7 @@ impl SqlMemoryStore {
 
     /// Lightweight list for API responses — skips embedding, source_event_ids,
     /// extra_metadata to reduce I/O and deserialization cost.
+    #[allow(clippy::too_many_arguments)]
     pub async fn list_active_lite(
         &self,
         table: &str,
@@ -4602,6 +4716,7 @@ impl SqlMemoryStore {
         limit: i64,
         memory_type: Option<&str>,
         session_id: Option<&str>,
+        trust_tier: Option<&str>,
         cursor: Option<&str>,
     ) -> Result<Vec<Memory>, MemoriaError> {
         let table = self.t(table);
@@ -4615,6 +4730,9 @@ impl SqlMemoryStore {
         }
         if session_id.is_some() {
             inner.push_str(" AND session_id = ?");
+        }
+        if trust_tier.is_some() {
+            inner.push_str(" AND trust_tier = ?");
         }
         if cursor.is_some() {
             inner.push_str(" AND memory_id < ?");
@@ -4635,6 +4753,9 @@ impl SqlMemoryStore {
         }
         if let Some(session_id) = session_id {
             q = q.bind(session_id);
+        }
+        if let Some(tt) = trust_tier {
+            q = q.bind(tt);
         }
         if let Some(c) = cursor {
             q = q.bind(c);

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -1577,7 +1577,12 @@ impl SqlMemoryStore {
             .await;
             match &add_col {
                 Ok(_) => tracing::info!("migration: added author_id column to {memories_table}"),
-                Err(e) => tracing::error!("migration: failed to add author_id to {memories_table}: {e}"),
+                Err(e) if is_duplicate_column(e) => tracing::info!(
+                    "migration: author_id column already exists in {memories_table}, skipping"
+                ),
+                Err(e) => tracing::error!(
+                    "migration: failed to add author_id to {memories_table}: {e}"
+                ),
             }
         } else {
             tracing::debug!("migration: author_id column already exists in {memories_table}, skipping");
@@ -1602,19 +1607,35 @@ impl SqlMemoryStore {
 
         // Also add author_id to any existing branch tables (which are separate physical tables).
         // Branch tables are created as copies of mem_memories and need the same schema.
-        let branch_table_names: Vec<String> = sqlx::query_scalar(&format!(
+        let branch_table_names: Vec<String> = match sqlx::query_scalar(&format!(
             "SELECT table_name FROM {branches_table} WHERE status = 'active' AND table_name != ''"
         ))
         .fetch_all(pool)
         .await
-        .unwrap_or_default();
+        {
+            Ok(names) => names,
+            Err(e) => {
+                tracing::warn!(
+                    "migration: failed to load branch table names from {branches_table}, \
+                     skipping author_id/idx_author migration for branch tables: {e}"
+                );
+                vec![]
+            }
+        };
 
         // Branch tables are physically separate copies of mem_memories; they need
         // the same author_id column/index. ALTER TABLE here can race with a concurrent
         // `data branch merge` (MatrixOne 20631 "def changed"), so we use a retrying
         // helper instead of plain sqlx::query().execute().
         for bt_raw in &branch_table_names {
-            // bt_raw is the raw table name (e.g. br_abc123_my_branch) without DB prefix
+            // bt_raw is the raw table name (e.g. br_abc123_my_branch) without DB prefix.
+            // Validate against a strict allowlist before interpolating into DDL.
+            if !bt_raw.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+                tracing::warn!(
+                    "migration: skipping branch table with invalid identifier '{bt_raw}'"
+                );
+                continue;
+            }
             let bt_full = self.t(bt_raw);
             let has_col =
                 info_schema_column_exists(pool, schema_name, bt_raw, "author_id").await;
@@ -1626,7 +1647,15 @@ impl SqlMemoryStore {
                 .await;
                 match r {
                     Ok(_) => tracing::info!("migration: added author_id to branch table {bt_full}"),
-                    Err(e) => tracing::error!("migration: failed to add author_id to branch table {bt_full}: {e}"),
+                    Err(e) => {
+                        // Propagate the error so that migrate_user() does NOT write the
+                        // schema version. The migration will be retried on the next startup
+                        // rather than being silently marked as complete.
+                        tracing::error!(
+                            "migration: failed to add author_id to branch table {bt_full}: {e}"
+                        );
+                        return Err(db_err(e));
+                    }
                 }
             }
             // Always ensure the index exists regardless of whether the column was just
@@ -2512,6 +2541,9 @@ impl SqlMemoryStore {
                 Ok((
                     r.try_get::<String, _>("name").map_err(db_err)?,
                     r.try_get::<String, _>("table_name").map_err(db_err)?,
+                    // Lenient: a corrupt/NULL timestamp yields None rather than failing the
+                    // entire branch list. name and table_name are strict because they drive
+                    // branch operations.
                     r.try_get::<Option<chrono::NaiveDateTime>, _>("created_at").ok().flatten(),
                 ))
             })

--- a/memoria/crates/memoria-storage/tests/branch_ops.rs
+++ b/memoria/crates/memoria-storage/tests/branch_ops.rs
@@ -214,7 +214,7 @@ async fn test_list_branches() {
         .expect("reg b2");
 
     let branches = store.list_branches(&user).await.expect("list");
-    let names: Vec<_> = branches.iter().map(|(n, _)| n.as_str()).collect();
+    let names: Vec<_> = branches.iter().map(|(n, _, _)| n.as_str()).collect();
     assert!(names.contains(&b1.as_str()), "b1 missing");
     assert!(names.contains(&b2.as_str()), "b2 missing");
     println!("✅ list_branches: {:?}", names);
@@ -222,7 +222,7 @@ async fn test_list_branches() {
     // Delete one — should disappear
     store.deregister_branch(&user, &b1).await.expect("dereg");
     let branches = store.list_branches(&user).await.expect("list after delete");
-    let names: Vec<_> = branches.iter().map(|(n, _)| n.as_str()).collect();
+    let names: Vec<_> = branches.iter().map(|(n, _, _)| n.as_str()).collect();
     assert!(!names.contains(&b1.as_str()), "b1 should be gone");
     assert!(names.contains(&b2.as_str()), "b2 should remain");
     println!("✅ list_branches after delete: {:?}", names);

--- a/memoria/crates/memoria-storage/tests/store_crud.rs
+++ b/memoria/crates/memoria-storage/tests/store_crud.rs
@@ -717,7 +717,7 @@ async fn test_list_active_lite() {
         .expect("soft_delete");
 
     let results = store
-        .list_active_lite("mem_memories", &uid, 10, None, None, None)
+        .list_active_lite("mem_memories", &uid, 10, None, None, None, None)
         .await
         .expect("list_active_lite");
     assert_eq!(results.len(), 2, "should exclude soft-deleted");
@@ -751,14 +751,14 @@ async fn test_list_active_lite_limit_cap() {
     }
     // Request limit=2, should only get 2
     let results = store
-        .list_active_lite("mem_memories", &uid, 2, None, None, None)
+        .list_active_lite("mem_memories", &uid, 2, None, None, None, None)
         .await
         .expect("list_active_lite");
     assert_eq!(results.len(), 2, "should respect limit");
 
     // Request absurdly large limit — capped at 500 internally
     let results = store
-        .list_active_lite("mem_memories", &uid, 999999, None, None, None)
+        .list_active_lite("mem_memories", &uid, 999999, None, None, None, None)
         .await
         .expect("list_active_lite");
     assert!(results.len() <= 501, "should cap at 501");


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [x] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes # https://github.com/matrixorigin/memoria-website/issues/98

## What this PR does / why we need it


### Scope

These edits extend Memoria’s storage/API/MCP layers for **group collaboration**, **branch metadata**, **list filtering**, **MatrixOne compatibility**, and **operational observability**. They also align tests with updated function signatures.

---

### 1. `memoria-storage` (`store.rs` + tests)

**Schema / migrations**

- **`CURRENT_USER_SCHEMA_VERSION`**: bumped from `1` → **`2`** so existing user databases run compat migrations on next startup.
- **`author_id` on `mem_memories`**: migration is **idempotent** — adds column only if missing (information_schema check); **`AFTER user_id` removed** for broader MatrixOne compatibility.
- **`idx_author`**: added only if missing (handles “column exists but index missing”).
- **Branch tables** (`mem_branches.table_name` → physical branch tables): **same `author_id` + `idx_author` migration** applied per active branch table. Rationale: upstream group mode added `author_id` to inserts; **legacy branch tables** created before that column may not have it; zero-copy branches don’t automatically pick up a later `ALTER` on `mem_memories`.

**Behavior**

- **`active_table`**: when `mem_branches` has metadata for the active branch, **trust it** and **skip** `information_schema.tables` existence checks — MatrixOne zero-copy branch tables may not appear reliably there; failures surface on actual DML instead.
- **`list_branches`**: return type extended to **`(name, table_name, created_at)`**; query adds **`ORDER BY created_at ASC`** for stable ordering.
- **`list_active_lite`**: new parameter **`trust_tier: Option<&str>`** with SQL filtering when set.

**Tests**

- `branch_ops.rs`: destructuring updated for 3-tuple `list_branches`.
- `store_crud.rs`: `list_active_lite(..., None)` extended with extra **`None`** for `trust_tier`.

---

### 2. `memoria-service` (`service.rs`)

- **`list_active_filtered`**: accepts **`trust_tier: Option<&str>`** and filters in-memory when provided (consistent with REST/MCP).

---

### 3. `memoria-api`

**`routes/memory.rs`**

- **`ListQuery`**: optional **`trust_tier`** query param wired through to **`list_active_filtered`**.

**`routes/snapshots.rs`**

- **`list_branches` JSON**: includes **`created_at`** where available (tuple destructuring updated for new storage return type).

**`routes/admin.rs`**

- **`user_stats`**: counting memories for **group scopes** (`grp_*`) adjusted so counts are not incorrectly filtered by personal `user_id` only.
- **New handler `user_branch_stats`**: **`GET /admin/users/:user_id/branch-stats`** — returns per-branch memory counts (uses main count + iterates branches via `list_branches`), with defensive error handling per branch.

**`lib.rs`**

- Registers the new admin route above.

---

### 4. `memoria-mcp`

**`server.rs`**

- **`ACTOR_USER_ID`** (task-local): captured before **`spawn_blocking`** and re-entered inside the blocking closure so **active branch context matches** between async REST/MCP paths and blocking Git/storage work (fixes Dashboard vs MCP branch mismatch when using the same API key).

**`tools.rs`**

- **`memory_list` / list path**: passes **`trust_tier`** from tool args into **`list_active_filtered`**.

**`git_tools.rs`**

- All **`list_branches`** call sites updated for **3-tuple** return (third element ignored where unused).

---

### 5. `memoria-git` (`service.rs` + `Cargo.toml`)

**MatrixOne DDL reliability**

- **`exec_ddl`**: retries up to **3 attempts** with backoff when the DB returns **20631** / **`txn need retry`** (“def changed” under RC mode). Typical trigger: concurrent **`data branch merge`** vs **`ALTER TABLE`** on branch tables during migration (transient; retry is the intended client-side mitigation).

**Diff / compatibility**

- **`data branch diff`**: **`columns (...)` clause removed** from SQL — filtered in Rust instead — for **MatrixOne version differences** (local vs cloud).
- **`FIXME(memoria-team)`** comment documenting **duplicate `memory_id` rows** in diff results / UI linkage — left for upstream; not “fixed” here.

**Dependencies**

- **`tokio`** moved from **dev-dependencies only** to **normal dependency** (needed for **`tokio::time::sleep`** in `exec_ddl` retry loop).

---

### 6. Integration tests (`memoria-mcp`)

- **`branch_e2e.rs`**, **`integration_full.rs`**: tuple destructuring updated for **`list_branches`** 3-tuple.

---

### Risks / review focus

1. **Migration + DDL concurrency**: `author_id` ALTERs on branch tables can overlap with **`data branch merge`** — mitigated by **`exec_ddl` retry**; reviewers may want to confirm whether long-term **serialization** or **migration ordering** is preferable.
2. **`CURRENT_USER_SCHEMA_VERSION = 2`**: ensures one migration pass; coordinate with upstream versioning if they already use `2` differently.
3. **Admin `user_branch_stats`**: new surface area — auth / master-key expectations should match existing admin routes.
4. **Known open issue**: **`FIXME`** in `memoria-git` for duplicate diff rows — document for Memoria team.

---

### How to verify locally

- **`cargo check`** / **`cargo test`** with a running MatrixOne and **`DATABASE_URL`** pointing at the correct port (e.g. **`6001`** if that’s where MO listens). Note: **`group_collab_api`** defaults to port **`6666`** if **`DATABASE_URL`** is unset — set env explicitly if tests fail with DB timeouts.

---

### Files changed (from your status)

| Area | Files |
|------|--------|
| API | `memoria-api/src/lib.rs`, `routes/admin.rs`, `routes/memory.rs`, `routes/snapshots.rs` |
| Git / DDL | `memoria-git/Cargo.toml`, `memoria-git/src/service.rs` |
| MCP | `memoria-mcp/src/git_tools.rs`, `server.rs`, `tools.rs`, tests `branch_e2e.rs`, `integration_full.rs` |
| Service | `memoria-service/src/service.rs` |
| Storage | `memoria-storage/src/store.rs`, tests `branch_ops.rs`, `store_crud.rs` |

---

You can paste this block into a PR description or share it as an internal review brief. If you want a shorter “changelog” paragraph only, say so and I’ll trim it.