### PR TITLE
perf(snapshot): optimize snapshot listing

### DIFF
--- a/memoria/crates/memoria-api/src/routes/snapshots.rs
+++ b/memoria/crates/memoria-api/src/routes/snapshots.rs
@@ -374,15 +374,51 @@ async fn snapshot_summary_value(
     snapshot: &memoria_mcp::git_tools::VisibleSnapshot,
 ) -> Result<Value, (StatusCode, String)> {
     let snapshot_name = validate_snapshot_identifier(&snapshot.internal_name)?.to_string();
-    let table = sql.t("mem_memories");
-    let count_sql = format!(
-        "SELECT COUNT(*) as cnt FROM {table} {{SNAPSHOT = '{snapshot_name}'}} WHERE user_id = ? AND is_active > 0"
-    );
-    let memory_count: i64 = sqlx::query_scalar(&count_sql)
-        .bind(user_id)
-        .fetch_one(sql.pool())
-        .await
-        .map_err(api_err)?;
+    let memory_count = if let Some(memory_count) = snapshot.memory_count {
+        memory_count
+    } else {
+        // Read-through backfill for registrations created before mem_snapshots.extra.
+        // The response still returns a concrete count, and registered snapshots are
+        // persisted so later list calls avoid historical COUNT queries.
+        let started = std::time::Instant::now();
+        let memory_count =
+            memoria_mcp::git_tools::count_active_memories_at_snapshot(sql, user_id, &snapshot_name)
+                .await
+                .map_err(api_err_typed)?;
+        if snapshot.registered {
+            sql.update_snapshot_memory_count(
+                user_id,
+                &snapshot.display_name,
+                &snapshot_name,
+                memory_count,
+            )
+            .await
+            .map_err(api_err_typed)?;
+        }
+        let elapsed_ms = started.elapsed().as_millis();
+        if elapsed_ms >= 100 {
+            tracing::info!(
+                user_id = %user_id,
+                snapshot_display = %snapshot.display_name,
+                snapshot_internal = %snapshot_name,
+                memory_count,
+                persisted = snapshot.registered,
+                elapsed_ms,
+                "snapshot_list_phase: snapshot_memory_count"
+            );
+        } else {
+            tracing::debug!(
+                user_id = %user_id,
+                snapshot_display = %snapshot.display_name,
+                snapshot_internal = %snapshot_name,
+                memory_count,
+                persisted = snapshot.registered,
+                elapsed_ms,
+                "snapshot_list_phase: snapshot_memory_count"
+            );
+        }
+        memory_count
+    };
     let timestamp = format_snapshot_timestamp(snapshot.timestamp);
     Ok(json!({
         "name": snapshot.display_name,
@@ -401,11 +437,17 @@ async fn snapshot_list_payload(
     limit: i64,
     offset: i64,
 ) -> Result<Value, (StatusCode, String)> {
+    let started = std::time::Instant::now();
+    let store_started = std::time::Instant::now();
     let sql = user_snapshot_store(state, user_id).await?;
+    let store_elapsed_ms = store_started.elapsed().as_millis();
+    let visible_started = std::time::Instant::now();
     let all = memoria_mcp::git_tools::visible_snapshots_for_user(&state.service, user_id)
         .await
         .map_err(api_err_typed)?;
+    let visible_elapsed_ms = visible_started.elapsed().as_millis();
     let total = all.len();
+    let summaries_started = std::time::Instant::now();
     let mut snapshots = Vec::new();
     for snapshot in all
         .iter()
@@ -414,8 +456,37 @@ async fn snapshot_list_payload(
     {
         snapshots.push(snapshot_summary_value(&sql, user_id, snapshot).await?);
     }
+    let summaries_elapsed_ms = summaries_started.elapsed().as_millis();
     let has_more = offset.max(0) as usize + snapshots.len() < total;
     let result = format_snapshot_list_result(&snapshots, total);
+    let total_elapsed_ms = started.elapsed().as_millis();
+    if total_elapsed_ms >= 100 {
+        tracing::info!(
+            user_id = %user_id,
+            total_snapshots = total,
+            returned_snapshots = snapshots.len(),
+            limit = limit.max(0),
+            offset = offset.max(0),
+            store_elapsed_ms,
+            visible_elapsed_ms,
+            summaries_elapsed_ms,
+            total_elapsed_ms,
+            "snapshot_list_phase: list_payload"
+        );
+    } else {
+        tracing::debug!(
+            user_id = %user_id,
+            total_snapshots = total,
+            returned_snapshots = snapshots.len(),
+            limit = limit.max(0),
+            offset = offset.max(0),
+            store_elapsed_ms,
+            visible_elapsed_ms,
+            summaries_elapsed_ms,
+            total_elapsed_ms,
+            "snapshot_list_phase: list_payload"
+        );
+    }
     Ok(json!({
         "snapshots": snapshots,
         "total": total,

--- a/memoria/crates/memoria-git/src/service.rs
+++ b/memoria/crates/memoria-git/src/service.rs
@@ -544,37 +544,59 @@ impl GitForDataService {
     }
 
     pub async fn list_snapshots(&self) -> Result<Vec<Snapshot>, MemoriaError> {
-        let rows = sqlx::query("SHOW SNAPSHOTS")
+        let started = std::time::Instant::now();
+        let show_sql = format!(
+            "SHOW SNAPSHOTS WHERE DATABASE_NAME = '{}'",
+            quote_sql_literal(&self.db_name)
+        );
+        let rows = sqlx::query(&show_sql)
             .fetch_all(&self.pool)
             .await
             .map_err(db_err)?;
-        rows.iter()
+        let show_elapsed_ms = started.elapsed().as_millis();
+        let snapshots: Vec<Snapshot> = rows
+            .iter()
             .map(|r| {
-                // Try NaiveDateTime directly first, then fall back to string parsing
-                let timestamp = r.try_get::<NaiveDateTime, _>("TIMESTAMP").ok().or_else(|| {
-                    r.try_get::<String, _>("TIMESTAMP").ok().and_then(|s| {
+                // `SHOW SNAPSHOTS WHERE ...` is rewritten through a SELECT wrapper in
+                // MatrixOne and returns lower-case output column names.
+                let timestamp = r.try_get::<NaiveDateTime, _>("timestamp").ok().or_else(|| {
+                    r.try_get::<String, _>("timestamp").ok().and_then(|s| {
                         NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S%.f")
                             .ok()
                             .or_else(|| NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S").ok())
                     })
                 });
                 Ok(Snapshot {
-                    snapshot_name: r.try_get("SNAPSHOT_NAME").map_err(db_err)?,
+                    snapshot_name: r.try_get("snapshot_name").map_err(db_err)?,
                     timestamp,
-                    snapshot_level: r.try_get("SNAPSHOT_LEVEL").map_err(db_err)?,
-                    account_name: r.try_get("ACCOUNT_NAME").map_err(db_err)?,
-                    database_name: r.try_get("DATABASE_NAME").ok(),
-                    table_name: r.try_get("TABLE_NAME").ok(),
+                    snapshot_level: r.try_get("snapshot_level").map_err(db_err)?,
+                    account_name: r.try_get("account_name").map_err(db_err)?,
+                    database_name: r.try_get("database_name").ok(),
+                    table_name: r.try_get("table_name").ok(),
                 })
             })
-            .filter(|result| {
-                result
-                    .as_ref()
-                    .ok()
-                    .and_then(|snapshot| snapshot.database_name.as_ref())
-                    .is_some_and(|db_name| db_name == &self.db_name)
-            })
-            .collect()
+            .collect::<Result<Vec<Snapshot>, MemoriaError>>()?;
+        let total_elapsed_ms = started.elapsed().as_millis();
+        if total_elapsed_ms >= 100 {
+            tracing::info!(
+                db_name = %self.db_name,
+                show_rows = rows.len(),
+                filtered_rows = snapshots.len(),
+                show_elapsed_ms,
+                total_elapsed_ms,
+                "snapshot_list_phase: show_snapshots"
+            );
+        } else {
+            tracing::debug!(
+                db_name = %self.db_name,
+                show_rows = rows.len(),
+                filtered_rows = snapshots.len(),
+                show_elapsed_ms,
+                total_elapsed_ms,
+                "snapshot_list_phase: show_snapshots"
+            );
+        }
+        Ok(snapshots)
     }
 
     pub async fn get_snapshot(&self, name: &str) -> Result<Option<Snapshot>, MemoriaError> {

--- a/memoria/crates/memoria-mcp/src/git_tools.rs
+++ b/memoria/crates/memoria-mcp/src/git_tools.rs
@@ -191,6 +191,7 @@ fn safety_display_name(internal: &str) -> Option<String> {
 pub struct VisibleSnapshot {
     pub display_name: String,
     pub internal_name: String,
+    pub memory_count: Option<i64>,
     pub timestamp: Option<NaiveDateTime>,
     pub registered: bool,
 }
@@ -355,14 +356,34 @@ fn git_for_store(
     ))
 }
 
+pub async fn count_active_memories_at_snapshot(
+    sql: &Arc<memoria_storage::SqlMemoryStore>,
+    user_id: &str,
+    snapshot_name: &str,
+) -> Result<i64, MemoriaError> {
+    let snapshot_name = validate_identifier(snapshot_name)?;
+    let table = sql.t("mem_memories");
+    let count_sql = format!(
+        "SELECT COUNT(*) as cnt FROM {table} {{SNAPSHOT = '{snapshot_name}'}} WHERE user_id = ? AND is_active > 0"
+    );
+    sqlx::query_scalar(&count_sql)
+        .bind(user_id)
+        .fetch_one(sql.pool())
+        .await
+        .map_err(db_err)
+}
+
 pub async fn visible_snapshots_for_user(
     svc: &Arc<MemoryService>,
     user_id: &str,
 ) -> Result<Vec<VisibleSnapshot>, MemoriaError> {
+    let started = std::time::Instant::now();
     let sql = snapshot_store(svc, user_id).await?;
     let db_name = sql.database_name();
     let git = git_for_store(&sql)?;
+    let list_started = std::time::Instant::now();
     let all = git.list_snapshots().await.map_err(git_err)?;
+    let list_elapsed_ms = list_started.elapsed().as_millis();
     let actual_by_name: HashMap<String, memoria_git::Snapshot> = all
         .into_iter()
         .filter(|s| {
@@ -374,12 +395,16 @@ pub async fn visible_snapshots_for_user(
 
     let mut snapshots = Vec::new();
     let mut seen_internal = HashSet::new();
-    for reg in sql.list_snapshot_registrations(user_id).await? {
+    let registrations_started = std::time::Instant::now();
+    let registrations = sql.list_snapshot_registrations(user_id).await?;
+    let registrations_elapsed_ms = registrations_started.elapsed().as_millis();
+    for reg in registrations {
         if let Some(actual) = actual_by_name.get(&reg.snapshot_name) {
             seen_internal.insert(reg.snapshot_name.clone());
             snapshots.push(VisibleSnapshot {
                 display_name: reg.name,
                 internal_name: reg.snapshot_name,
+                memory_count: memoria_storage::snapshot_extra_memory_count(reg.extra.as_ref()),
                 timestamp: actual.timestamp.or(Some(reg.created_at)),
                 registered: true,
             });
@@ -399,6 +424,7 @@ pub async fn visible_snapshots_for_user(
                     snap_display(&actual.snapshot_name)
                 },
                 internal_name: actual.snapshot_name.clone(),
+                memory_count: None,
                 timestamp: actual.timestamp,
                 registered: false,
             });
@@ -406,6 +432,30 @@ pub async fn visible_snapshots_for_user(
     }
 
     snapshots.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    let total_elapsed_ms = started.elapsed().as_millis();
+    if total_elapsed_ms >= 100 {
+        tracing::info!(
+            user_id = %user_id,
+            db_name = ?db_name,
+            actual_snapshot_count = actual_by_name.len(),
+            visible_snapshot_count = snapshots.len(),
+            show_snapshots_elapsed_ms = list_elapsed_ms,
+            registrations_elapsed_ms,
+            total_elapsed_ms,
+            "snapshot_list_phase: visible_snapshots_for_user"
+        );
+    } else {
+        tracing::debug!(
+            user_id = %user_id,
+            db_name = ?db_name,
+            actual_snapshot_count = actual_by_name.len(),
+            visible_snapshot_count = snapshots.len(),
+            show_snapshots_elapsed_ms = list_elapsed_ms,
+            registrations_elapsed_ms,
+            total_elapsed_ms,
+            "snapshot_list_phase: visible_snapshots_for_user"
+        );
+    }
     Ok(snapshots)
 }
 
@@ -816,7 +866,10 @@ pub async fn call(
                         return Err(git_err(err));
                     }
                 };
-                sql.register_snapshot(user_id, &display, &snap.snapshot_name)
+                let memory_count =
+                    count_active_memories_at_snapshot(&sql, user_id, &snap.snapshot_name).await?;
+                let extra = memoria_storage::snapshot_extra_with_memory_count(memory_count);
+                sql.register_snapshot(user_id, &display, &snap.snapshot_name, Some(&extra))
                     .await?;
                 Ok(mcp_text(&format!(
                     "Snapshot '{}' created at {:?}",

--- a/memoria/crates/memoria-storage/src/lib.rs
+++ b/memoria/crates/memoria-storage/src/lib.rs
@@ -22,6 +22,7 @@ pub use pool_config::{
 };
 pub use router::{DbRouter, UserDatabaseRecord};
 pub use store::{
-    FeedbackStats, MemoryFeedback, OwnedEditLogEntry, PoolHealthLevel, PoolHealthSnapshot,
-    SqlMemoryStore, TierFeedback, UserRetrievalParams, ACTOR_USER_ID,
+    snapshot_extra_memory_count, snapshot_extra_with_memory_count, FeedbackStats, MemoryFeedback,
+    OwnedEditLogEntry, PoolHealthLevel, PoolHealthSnapshot, SqlMemoryStore, TierFeedback,
+    UserRetrievalParams, ACTOR_USER_ID,
 };

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -173,6 +173,19 @@ async fn is_fresh_database(pool: &MySqlPool, schema_name: &str) -> Result<bool, 
     .map_err(db_err)
 }
 
+async fn info_schema_table_exists(pool: &MySqlPool, schema_name: &str, table_name: &str) -> bool {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM information_schema.tables \
+         WHERE table_schema = ? AND table_name = ?",
+    )
+    .bind(schema_name)
+    .bind(table_name)
+    .fetch_one(pool)
+    .await
+    .unwrap_or(0)
+        > 0
+}
+
 /// Bump whenever user-DB schema expectations change, including tables created
 /// by `bootstrap_user_schema()`, graph schema bootstrapping, or any compat
 /// migration handled by `apply_user_compat_migrations()`.
@@ -720,7 +733,24 @@ pub struct SqlMemoryStore {
 pub struct SnapshotRegistration {
     pub name: String,
     pub snapshot_name: String,
+    /// Extensible per-snapshot metadata. Keep derived fields here so future
+    /// snapshot attributes do not require another per-user schema migration.
+    pub extra: Option<serde_json::Value>,
     pub created_at: chrono::NaiveDateTime,
+}
+
+pub fn snapshot_extra_with_memory_count(memory_count: i64) -> serde_json::Value {
+    serde_json::json!({ "memory_count": memory_count })
+}
+
+pub fn snapshot_extra_memory_count(extra: Option<&serde_json::Value>) -> Option<i64> {
+    extra?.as_object()?.get("memory_count")?.as_i64()
+}
+
+fn snapshot_extra_from_row(
+    row: &sqlx::mysql::MySqlRow,
+) -> Result<Option<serde_json::Value>, MemoriaError> {
+    row.try_get("extra").map_err(db_err)
 }
 
 /// Aggregated feedback statistics for a user.
@@ -1182,6 +1212,7 @@ impl SqlMemoryStore {
                 user_id        VARCHAR(64)  NOT NULL,
                 name           VARCHAR(100) NOT NULL,
                 snapshot_name  VARCHAR(100) NOT NULL,
+                extra          JSON         DEFAULT NULL,
                 status         VARCHAR(20)  NOT NULL DEFAULT 'active',
                 created_at     DATETIME(6)  NOT NULL,
                 INDEX idx_user_snapshot_name (user_id, name, status),
@@ -1675,6 +1706,47 @@ impl SqlMemoryStore {
         Ok(())
     }
 
+    async fn ensure_snapshot_extra_column(
+        &self,
+        pool: &MySqlPool,
+        schema_name: &str,
+    ) -> Result<(), MemoriaError> {
+        // Targeted migration: old user DBs can stay at the same schema version,
+        // and missing derived values are populated lazily when snapshots are read.
+        if !info_schema_table_exists(pool, schema_name, "mem_snapshots").await
+            || info_schema_column_exists(pool, schema_name, "mem_snapshots", "extra").await
+        {
+            return Ok(());
+        }
+
+        let snapshots_table = self.t("mem_snapshots");
+        let started = std::time::Instant::now();
+        let result = sqlx::query(&format!(
+            "ALTER TABLE {snapshots_table} ADD COLUMN extra JSON DEFAULT NULL AFTER snapshot_name"
+        ))
+        .execute(pool)
+        .await;
+        match result {
+            Ok(_) => {
+                tracing::info!(
+                    schema_name,
+                    elapsed_ms = started.elapsed().as_millis(),
+                    "migration: added mem_snapshots.extra"
+                );
+                Ok(())
+            }
+            Err(e) if is_duplicate_column(&e) => Ok(()),
+            Err(e) => {
+                tracing::error!(
+                    schema_name,
+                    error = %e,
+                    "migration: failed to add mem_snapshots.extra"
+                );
+                Err(db_err(e))
+            }
+        }
+    }
+
     pub async fn migrate_user(&self) -> Result<(), MemoriaError> {
         let pool = &self.pool;
         let meta_table = self.t("mem_schema_meta");
@@ -1687,6 +1759,7 @@ impl SqlMemoryStore {
         }
 
         ensure_user_schema_meta_table(pool, &meta_table).await?;
+        self.ensure_snapshot_extra_column(pool, schema_name).await?;
         if load_user_schema_version(pool, &meta_table).await? == Some(CURRENT_USER_SCHEMA_VERSION) {
             return Ok(());
         }
@@ -2555,18 +2628,21 @@ impl SqlMemoryStore {
         user_id: &str,
         name: &str,
         snapshot_name: &str,
+        extra: Option<&serde_json::Value>,
     ) -> Result<(), MemoriaError> {
         let snapshots_table = self.t("mem_snapshots");
         let now = Utc::now().naive_utc();
         let id = uuid::Uuid::new_v4().simple().to_string();
+        let extra = extra.map(serde_json::to_string).transpose()?;
         sqlx::query(&format!(
-            r#"INSERT INTO {snapshots_table} (id, user_id, name, snapshot_name, status, created_at)
-               VALUES (?, ?, ?, ?, 'active', ?)"#
+            r#"INSERT INTO {snapshots_table} (id, user_id, name, snapshot_name, extra, status, created_at)
+               VALUES (?, ?, ?, ?, ?, 'active', ?)"#
         ))
         .bind(id)
         .bind(user_id)
         .bind(name)
         .bind(snapshot_name)
+        .bind(extra)
         .bind(now)
         .execute(&self.pool)
         .await
@@ -2581,7 +2657,7 @@ impl SqlMemoryStore {
     ) -> Result<Option<SnapshotRegistration>, MemoriaError> {
         let snapshots_table = self.t("mem_snapshots");
         let row = sqlx::query(&format!(
-            "SELECT name, snapshot_name, created_at \
+            "SELECT name, snapshot_name, extra, created_at \
              FROM {snapshots_table} \
              WHERE user_id = ? AND name = ? AND status = 'active' \
              ORDER BY created_at DESC LIMIT 1"
@@ -2596,6 +2672,7 @@ impl SqlMemoryStore {
             Ok(SnapshotRegistration {
                 name: r.try_get("name").map_err(db_err)?,
                 snapshot_name: r.try_get("snapshot_name").map_err(db_err)?,
+                extra: snapshot_extra_from_row(&r)?,
                 created_at: r.try_get("created_at").map_err(db_err)?,
             })
         })
@@ -2609,7 +2686,7 @@ impl SqlMemoryStore {
     ) -> Result<Option<SnapshotRegistration>, MemoriaError> {
         let snapshots_table = self.t("mem_snapshots");
         let row = sqlx::query(&format!(
-            "SELECT name, snapshot_name, created_at \
+            "SELECT name, snapshot_name, extra, created_at \
              FROM {snapshots_table} \
              WHERE user_id = ? AND snapshot_name = ? AND status = 'active' \
              ORDER BY created_at DESC LIMIT 1"
@@ -2624,6 +2701,7 @@ impl SqlMemoryStore {
             Ok(SnapshotRegistration {
                 name: r.try_get("name").map_err(db_err)?,
                 snapshot_name: r.try_get("snapshot_name").map_err(db_err)?,
+                extra: snapshot_extra_from_row(&r)?,
                 created_at: r.try_get("created_at").map_err(db_err)?,
             })
         })
@@ -2636,7 +2714,7 @@ impl SqlMemoryStore {
     ) -> Result<Vec<SnapshotRegistration>, MemoriaError> {
         let snapshots_table = self.t("mem_snapshots");
         let rows = sqlx::query(&format!(
-            "SELECT name, snapshot_name, created_at \
+            "SELECT name, snapshot_name, extra, created_at \
              FROM {snapshots_table} \
              WHERE user_id = ? AND status = 'active' \
              ORDER BY created_at DESC"
@@ -2651,10 +2729,67 @@ impl SqlMemoryStore {
                 Ok(SnapshotRegistration {
                     name: r.try_get("name").map_err(db_err)?,
                     snapshot_name: r.try_get("snapshot_name").map_err(db_err)?,
+                    extra: snapshot_extra_from_row(r)?,
                     created_at: r.try_get("created_at").map_err(db_err)?,
                 })
             })
             .collect()
+    }
+
+    pub async fn update_snapshot_memory_count(
+        &self,
+        user_id: &str,
+        name: &str,
+        snapshot_name: &str,
+        memory_count: i64,
+    ) -> Result<(), MemoriaError> {
+        let snapshots_table = self.t("mem_snapshots");
+        let row = sqlx::query(&format!(
+            "SELECT extra FROM {snapshots_table} \
+             WHERE user_id = ? AND name = ? AND snapshot_name = ? AND status = 'active' \
+             ORDER BY created_at DESC LIMIT 1"
+        ))
+        .bind(user_id)
+        .bind(name)
+        .bind(snapshot_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(db_err)?;
+
+        let Some(row) = row else {
+            return Err(MemoriaError::Internal(format!(
+                "active snapshot registration not found for user={user_id:?}, name={name:?}, snapshot={snapshot_name:?}"
+            )));
+        };
+
+        let mut extra = snapshot_extra_from_row(&row)?
+            .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
+        let Some(obj) = extra.as_object_mut() else {
+            return Err(MemoriaError::Internal(format!(
+                "snapshot extra must be a JSON object for user={user_id:?}, name={name:?}, snapshot={snapshot_name:?}"
+            )));
+        };
+        obj.insert("memory_count".to_string(), serde_json::json!(memory_count));
+        let extra = serde_json::to_string(&extra)?;
+
+        let result = sqlx::query(&format!(
+            "UPDATE {snapshots_table} SET extra = ? \
+             WHERE user_id = ? AND name = ? AND snapshot_name = ? AND status = 'active'"
+        ))
+        .bind(extra)
+        .bind(user_id)
+        .bind(name)
+        .bind(snapshot_name)
+        .execute(&self.pool)
+        .await
+        .map_err(db_err)?;
+
+        if result.rows_affected() == 0 {
+            return Err(MemoriaError::Internal(format!(
+                "failed to update snapshot memory_count for user={user_id:?}, name={name:?}, snapshot={snapshot_name:?}"
+            )));
+        }
+        Ok(())
     }
 
     pub async fn deregister_snapshot(&self, user_id: &str, name: &str) -> Result<(), MemoriaError> {


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [x] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes matrixorigin/memoria-website#132

## What this PR does / why we need it

**Root cause**

`/v1/snapshots` called `SHOW SNAPSHOTS` without a predicate. On a cluster with many users, MatrixOne returned every visible snapshot first, and Memoria filtered the current user's database in Rust. With 10K snapshots this made snapshot listing spend seconds in `SHOW SNAPSHOTS` even when the current user only had 50 snapshots.

**Changes**

- Filter MatrixOne snapshot listing at the source with `SHOW SNAPSHOTS WHERE DATABASE_NAME = '<user db>'`.
- Decode the lower-case output column names returned by MatrixOne's `SHOW ... WHERE` rewrite.
- Store derived snapshot metadata in `mem_snapshots.extra` JSON instead of adding a narrow `memory_count` column.
- Persist `extra.memory_count` when creating snapshots.
- Lazily backfill `extra.memory_count` for old snapshot registrations on read, while still returning a concrete `memory_count` in `/v1/snapshots`.
- Keep focused snapshot-listing timing logs so regressions are easy to identify.

**Compatibility**

- No user schema version bump.
- Existing user DBs get a targeted `mem_snapshots.extra JSON` column migration when accessed.
- Old registrations with missing `extra.memory_count` are read-through backfilled for returned snapshots only.
- New users get the `extra` column in the initial `mem_snapshots` schema.

**Validation**

- `SQLX_OFFLINE=true cargo check -p memoria-storage -p memoria-git -p memoria-mcp -p memoria-api`
- Remote MatrixOne real-snapshot stress reuse: 200 users, 100K memories, 10K physical snapshots, 400/400 `/v1/snapshots` requests succeeded.
- `SHOW SNAPSHOTS` rows per request dropped from 10004 to 50.
- `SHOW SNAPSHOTS` latency improved from p50 1.67s / p95 4.35s / max 9.93s to p50 185ms / p95 376ms / max 421ms.
- API/MCP walkthrough on a complete-schema test user: 56 checks, 0 failures.
