### PR TITLE
fix(snapshot): read SHOW SNAPSHOTS columns case-insensitively for MatrixOne v4.x

### DIFF
--- a/memoria/crates/memoria-git/src/service.rs
+++ b/memoria/crates/memoria-git/src/service.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 use memoria_core::MemoriaError;
 use serde::{Deserialize, Serialize};
-use sqlx::{mysql::MySqlPool, Row};
+use sqlx::{mysql::MySqlPool, Column, Row};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -9,6 +9,18 @@ use std::sync::{
 
 fn db_err(e: sqlx::Error) -> MemoriaError {
     MemoriaError::Database(e.to_string())
+}
+
+/// Look up a column index by name, case-insensitively.
+///
+/// `SHOW SNAPSHOTS WHERE ...` output column names differ in case across MatrixOne
+/// versions: v3.0.17 returns lower-case (`snapshot_name`), while v4.x returns
+/// upper-case (`SNAPSHOT_NAME`). sqlx's `try_get(name)` is case-sensitive, so a
+/// hard-coded name breaks on one of them. Resolve the index ourselves instead.
+fn ci_column_index(row: &sqlx::mysql::MySqlRow, name: &str) -> Option<usize> {
+    row.columns()
+        .iter()
+        .position(|c| c.name().eq_ignore_ascii_case(name))
 }
 
 /// Returns true when the error is MatrixOne's "txn need retry in rc mode, def changed"
@@ -557,22 +569,35 @@ impl GitForDataService {
         let snapshots: Vec<Snapshot> = rows
             .iter()
             .map(|r| {
-                // `SHOW SNAPSHOTS WHERE ...` is rewritten through a SELECT wrapper in
-                // MatrixOne and returns lower-case output column names.
-                let timestamp = r.try_get::<NaiveDateTime, _>("timestamp").ok().or_else(|| {
-                    r.try_get::<String, _>("timestamp").ok().and_then(|s| {
-                        NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S%.f")
-                            .ok()
-                            .or_else(|| NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S").ok())
+                // `SHOW SNAPSHOTS WHERE ...` output column-name case differs by
+                // MatrixOne version: v3.0.17 lower-cases them (`snapshot_name`),
+                // v4.x preserves upper-case (`SNAPSHOT_NAME`). Resolve indexes
+                // case-insensitively so both are handled.
+                let idx = |name: &str| ci_column_index(r, name);
+                let get_str = |name: &str| -> Result<String, MemoriaError> {
+                    match idx(name) {
+                        Some(i) => r.try_get::<String, _>(i).map_err(db_err),
+                        None => Err(db_err(sqlx::Error::ColumnNotFound(name.to_string()))),
+                    }
+                };
+                let timestamp = idx("timestamp").and_then(|i| {
+                    r.try_get::<NaiveDateTime, _>(i).ok().or_else(|| {
+                        r.try_get::<String, _>(i).ok().and_then(|s| {
+                            NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S%.f")
+                                .ok()
+                                .or_else(|| {
+                                    NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S").ok()
+                                })
+                        })
                     })
                 });
                 Ok(Snapshot {
-                    snapshot_name: r.try_get("snapshot_name").map_err(db_err)?,
+                    snapshot_name: get_str("snapshot_name")?,
                     timestamp,
-                    snapshot_level: r.try_get("snapshot_level").map_err(db_err)?,
-                    account_name: r.try_get("account_name").map_err(db_err)?,
-                    database_name: r.try_get("database_name").ok(),
-                    table_name: r.try_get("table_name").ok(),
+                    snapshot_level: get_str("snapshot_level")?,
+                    account_name: get_str("account_name")?,
+                    database_name: idx("database_name").and_then(|i| r.try_get(i).ok()),
+                    table_name: idx("table_name").and_then(|i| r.try_get(i).ok()),
                 })
             })
             .collect::<Result<Vec<Snapshot>, MemoriaError>>()?;


### PR DESCRIPTION
## What type of PR is this?

- [x] fix (bug fix)

## Which issue(s) this PR fixes

Fixes #225

## What this PR does / why we need it

### 根因

`DB Tests` 在 `matrixorigin/matrixone:latest`（v4.1.x）上有 9 个快照相关测试失败，报错 `no column found for name: snapshot_name`。

根因是 MatrixOne v4.x 改变了 `SHOW SNAPSHOTS WHERE DATABASE_NAME = '...'` 返回结果列名的大小写：

| 查询 | v3.0.17（通过） | v4.1.2 = latest（失败） |
|---|---|---|
| `SHOW SNAPSHOTS WHERE DATABASE_NAME = '…'` | `snapshot_name`（小写） | `SNAPSHOT_NAME`（大写） |

`memoria-git` 的 `list_snapshots()` 使用大小写敏感的 `r.try_get("snapshot_name")` 读取，v4.x 返回大写列名后就找不到该列，抛出 `no column found for name: snapshot_name`，在快照 API 上表现为 500 / 404。

这不是 `mem_snapshots` 用户表丢列（该表 DDL 在两个版本上都正常），本质是代码对未文档化、且版本间不稳定的列名大小写的硬编码假设。

### 修复

将 `list_snapshots()` 中对 `SHOW SNAPSHOTS` 结果的列名读取改为**大小写不敏感**（`eq_ignore_ascii_case` 解析列索引后按索引取值），同时兼容 v3.x 与 v4.x。另外两处使用不带 `WHERE` 的 `SHOW SNAPSHOTS` 的调用点本就按大写读取、两版本一致，无需改动。

### 验证

分别对 v4.1.2（latest）和 v3.0.17 各跑一遍：

- 原本失败的 9 个测试：全部通过
- snapshot 相关全量筛选（10 个）：全部通过
- `cargo clippy -p memoria-git`：无警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)
