### PR TITLE
ci: increase MatrixOne memory limit

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -24,7 +24,7 @@ jobs:
         image: matrixorigin/matrixone:latest
         ports:
           - 6001:6001
-        options: --memory=2g
+        options: --memory=4g
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         image: matrixorigin/matrixone:latest
         ports:
           - 6001:6001
-        options: --memory=2g
+        options: --memory=4g
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85.0


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [x] build / ci (build or CI changes)

## Which issue(s) this PR fixes

N/A

## What this PR does / why we need it

Increase the MatrixOne service container memory limit from 2 GiB to 4 GiB in both database-test workflows.

The failed DB Tests job repeatedly reported available-mem=0 and OOM alerts while MatrixOne RSS reached the 2 GiB cgroup limit. The first graph test then lost its database connection with an unexpected EOF, and all subsequent graph tests timed out waiting for MatrixOne.

Failing job: https://github.com/matrixorigin/Memoria/actions/runs/31790266225/job/94735735526

The public Ubuntu runner has 16 GB RAM, so a 4 GiB service limit leaves sufficient capacity for Cargo and the remaining job processes.

Validation:
- actionlint passed for both modified workflows
- git diff --check passed