### PR TITLE
fix(snapshot): preserve data when restoring pre-subject_id snapshots

### DIFF
--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -49,3 +49,5 @@ jobs:
         run: cd memoria && cargo test -- --test-threads=1
       - name: Restore transaction failure regression
         run: cd memoria && cargo test -p memoria-git --lib failed_insert_rolls_back_preceding_delete -- --ignored --nocapture
+      - name: Offline restore cleanup regressions
+        run: cd memoria && cargo test -p memoria-git --example restore_cleanup -- --include-ignored --nocapture

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -47,3 +47,5 @@ jobs:
           done
       - name: All tests
         run: cd memoria && cargo test -- --test-threads=1
+      - name: Restore transaction failure regression
+        run: cd memoria && cargo test -p memoria-git --lib failed_insert_rolls_back_preceding_delete -- --ignored --nocapture

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -49,5 +49,7 @@ jobs:
         run: cd memoria && cargo test -- --test-threads=1
       - name: Restore transaction failure regression
         run: cd memoria && cargo test -p memoria-git --lib failed_insert_rolls_back_preceding_delete -- --ignored --nocapture
+      - name: Branch capability probe cleanup regression
+        run: cd memoria && cargo test -p memoria-storage --lib materialized_probe_cleanup_preserves_unrelated_tables -- --ignored --nocapture
       - name: Offline restore cleanup regressions
         run: cd memoria && cargo test -p memoria-git --example restore_cleanup -- --include-ignored --nocapture

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,5 +78,7 @@ jobs:
         run: cd memoria && cargo test -- --test-threads=1
       - name: Restore transaction failure regression
         run: cd memoria && cargo test -p memoria-git --lib failed_insert_rolls_back_preceding_delete -- --ignored --nocapture
+      - name: Branch capability probe cleanup regression
+        run: cd memoria && cargo test -p memoria-storage --lib materialized_probe_cleanup_preserves_unrelated_tables -- --ignored --nocapture
       - name: Offline restore cleanup regressions
         run: cd memoria && cargo test -p memoria-git --example restore_cleanup -- --include-ignored --nocapture

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,3 +78,5 @@ jobs:
         run: cd memoria && cargo test -- --test-threads=1
       - name: Restore transaction failure regression
         run: cd memoria && cargo test -p memoria-git --lib failed_insert_rolls_back_preceding_delete -- --ignored --nocapture
+      - name: Offline restore cleanup regressions
+        run: cd memoria && cargo test -p memoria-git --example restore_cleanup -- --include-ignored --nocapture

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,3 +76,5 @@ jobs:
           done
       - name: All tests
         run: cd memoria && cargo test -- --test-threads=1
+      - name: Restore transaction failure regression
+        run: cd memoria && cargo test -p memoria-git --lib failed_insert_rolls_back_preceding_delete -- --ignored --nocapture

--- a/docs/branch-copy-compatibility.md
+++ b/docs/branch-copy-compatibility.md
@@ -1,0 +1,60 @@
+# Branch data compatibility
+
+## Field preservation
+
+Default `memory_merge` (`accept` / `replace`) and every `memory_apply` copy retain
+both `subject_id` and `author_id`. This includes inactive historical records
+copied by update, remove, restore and conflict acceptance. A historical row that
+never had a subject remains `NULL`; copying a scoped row must not make it unscoped.
+
+Similarity-based replacement only compares memories belonging to the same user
+and subject. Two `NULL` subjects match; a `NULL` subject and a named subject do not.
+The existing content-replacement strategy retains the target record's identity
+and attribution; newly inserted records retain the source record's attribution.
+
+## Historical schemas
+
+When a historical snapshot branch lacks `subject_id`, Memoria adds it at the
+same column position as the current main table. Before registration, it verifies
+column names, order, types (including vector dimensions), nullability, defaults
+and extra attributes. Equivalent implicit and explicit SQL NULL defaults are
+accepted. Index creation remains best effort and is not a correctness gate.
+
+Native diff, merge and pick also check the current schemas on each operation.
+This protects previously registered branches whose startup migration reported
+an incompatibility. Unsupported schema differences fail explicitly before the
+native operation; existing branches are not deleted or silently rewritten.
+Preserve/export their data before recreating a compatible branch. A newly created
+incompatible snapshot clone is not registered and is cleaned up.
+
+This is deliberately conservative across MatrixOne versions. MatrixOne 4.2.1
+can handle some column-order differences, but that behavior is not assumed for
+all supported builds. This guard does not apply to row restoration from a
+snapshot, which uses explicit column-name mapping and current defaults.
+
+Concurrent schema changes and branch/snapshot operations must be serialized;
+the preflight schema check is not a lock against concurrent DDL.
+
+## Snapshot names
+
+Unicode snapshot names retain their existing physical-name mapping. CREATE and
+DROP quote the SQL identifier, while snapshot lookup continues to use its
+existing name. No snapshot rename or user-data migration is required.
+
+## Regression commands
+
+Use a disposable MatrixOne server, not a production database. Each new E2E test
+creates isolated databases and users. Set `DATABASE_URL` to that server and run
+from `memoria/`:
+
+```sh
+SQLX_OFFLINE=true cargo test -p memoria-mcp --test branch_scope_e2e -- --test-threads=1
+SQLX_OFFLINE=true cargo test -p memoria-mcp --test branch_e2e --test snapshot_e2e -- --test-threads=1
+SQLX_OFFLINE=true cargo test -p memoria-git --test legacy_snapshot -- --test-threads=1
+SQLX_OFFLINE=true cargo test -p memoria-storage --lib table_schema
+```
+
+The scope suite covers ordinary and historical branches, all six apply-copy
+statements, active/inactive records, nullable ownership, default merge, and
+cross-subject similarity isolation. The legacy suite also verifies native-operation
+rejection without data mutation and Unicode snapshot restore/delete.

--- a/docs/branch-copy-compatibility.md
+++ b/docs/branch-copy-compatibility.md
@@ -35,6 +35,40 @@ snapshot, which uses explicit column-name mapping and current defaults.
 Concurrent schema changes and branch/snapshot operations must be serialized;
 the preflight schema check is not a lock against concurrent DDL.
 
+## ALTER capability protection
+
+Before a required branch-column migration, Memoria verifies the actual engine
+behavior on two uniquely named disposable tables containing only synthetic data.
+The probe includes parent/child ALTER, a subject index, native diff/merge with
+field-value checks, and native deletion. It does not snapshot or copy user data
+and does not rely on the server version string or a `_copy_` name in metadata.
+The validated baseline is MatrixOne `4.2.1-d2393868a`; this is not a guarantee
+that every build labelled 4.x has the same capability.
+
+A failed probe stops required column migration before ALTER touches the user
+branch. A newly created, unaltered historical clone is rejected and cleaned up
+through the existing native branch deletion path. Existing branches are retained.
+Optional index changes are skipped with a warning when capability is unverified.
+Parent subject migration with registered branches and legacy compatibility DDL
+are also checked, since altering the parent can affect its descendants.
+Ordinary current-schema branches and non-migrating reads do not need a probe.
+
+The service account needs CREATE/ALTER/DROP and native branch privileges to run
+the probe. Permission errors and connectivity failures do not enable migration.
+Concurrent callers on a store share the check; successful checks are cached for
+five minutes and failures for thirty seconds, then retried. A process restart or
+store database change resets the cache. Restart Memoria after an engine change;
+do not downgrade or mix incompatible database builds during active migrations.
+
+Request cancellation does not cancel the bounded probe/cleanup task. Cleanup
+only targets exact, randomly generated names successfully created by that probe.
+If an old engine turns its probe branch into a regular table, DROP TABLE is
+allowed for that owned probe only, never as a generic user-branch delete fallback.
+Cleanup failure cannot yield a successful capability check. A process/DB failure
+or ambiguous CREATE response may still leave named `mem_lineage_probe_*` artifacts;
+logs identify exact names for administrator inspection, not prefix-based deletion.
+This protection does not repair branches already damaged by an earlier migration.
+
 ## Snapshot names
 
 Unicode snapshot names retain their existing physical-name mapping. CREATE and
@@ -52,6 +86,7 @@ SQLX_OFFLINE=true cargo test -p memoria-mcp --test branch_scope_e2e -- --test-th
 SQLX_OFFLINE=true cargo test -p memoria-mcp --test branch_e2e --test snapshot_e2e -- --test-threads=1
 SQLX_OFFLINE=true cargo test -p memoria-git --test legacy_snapshot -- --test-threads=1
 SQLX_OFFLINE=true cargo test -p memoria-storage --lib table_schema
+SQLX_OFFLINE=true cargo test -p memoria-storage --lib branch_capability -- --include-ignored --test-threads=1
 ```
 
 The scope suite covers ordinary and historical branches, all six apply-copy

--- a/docs/legacy-snapshot-compatibility.md
+++ b/docs/legacy-snapshot-compatibility.md
@@ -1,0 +1,78 @@
+# Historical snapshots across schema upgrades
+
+Related issue: [#246](https://github.com/matrixorigin/memoria/issues/246).
+
+Snapshots created before `subject_id` was introduced retain the earlier memory
+table schema. Upgrading the live table does not upgrade historical snapshots.
+
+## Restore behavior
+
+Restoration maps historical and current columns by name, not position. Added
+columns use the current schema's defaults; historical memories receive a NULL
+`subject_id`. A missing required column without a default is rejected.
+
+Before modifying the current table, the server materializes the historical rows
+in a private `mem_restore_<uuid>` table with the current schema and constraints.
+Source read failures, incompatible data and constraint failures leave current
+rows untouched. Once preparation succeeds, DELETE and INSERT run in one database
+transaction against live tables. An INSERT failure rolls back the DELETE.
+Historical snapshot reads do not occur inside that transaction.
+
+The database account needs CREATE/DROP TABLE privileges in the user's database,
+and temporary capacity for a copy of the restored rows and their indexes. If
+preparation cannot allocate storage or create the table, restoration fails
+before deleting live rows.
+
+Staging tables are cleaned after success and failure; request cancellation also
+schedules cleanup. An abrupt process/database failure can leave a staging table
+behind. Such a table is not a registered branch. Inspect cleanup warnings and
+remove only confirmed abandoned staging tables, after checking that no restore
+is still using them.
+
+Atomicity is per restored table, not the entire multi-table memory/graph rollback.
+Existing graph-table best-effort behavior is unchanged. Operators should retain
+normal backups, serialize rollback operations and avoid concurrent writes while
+restoring. A connection loss during COMMIT leaves the client uncertain whether
+the complete transaction committed; do not blindly retry or delete data as
+compensation.
+
+## Branches from historical snapshots
+
+Before registering a newly cloned historical branch, Memoria ensures that
+`subject_id` and its composite index exist. Migration failures are returned and
+cleanup of the unregistered clone is attempted. Creating branches from current
+data retains its existing behavior.
+
+## Regression checks
+
+Use a disposable MatrixOne instance, not a production database. The new legacy
+tests create isolated databases. Run against both 3.0.11 and 3.0.15, selecting the
+appropriate local port in `DATABASE_URL`:
+
+```sh
+cd memoria
+export SQLX_OFFLINE=true
+export DATABASE_URL=mysql://root:111@127.0.0.1:16011/test
+export EMBEDDING_DIM=8
+cargo test -p memoria-git --test legacy_snapshot -- --test-threads=1
+cargo test -p memoria-git --lib failed_insert_rolls_back_preceding_delete -- --ignored --nocapture
+cargo test -p memoria-mcp --test branch_e2e --test snapshot_e2e -- --test-threads=1
+```
+
+Coverage includes reordered/new columns and defaults, populated and empty legacy
+snapshots, repeated restore, missing snapshots/required columns, incompatible
+constraints, failure after DELETE, and MCP branch read/write plus rollback after
+the schema migration. The database failure-injection test is explicitly invoked
+by CI; it is ignored by the database-free unit-test command.
+
+Local verification on 2026-09-08 passed against isolated official images:
+
+| MatrixOne | Build commit | Legacy restore tests | Transaction failure | MCP branch tests | MCP snapshot tests |
+| --- | --- | --- | --- | --- | --- |
+| 3.0.11 | `6a0394c` | 6 | 1 | 46 | 21 |
+| 3.0.15 | `43e871c` | 6 | 1 | 46 | 21 |
+
+The original DELETE/SELECT-star sequence was reproduced only on disposable test
+data and left its table empty after a column-count error. The fixed implementation
+successfully restored that same fixture. This verifies the snapshot fix, not the
+entire production upgrade or rolling-deployment compatibility.

--- a/docs/legacy-snapshot-compatibility.md
+++ b/docs/legacy-snapshot-compatibility.md
@@ -13,6 +13,12 @@ columns use the current schema's defaults; historical memories receive a NULL
 
 Before modifying the current table, the server materializes the historical rows
 in a private `mem_restore_<uuid>` table with the current schema and constraints.
+The staging table retains the copied schema, constraints and indexes. This
+includes FULLTEXT and IVF indexes: staging therefore incurs additional search
+index writes. Removing copied search indexes via ALTER TABLE was not safe on the
+3.0.11 historical-branch fixture (missing internal secondary-index tables), so
+this optimization is deliberately not enabled. The regression suite instead
+covers restoration with 512 vectors and real FULLTEXT/IVF indexes.
 Source read failures, incompatible data and constraint failures leave current
 rows untouched. Once preparation succeeds, DELETE and INSERT run in one database
 transaction against live tables. An INSERT failure rolls back the DELETE.
@@ -36,18 +42,160 @@ restoring. A connection loss during COMMIT leaves the client uncertain whether
 the complete transaction committed; do not blindly retry or delete data as
 compensation.
 
+The replacement is one transaction containing a whole-table DELETE and INSERT.
+Peak memory, transaction write limits, disk/WAL space and timeouts depend on the
+MatrixOne build, configuration, row/embedding sizes and live indexes. There is no
+validated universal row-count limit. The indexed regression covers 512 vectors,
+not production-scale capacity. Before restoring a large table, rehearse the same
+snapshot size on a matching isolated deployment and provision headroom for both
+staging and transaction writes. Do not split the replacement into independently
+committed batches: that would lose the all-or-nothing guarantee.
+
+## Offline recovery of abandoned tables
+
+No online prefix-based deletion is enabled for `mem_restore_` or `br_` tables.
+An unregistered table may belong to an in-flight restore or a branch not yet
+registered. The existing sandbox reaper must not be expanded to these prefixes.
+
+The `restore_cleanup` example provides an explicit offline fallback. Set
+`DATABASE_URL` securely to **one affected user database**, not the system database.
+Its default mode only lists exact generated names and their registration status:
+
+```sh
+cd memoria
+SQLX_OFFLINE=true cargo run -p memoria-git --example restore_cleanup
+```
+
+Before deleting anything, stop **all** Memoria API replicas, background workers,
+MCP processes and any other writers connected to that database; wait for their
+database operations to end. Inspect the candidate and retain a backup if needed.
+Then select one exact table printed by the inspection:
+
+```sh
+SQLX_OFFLINE=true cargo run -p memoria-git --example restore_cleanup -- \
+  --delete EXACT_TABLE_NAME --all-writers-stopped
+```
+
+`--all-writers-stopped` is an operator confirmation, not an automatic fence.
+Never schedule this command as an online job. It rejects unexpected names,
+protects branches registered in **any** status, rechecks registration before
+deletion, and fails closed when the registry cannot be read. Deletion has no
+automatic undo; recovery requires a retained backup or snapshot.
+
 ## Branches from historical snapshots
 
 Before registering a newly cloned historical branch, Memoria ensures that
-`subject_id` and its composite index exist. Migration failures are returned and
-cleanup of the unregistered clone is attempted. Creating branches from current
+`subject_id` and every column in the live `mem_memories` schema exist. This is a
+table-shape check, not the historical-row default rule: current reads and writes
+also reference nullable/defaulted columns such as `embedding`, `updated_at` and
+`trust_tier`. Those missing columns must not be silently accepted. Only the known
+`subject_id` migration is applied automatically; other missing columns require
+an explicit compatible migration rather than guessed values. Column migration failures are
+returned and cleanup of the unregistered clone is attempted. Creating the subject
+index is best-effort: an index error is logged without rejecting a usable branch.
+Startup migration and historical-clone migration share this policy; startup
+continues to log errors on existing branches rather than failing all users.
+Creating branches from current
 data retains its existing behavior.
 
+This column-presence check does not normalize column order or types. MatrixOne's
+native branch diff has a stricter schema-equivalence requirement and may reject
+a historical clone whose schema differs from the live table, even when Memoria's
+explicit-column reads/writes and merge work. Passing this check is not a guarantee
+of native diff compatibility.
+
+New physical branch names are ASCII while `mem_branches.name` retains the user's
+original display name, including Chinese. Normal creation and creation from a
+snapshot use the same physical-name generator. Existing Unicode physical names
+remain valid for migration, access and offline cleanup, with SQL identifier
+quoting. Snapshot-name generation is unchanged to preserve historical mappings.
+
+## Database compatibility boundaries
+
+SQLx obtains historical column metadata using PREPARE on a SELECT with
+`{SNAPSHOT = '...'}`. This is an explicit database capability dependency, verified
+on the 3.0.11 and 3.0.15 builds below, not a claim of support for every MO version.
+Snapshot reads remain outside the write transaction. Callers must serialize
+snapshot operations and quiesce writes (historical MO#23860 / MO#23861 concerns).
+
+Known 3.0.11 schema-migration limitation: adding a column to a table with UNIQUE,
+FULLTEXT and IVF indexes can make an otherwise working FULLTEXT query fail with
+`invalid input: column word does not exist`, **before any restore was called**.
+This was reproduced with SQL alone; the equivalent indexed upgrade fixture
+passed on 3.0.15. This change does not fix
+MatrixOne or certify that upgrade path on 3.0.11. Rehearse migrations of indexed
+production tables separately; do not treat successful restore tests as approval
+for a direct production upgrade. The indexed restore regression starts from a
+schema with working search indexes; separate legacy tests cover added columns.
+
 ## Regression checks
+
+### Production upgrade target: MatrixOne 4.2.1
+
+The production candidate is
+`shanghai.idc.matrixorigin.cn:30019/mocloud/matrixone:v4.2.1-d2393868a-2026-08-28`,
+not 3.0.15. The older builds below are historical regression baselines only.
+
+An isolated local upgrade rehearsal on 2026-09-08 used:
+
+- Target image digest:
+  `sha256:dab6628f0a71f53b6ec347a6264ed9f1bf72cf1cb47f0e451f377fe9ed243cff`.
+- Source: MatrixOne 3.0.11, SQL-reported commit `6a0394c`.
+- Unchanged Memoria image: `apiserver-20260511-27107f5-df643526` (0.4.0).
+- Synthetic multi-database users, API keys, memories, a snapshot, a branch, and
+  a separate 512-vector fixture with UNIQUE, FULLTEXT and IVF indexes.
+- Linux/amd64 images under local emulation, not a production performance test.
+
+**The in-place upgrade is not approved by this rehearsal.** The target returned
+`8.0.30-MatrixOne-v4.2.1` / `d2393868a`; existing rows, direct historical snapshot
+reads, fulltext search and nearest-neighbor queries worked. However, asynchronous
+catalog migration repeatedly failed while adding `kind` to `mo_catalog.mo_pitr`:
+
+```text
+no such table mo_catalog.mo_feature_registry
+```
+
+The final internal catalog version `4.0.6`, offset `5`, remained in state `0`,
+with the first `3.0.2 -> 4.0.0` migration incomplete. These are internal catalog
+versions, not the server release tag. `SHOW SNAPSHOTS` failed with
+`invalid input: column kind does not exist`, and the unchanged old API's snapshot
+path returned HTTP 500. An open SQL port, a successful `SELECT VERSION()`, or
+Memoria's `/health` response therefore does not establish upgrade readiness.
+The new Memoria regression suites have **not** been validated on this target.
+
+Before production rollout, resolve the catalog-upgrade failure through the
+MatrixOne-supported upgrade procedure or an approved corrected build, then repeat
+the old-Memoria acceptance checks before deploying new Memoria. Do not manually
+create system tables or assume an untested intermediate release fixes the issue.
+No MatrixOne source or production deployment was changed by this test.
+
+Deployment preconditions for repeating the rehearsal:
+
+- Preserve LogService identity, including its effective hostname; reusing the
+  data volume under a different hostname can produce `shard not bootstrapped`.
+- Preserve the old file-service backend and paths. This target's bundled
+  quickstart opts into `DISK-V2` for fresh deployments; the rehearsal reused the
+  old launch configuration instead of changing the storage backend.
+- Keep a pre-upgrade data copy. The local 3.0.11 process exceeded the 30-second
+  stop timeout and exited with code 137; this run includes recovery after forced
+  termination, not a certified graceful-shutdown or cluster rolling-upgrade test.
+
+### Historical regression baselines
 
 Use a disposable MatrixOne instance, not a production database. The new legacy
 tests create isolated databases. Run against both 3.0.11 and 3.0.15, selecting the
 appropriate local port in `DATABASE_URL`:
+
+For local verification, start dedicated test instances first (these ports are
+not assumed to be permanent services; do not substitute an existing user stack):
+
+```sh
+docker run -d --name memoria-snapshot-test3011 -p 127.0.0.1:16011:6001 matrixorigin/matrixone:3.0.11
+docker run -d --name memoria-snapshot-test3015 -p 127.0.0.1:16015:6001 matrixorigin/matrixone:3.0.15
+```
+
+Wait until each instance accepts SQL connections before running tests. A refused
+connection or pool timeout means the test did not reach database verification.
 
 ```sh
 cd memoria
@@ -56,21 +204,43 @@ export DATABASE_URL=mysql://root:111@127.0.0.1:16011/test
 export EMBEDDING_DIM=8
 cargo test -p memoria-git --test legacy_snapshot -- --test-threads=1
 cargo test -p memoria-git --lib failed_insert_rolls_back_preceding_delete -- --ignored --nocapture
+cargo test -p memoria-git --example restore_cleanup -- --include-ignored --nocapture
 cargo test -p memoria-mcp --test branch_e2e --test snapshot_e2e -- --test-threads=1
 ```
 
 Coverage includes reordered/new columns and defaults, populated and empty legacy
 snapshots, repeated restore, missing snapshots/required columns, incompatible
 constraints, failure after DELETE, and MCP branch read/write plus rollback after
-the schema migration. The database failure-injection test is explicitly invoked
+the schema migration. Additional regressions cover 512 non-null embeddings with
+real IVF/FULLTEXT indexes and constraint preservation,
+restoring duplicate rows in tables without unique keys, real DDL permission
+failures (optional index versus required column), preservation
+of the original error when rollback fails, Unicode branch names (new and legacy),
+required/nullable/defaulted columns missing from historical clones, and offline
+cleanup safety for both ASCII and Unicode table names. The database failure-injection test is explicitly invoked
 by CI; it is ignored by the database-free unit-test command.
+
+After local testing, stop and remove only the dedicated instances above. Their
+disposable database contents are deleted with the containers:
+
+```sh
+docker stop memoria-snapshot-test3011 memoria-snapshot-test3015
+docker rm memoria-snapshot-test3011 memoria-snapshot-test3015
+```
 
 Local verification on 2026-09-08 passed against isolated official images:
 
-| MatrixOne | Build commit | Legacy restore tests | Transaction failure | MCP branch tests | MCP snapshot tests |
-| --- | --- | --- | --- | --- | --- |
-| 3.0.11 | `6a0394c` | 6 | 1 | 46 | 21 |
-| 3.0.15 | `43e871c` | 6 | 1 | 46 | 21 |
+| MatrixOne | Build commit | Restore/branch compatibility | Transaction failure | Offline cleanup safety | MCP branch tests | MCP snapshot tests |
+| --- | --- | --- | --- | --- | --- | --- |
+| 3.0.11 | `6a0394c` | 9 | 1 | 1 | 49 | 21 |
+| 3.0.15 | `43e871c` | 9 | 1 | 1 | 49 | 21 |
+
+Seven focused database-free tests also cover Send compatibility, missing-runtime
+Drop, original-error preservation, offline cleanup argument/name validation,
+ASCII branch suffixes without changing snapshot mappings, and the distinction
+between missing historical values and missing physical columns.
+The storage `branch_ops` and `subject_id_mo_compat` suites also passed on each
+build (10 tests each), including startup migration idempotency and scoped reads.
 
 The original DELETE/SELECT-star sequence was reproduced only on disposable test
 data and left its table empty after a column-count error. The fixed implementation

--- a/memoria/crates/memoria-core/src/lib.rs
+++ b/memoria/crates/memoria-core/src/lib.rs
@@ -7,6 +7,13 @@ pub use error::MemoriaError;
 pub use sensitivity::{check_sensitivity, SensitivityResult, SensitivityTier};
 pub use types::{Memory, MemoryType, TrustTier, FEEDBACK_SIGNALS};
 
+/// Identifier allowlist used for generated and legacy physical table names.
+/// Legacy names may contain Unicode letters/digits. New branch names are ASCII,
+/// but validation must not strand previously created Unicode tables.
+pub fn is_safe_sql_identifier(name: &str) -> bool {
+    !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_')
+}
+
 /// Workaround: MO#24001 — PREPARE/EXECUTE stores `Option<String>::None` as empty
 /// string `''` instead of SQL NULL for VARCHAR columns.  Normalize at both write
 /// (bind) and read boundaries so the rest of the codebase can treat `None` and

--- a/memoria/crates/memoria-git/Cargo.toml
+++ b/memoria/crates/memoria-git/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 memoria-core = { workspace = true }
+memoria-storage = { path = "../memoria-storage" }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -13,6 +14,3 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
-
-[dev-dependencies]
-memoria-storage = { path = "../memoria-storage" }

--- a/memoria/crates/memoria-git/Cargo.toml
+++ b/memoria/crates/memoria-git/Cargo.toml
@@ -12,7 +12,7 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 memoria-storage = { path = "../memoria-storage" }
-uuid = { workspace = true }

--- a/memoria/crates/memoria-git/examples/restore_cleanup.rs
+++ b/memoria/crates/memoria-git/examples/restore_cleanup.rs
@@ -167,12 +167,26 @@ mod tests {
         // Orphan here means missing from Memoria's registry, not missing from
         // MatrixOne's native branch lineage. Use genuine branches so this test
         // exercises the same deletion contract as abandoned branch creation.
-        sqlx::raw_sql("CREATE TABLE mem_branches (table_name VARCHAR(100), status VARCHAR(20)); CREATE TABLE cleanup_source (id INT PRIMARY KEY); INSERT INTO cleanup_source VALUES (7); DATA BRANCH CREATE TABLE br_12345678_registered FROM cleanup_source; DATA BRANCH CREATE TABLE br_12345678_orphan FROM cleanup_source; CREATE TABLE mem_restore_0123456789abcdef0123456789abcdef (id INT); INSERT INTO mem_branches VALUES ('br_12345678_registered', 'inactive')")
-            .execute(&pool).await.unwrap();
         // ASCII clone + quoted rename also works on older MO versions whose
         // native clone parser does not accept a Unicode destination directly.
-        sqlx::raw_sql("DATA BRANCH CREATE TABLE br_12345678_unicode_registered FROM cleanup_source; ALTER TABLE br_12345678_unicode_registered RENAME TO `br_12345678_已有`; DATA BRANCH CREATE TABLE br_12345678_unicode_orphan FROM cleanup_source; ALTER TABLE br_12345678_unicode_orphan RENAME TO `br_12345678_孤儿`; INSERT INTO mem_branches VALUES ('br_12345678_已有', 'active')")
-            .execute(&pool).await.unwrap();
+        // Native DDL must be sent separately for MO 3.0.11: its branch parser
+        // inspects the whole request text instead of just the current statement.
+        for statement in [
+            "CREATE TABLE mem_branches (table_name VARCHAR(100), status VARCHAR(20))",
+            "CREATE TABLE cleanup_source (id INT PRIMARY KEY)",
+            "INSERT INTO cleanup_source VALUES (7)",
+            "DATA BRANCH CREATE TABLE br_12345678_registered FROM cleanup_source",
+            "DATA BRANCH CREATE TABLE br_12345678_orphan FROM cleanup_source",
+            "CREATE TABLE mem_restore_0123456789abcdef0123456789abcdef (id INT)",
+            "INSERT INTO mem_branches VALUES ('br_12345678_registered', 'inactive')",
+            "DATA BRANCH CREATE TABLE br_12345678_unicode_registered FROM cleanup_source",
+            "ALTER TABLE br_12345678_unicode_registered RENAME TO `br_12345678_已有`",
+            "DATA BRANCH CREATE TABLE br_12345678_unicode_orphan FROM cleanup_source",
+            "ALTER TABLE br_12345678_unicode_orphan RENAME TO `br_12345678_孤儿`",
+            "INSERT INTO mem_branches VALUES ('br_12345678_已有', 'active')",
+        ] {
+            sqlx::raw_sql(statement).execute(&pool).await.unwrap();
+        }
         let protected = delete_unregistered(&pool, "br_12345678_registered").await;
         let unicode_protected = delete_unregistered(&pool, "br_12345678_已有").await;
         let unicode_orphan = delete_unregistered(&pool, "br_12345678_孤儿").await;

--- a/memoria/crates/memoria-git/examples/restore_cleanup.rs
+++ b/memoria/crates/memoria-git/examples/restore_cleanup.rs
@@ -1,5 +1,7 @@
 //! Offline recovery tool. Read-only by default; never run deletion alongside
 //! Memoria servers, workers, or MCP processes. See legacy-snapshot-compatibility.md.
+//! The br_ path uses native branch deletion. A matching name alone does not make
+//! an ordinary table a native branch; rejection must not trigger a DROP fallback.
 use sqlx::{MySql, MySqlPool, QueryBuilder};
 
 fn candidate(name: &str) -> bool {
@@ -162,9 +164,14 @@ mod tests {
         let pool = MySqlPool::connect_with(options.database(&db))
             .await
             .unwrap();
-        sqlx::raw_sql("CREATE TABLE mem_branches (table_name VARCHAR(100), status VARCHAR(20)); CREATE TABLE br_12345678_registered (id INT); CREATE TABLE br_12345678_orphan (id INT); CREATE TABLE mem_restore_0123456789abcdef0123456789abcdef (id INT); INSERT INTO mem_branches VALUES ('br_12345678_registered', 'inactive')")
+        // Orphan here means missing from Memoria's registry, not missing from
+        // MatrixOne's native branch lineage. Use genuine branches so this test
+        // exercises the same deletion contract as abandoned branch creation.
+        sqlx::raw_sql("CREATE TABLE mem_branches (table_name VARCHAR(100), status VARCHAR(20)); CREATE TABLE cleanup_source (id INT PRIMARY KEY); INSERT INTO cleanup_source VALUES (7); DATA BRANCH CREATE TABLE br_12345678_registered FROM cleanup_source; DATA BRANCH CREATE TABLE br_12345678_orphan FROM cleanup_source; CREATE TABLE mem_restore_0123456789abcdef0123456789abcdef (id INT); INSERT INTO mem_branches VALUES ('br_12345678_registered', 'inactive')")
             .execute(&pool).await.unwrap();
-        sqlx::raw_sql("CREATE TABLE `br_12345678_已有` (id INT); CREATE TABLE `br_12345678_孤儿` (id INT); INSERT INTO mem_branches VALUES ('br_12345678_已有', 'active')")
+        // ASCII clone + quoted rename also works on older MO versions whose
+        // native clone parser does not accept a Unicode destination directly.
+        sqlx::raw_sql("DATA BRANCH CREATE TABLE br_12345678_unicode_registered FROM cleanup_source; ALTER TABLE br_12345678_unicode_registered RENAME TO `br_12345678_已有`; DATA BRANCH CREATE TABLE br_12345678_unicode_orphan FROM cleanup_source; ALTER TABLE br_12345678_unicode_orphan RENAME TO `br_12345678_孤儿`; INSERT INTO mem_branches VALUES ('br_12345678_已有', 'active')")
             .execute(&pool).await.unwrap();
         let protected = delete_unregistered(&pool, "br_12345678_registered").await;
         let unicode_protected = delete_unregistered(&pool, "br_12345678_已有").await;
@@ -180,6 +187,10 @@ mod tests {
         let closed = delete_unregistered(&pool, "br_12345678_unverified").await;
         let tables: Vec<String> = sqlx::query_scalar("SELECT table_name FROM information_schema.tables WHERE table_schema = ? ORDER BY table_name")
             .bind(&db).fetch_all(&pool).await.unwrap();
+        let source_rows: Vec<i32> = sqlx::query_scalar("SELECT id FROM cleanup_source ORDER BY id")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
         pool.close().await;
         let mut drop = QueryBuilder::<MySql>::new("DROP DATABASE ");
         drop.push(&db);
@@ -194,8 +205,14 @@ mod tests {
         assert!(orphan.is_ok(), "{orphan:?}");
         assert!(stage.is_ok(), "{stage:?}");
         assert!(closed.is_err());
-        assert_eq!(tables.len(), 3);
+        assert_eq!(
+            source_rows,
+            vec![7],
+            "cleanup must preserve the source table"
+        );
+        assert_eq!(tables.len(), 4);
         for name in [
+            "cleanup_source",
             "br_12345678_registered",
             "br_12345678_unverified",
             "br_12345678_已有",

--- a/memoria/crates/memoria-git/examples/restore_cleanup.rs
+++ b/memoria/crates/memoria-git/examples/restore_cleanup.rs
@@ -1,0 +1,206 @@
+//! Offline recovery tool. Read-only by default; never run deletion alongside
+//! Memoria servers, workers, or MCP processes. See legacy-snapshot-compatibility.md.
+use sqlx::{MySql, MySqlPool, QueryBuilder};
+
+fn candidate(name: &str) -> bool {
+    if let Some(id) = name.strip_prefix("mem_restore_") {
+        return id.len() == 32 && id.bytes().all(|c| c.is_ascii_hexdigit());
+    }
+    if let Some(branch) = name.strip_prefix("br_") {
+        if let Some((id, suffix)) = branch.split_once('_') {
+            return id.len() == 8
+                && id.bytes().all(|c| c.is_ascii_hexdigit())
+                && memoria_core::is_safe_sql_identifier(suffix);
+        }
+    }
+    false
+}
+
+fn delete_target(args: &[String]) -> Result<Option<&str>, &'static str> {
+    match args {
+        [] => Ok(None),
+        [flag, name, offline] if flag == "--delete" && offline == "--all-writers-stopped" => {
+            if candidate(name) {
+                Ok(Some(name))
+            } else {
+                Err("Refusing unexpected table name; use an exact generated stage/branch name")
+            }
+        }
+        _ => Err("Usage: restore_cleanup [--delete EXACT_TABLE --all-writers-stopped]"),
+    }
+}
+
+async fn registered(pool: &MySqlPool, table: &str) -> Result<bool, sqlx::Error> {
+    // Fail closed if the registry cannot be read. Protect every registered
+    // branch, not just 'active' branches, including an ambiguous registration.
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mem_branches WHERE table_name = ?")
+        .bind(table)
+        .fetch_one(pool)
+        .await?;
+    Ok(count != 0)
+}
+
+async fn delete_unregistered(
+    pool: &MySqlPool,
+    table: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !candidate(table) {
+        return Err("Refusing unexpected table name".into());
+    }
+    if registered(pool, table).await? {
+        return Err("Refusing to delete a registered branch".into());
+    }
+    let mut ddl = QueryBuilder::<MySql>::new(if table.starts_with("br_") {
+        "DATA BRANCH DELETE TABLE "
+    } else {
+        "DROP TABLE "
+    });
+    ddl.push("`").push(table).push("`");
+    sqlx::raw_sql(&ddl.into_sql()).execute(pool).await?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let delete = delete_target(&args)?;
+    let pool = MySqlPool::connect(&std::env::var("DATABASE_URL")?).await?;
+    let database: String = sqlx::query_scalar("SELECT DATABASE()")
+        .fetch_one(&pool)
+        .await?;
+    if matches!(
+        database.as_str(),
+        "mo_catalog" | "mysql" | "information_schema" | "system"
+    ) {
+        return Err("Select a single Memoria user database, not a system database".into());
+    }
+    let tables: Vec<String> = sqlx::query_scalar(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = ? ORDER BY table_name",
+    )
+    .bind(&database)
+    .fetch_all(&pool)
+    .await?;
+    if let Some(table) = delete {
+        if !tables.iter().any(|t| t == table) {
+            return Err("Target table does not exist in the selected database".into());
+        }
+        // The operator's offline confirmation is essential: absence from the
+        // registry is not proof that a live restore/branch creation is abandoned.
+        // This tool cannot fence other processes and is NEVER a scheduled reaper.
+        delete_unregistered(&pool, table).await?;
+        println!("Deleted {database}.{table}. No automatic undo; recovery requires a retained backup/snapshot.");
+    } else {
+        println!("Read-only inspection of {database}. Candidates may still be in use; stop ALL writers before deletion.");
+        for table in tables.into_iter().filter(|t| candidate(t)) {
+            let state = if registered(&pool, &table).await? {
+                "protected: registered branch"
+            } else {
+                "unregistered: investigate; NOT proof of abandonment"
+            };
+            println!("{table}\t{state}");
+        }
+    }
+    pool.close().await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deletion_requires_exact_target_and_offline_confirmation() {
+        assert_eq!(delete_target(&[]), Ok(None));
+        let name = "mem_restore_0123456789abcdef0123456789abcdef";
+        assert!(delete_target(&["--delete".into(), name.into()]).is_err());
+        assert_eq!(
+            delete_target(&[
+                "--delete".into(),
+                name.into(),
+                "--all-writers-stopped".into()
+            ]),
+            Ok(Some(name))
+        );
+    }
+
+    #[test]
+    fn reject_broad_prefixes_non_generated_names_and_injection() {
+        for name in [
+            "mem_memories",
+            "mem_restore_%",
+            "mem_restore_a",
+            "br_%",
+            "br_live",
+            "br_12345678_",
+            "br_12345678_x`; DROP TABLE mem_memories",
+            "br_12345678_实验`; DROP TABLE mem_memories",
+            "br_12345678_实验/表",
+            "memXrestore_0123456789abcdef0123456789abcdef",
+        ] {
+            assert!(!candidate(name), "{name}");
+        }
+        assert!(candidate("br_1234abcd_my_branch"));
+        assert!(candidate("br_1234abcd_实验"));
+        assert!(candidate("mem_restore_0123456789abcdef0123456789abcdef"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a disposable MatrixOne server via DATABASE_URL"]
+    async fn offline_cleanup_protects_registered_branches_and_fails_closed() {
+        let options: sqlx::mysql::MySqlConnectOptions =
+            std::env::var("DATABASE_URL").unwrap().parse().unwrap();
+        let admin = MySqlPool::connect_with(options.clone().database("mo_catalog"))
+            .await
+            .unwrap();
+        let db = format!("cleanup_test_{}", uuid::Uuid::new_v4().simple());
+        let mut ddl = QueryBuilder::<MySql>::new("CREATE DATABASE ");
+        ddl.push(&db);
+        sqlx::raw_sql(&ddl.into_sql())
+            .execute(&admin)
+            .await
+            .unwrap();
+        let pool = MySqlPool::connect_with(options.database(&db))
+            .await
+            .unwrap();
+        sqlx::raw_sql("CREATE TABLE mem_branches (table_name VARCHAR(100), status VARCHAR(20)); CREATE TABLE br_12345678_registered (id INT); CREATE TABLE br_12345678_orphan (id INT); CREATE TABLE mem_restore_0123456789abcdef0123456789abcdef (id INT); INSERT INTO mem_branches VALUES ('br_12345678_registered', 'inactive')")
+            .execute(&pool).await.unwrap();
+        sqlx::raw_sql("CREATE TABLE `br_12345678_已有` (id INT); CREATE TABLE `br_12345678_孤儿` (id INT); INSERT INTO mem_branches VALUES ('br_12345678_已有', 'active')")
+            .execute(&pool).await.unwrap();
+        let protected = delete_unregistered(&pool, "br_12345678_registered").await;
+        let unicode_protected = delete_unregistered(&pool, "br_12345678_已有").await;
+        let unicode_orphan = delete_unregistered(&pool, "br_12345678_孤儿").await;
+        let unexpected = delete_unregistered(&pool, "mem_branches").await;
+        let orphan = delete_unregistered(&pool, "br_12345678_orphan").await;
+        let stage =
+            delete_unregistered(&pool, "mem_restore_0123456789abcdef0123456789abcdef").await;
+        sqlx::raw_sql("DROP TABLE mem_branches; CREATE TABLE br_12345678_unverified (id INT)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let closed = delete_unregistered(&pool, "br_12345678_unverified").await;
+        let tables: Vec<String> = sqlx::query_scalar("SELECT table_name FROM information_schema.tables WHERE table_schema = ? ORDER BY table_name")
+            .bind(&db).fetch_all(&pool).await.unwrap();
+        pool.close().await;
+        let mut drop = QueryBuilder::<MySql>::new("DROP DATABASE ");
+        drop.push(&db);
+        sqlx::raw_sql(&drop.into_sql())
+            .execute(&admin)
+            .await
+            .unwrap();
+        assert!(protected.is_err());
+        assert!(unicode_protected.is_err());
+        assert!(unicode_orphan.is_ok(), "{unicode_orphan:?}");
+        assert!(unexpected.is_err());
+        assert!(orphan.is_ok(), "{orphan:?}");
+        assert!(stage.is_ok(), "{stage:?}");
+        assert!(closed.is_err());
+        assert_eq!(tables.len(), 3);
+        for name in [
+            "br_12345678_registered",
+            "br_12345678_unverified",
+            "br_12345678_已有",
+        ] {
+            assert!(tables.iter().any(|t| t == name), "{tables:?}");
+        }
+    }
+}

--- a/memoria/crates/memoria-git/src/service.rs
+++ b/memoria/crates/memoria-git/src/service.rs
@@ -667,7 +667,7 @@ impl GitForDataService {
     // ── Snapshots ─────────────────────────────────────────────────────────────
 
     pub async fn create_snapshot(&self, name: &str) -> Result<Snapshot, MemoriaError> {
-        let safe = validate_identifier(name)?;
+        let safe = quote_identifier(validate_identifier(name)?);
         exec_ddl(
             &self.pool,
             &format!(
@@ -757,7 +757,11 @@ impl GitForDataService {
 
     pub async fn drop_snapshot(&self, name: &str) -> Result<(), MemoriaError> {
         let safe = validate_identifier(name)?;
-        exec_ddl(&self.pool, &format!("DROP SNAPSHOT {safe}")).await
+        exec_ddl(
+            &self.pool,
+            &format!("DROP SNAPSHOT {}", quote_identifier(safe)),
+        )
+        .await
     }
 
     /// Restore historical data into the current schema. Prepare and validate all
@@ -914,6 +918,8 @@ impl GitForDataService {
     ) -> Result<(), MemoriaError> {
         let safe_branch = quote_identifier(validate_identifier(branch_table)?);
         let safe_main = quote_identifier(validate_identifier(main_table)?);
+        self.check_native_branch_schema(branch_table, main_table)
+            .await?;
         let db = quote_identifier(&self.db_name);
         exec_ddl(
             &self.pool,
@@ -939,6 +945,8 @@ impl GitForDataService {
         let safe_source = quote_identifier(validate_identifier(source_table)?);
         let safe_target = quote_identifier(validate_identifier(target_table)?);
         let conflict = pick_conflict_clause(strategy)?;
+        self.check_native_branch_schema(source_table, target_table)
+            .await?;
         let db = quote_identifier(&self.db_name);
         let key_list = keys
             .iter()
@@ -967,6 +975,8 @@ impl GitForDataService {
         let safe_from = validate_identifier(from_snapshot)?;
         let safe_to = validate_identifier(to_snapshot)?;
         let conflict = pick_conflict_clause(strategy)?;
+        self.check_native_branch_schema(source_table, target_table)
+            .await?;
         let db = quote_identifier(&self.db_name);
         exec_ddl(
             &self.pool,
@@ -998,6 +1008,28 @@ impl GitForDataService {
         Ok(total as i64)
     }
 
+    async fn check_native_branch_schema(
+        &self,
+        branch_table: &str,
+        main_table: &str,
+    ) -> Result<(), MemoriaError> {
+        // Check on every native operation, including previously registered
+        // branches whose startup migration only logged an incompatibility.
+        let branch = memoria_storage::table_schema::read_table_columns(
+            &self.pool,
+            &self.db_name,
+            branch_table,
+        )
+        .await?;
+        let current = memoria_storage::table_schema::read_table_columns(
+            &self.pool,
+            &self.db_name,
+            main_table,
+        )
+        .await?;
+        memoria_storage::table_schema::validate_native_branch_schema(&current, &branch)
+    }
+
     /// Native LCA-based diff rows, filtered by user_id.
     ///
     /// `data branch diff` is account-level (no WHERE clause supported), so we fetch
@@ -1026,6 +1058,8 @@ impl GitForDataService {
         let limit = limit.clamp(1, 5_000);
         let safe_branch = quote_identifier(validate_identifier(branch_table)?);
         let safe_main = quote_identifier(validate_identifier(main_table)?);
+        self.check_native_branch_schema(branch_table, main_table)
+            .await?;
         let db = quote_identifier(&self.db_name);
         // Fetch more rows than requested to account for user_id filtering in Rust.
         let fetch_limit = limit * 10 + 100;
@@ -1274,10 +1308,10 @@ impl GitForDataService {
                     "INSERT INTO {main_table_ref} \
                      (memory_id, user_id, memory_type, content, embedding, session_id, \
                       source_event_ids, extra_metadata, is_active, superseded_by, \
-                      trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id) \
+                      trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id) \
                      SELECT memory_id, user_id, memory_type, content, embedding, session_id, \
                             source_event_ids, extra_metadata, is_active, superseded_by, \
-                            trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id \
+                            trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id \
                      FROM {branch_table_ref} WHERE user_id = ? AND is_active = 1 AND memory_id IN ({ph})"
                 );
                 let mut q = sqlx::query(&insert_sql).bind(user_id);
@@ -1309,10 +1343,10 @@ impl GitForDataService {
                     "INSERT INTO {main_table_ref} \
                      (memory_id, user_id, memory_type, content, embedding, session_id, \
                       source_event_ids, extra_metadata, is_active, superseded_by, \
-                      trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id) \
+                      trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id) \
                      SELECT memory_id, user_id, memory_type, content, embedding, session_id, \
                             source_event_ids, extra_metadata, is_active, superseded_by, \
-                            trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id \
+                            trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id \
                      FROM {branch_table_ref} WHERE user_id = ? AND is_active = 1 AND memory_id IN ({ph})"
                 );
                 let mut q = sqlx::query(&insert_sql).bind(user_id);
@@ -1371,10 +1405,10 @@ impl GitForDataService {
                         "INSERT INTO {main_table_ref} \
                          (memory_id, user_id, memory_type, content, embedding, session_id, \
                           source_event_ids, extra_metadata, is_active, superseded_by, \
-                          trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id) \
+                          trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id) \
                          SELECT memory_id, user_id, memory_type, content, embedding, session_id, \
                                 source_event_ids, extra_metadata, is_active, superseded_by, \
-                                trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id \
+                                trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id \
                          FROM {branch_table_ref} WHERE memory_id = ? AND user_id = ?"
                     ))
                     .bind(&pair.old_id)
@@ -1387,10 +1421,10 @@ impl GitForDataService {
                         "INSERT INTO {main_table_ref} \
                          (memory_id, user_id, memory_type, content, embedding, session_id, \
                           source_event_ids, extra_metadata, is_active, superseded_by, \
-                          trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id) \
+                          trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id) \
                          SELECT memory_id, user_id, memory_type, content, embedding, session_id, \
                                 source_event_ids, extra_metadata, is_active, superseded_by, \
-                                trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id \
+                                trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id \
                          FROM {branch_table_ref} WHERE memory_id = ? AND user_id = ? AND is_active = 1"
                     ))
                     .bind(&pair.new_id)
@@ -1471,10 +1505,10 @@ impl GitForDataService {
                     "INSERT INTO {main_table_ref} \
                      (memory_id, user_id, memory_type, content, embedding, session_id, \
                       source_event_ids, extra_metadata, is_active, superseded_by, \
-                      trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id) \
+                      trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id) \
                      SELECT memory_id, user_id, memory_type, content, embedding, session_id, \
                             source_event_ids, extra_metadata, is_active, superseded_by, \
-                            trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id \
+                            trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id \
                      FROM {branch_table_ref} WHERE user_id = ? AND is_active = 0 AND memory_id IN ({ph})"
                 );
                 let mut q = sqlx::query(&ins_sql).bind(user_id);
@@ -1562,10 +1596,10 @@ impl GitForDataService {
                     "INSERT INTO {main_table_ref} \
                      (memory_id, user_id, memory_type, content, embedding, session_id, \
                       source_event_ids, extra_metadata, is_active, superseded_by, \
-                      trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id) \
+                      trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id) \
                      SELECT memory_id, user_id, memory_type, content, embedding, session_id, \
                             source_event_ids, extra_metadata, is_active, superseded_by, \
-                            trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id \
+                            trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id \
                      FROM {branch_table_ref} WHERE user_id = ? AND memory_id IN ({branch_ph})"
                 );
                 let mut q = sqlx::query(&ins_sql).bind(user_id);

--- a/memoria/crates/memoria-git/src/service.rs
+++ b/memoria/crates/memoria-git/src/service.rs
@@ -11,74 +11,6 @@ fn db_err(e: sqlx::Error) -> MemoriaError {
     MemoriaError::Database(e.to_string())
 }
 
-#[cfg(test)]
-mod restore_tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn restore_future_is_send() {
-        fn assert_send<T: Send>(_: T) {}
-        let pool = sqlx::mysql::MySqlPoolOptions::new()
-            .connect_lazy("mysql://root:111@127.0.0.1:6001/test")
-            .unwrap();
-        let git = GitForDataService::new(pool, "test");
-        assert_send(replace_from_stage(
-            &git.pool,
-            "DELETE FROM target",
-            "INSERT INTO target SELECT * FROM stage",
-        ));
-        assert_send(git.restore_table_from_snapshot("memories", "snapshot"));
-    }
-
-    #[tokio::test]
-    #[ignore = "requires a disposable MatrixOne server via DATABASE_URL"]
-    async fn failed_insert_rolls_back_preceding_delete() {
-        let url = std::env::var("DATABASE_URL").expect("DATABASE_URL required");
-        let options: sqlx::mysql::MySqlConnectOptions = url.parse().unwrap();
-        let admin = MySqlPool::connect_with(options.clone().database("mo_catalog"))
-            .await
-            .unwrap();
-        let db = format!("restore_atomic_{}", uuid::Uuid::new_v4().simple());
-        let mut ddl = QueryBuilder::<MySql>::new("CREATE DATABASE ");
-        ddl.push(&db);
-        sqlx::raw_sql(&ddl.into_sql())
-            .execute(&admin)
-            .await
-            .unwrap();
-        let pool = MySqlPool::connect_with(options.database(&db))
-            .await
-            .unwrap();
-        sqlx::raw_sql("CREATE TABLE target (id INT PRIMARY KEY, content VARCHAR(100)); CREATE TABLE stage (id INT, content VARCHAR(100)); INSERT INTO target VALUES (1, 'current'); INSERT INTO stage VALUES (2, 'first'), (2, 'duplicate')").execute(&pool).await.unwrap();
-        let result = replace_from_stage(
-            &pool,
-            "DELETE FROM target",
-            "INSERT INTO target SELECT * FROM stage",
-        )
-        .await;
-        let rows: Vec<(i32, String)> = sqlx::query_as("SELECT id, content FROM target")
-            .fetch_all(&pool)
-            .await
-            .unwrap();
-        pool.close().await;
-        let mut drop = QueryBuilder::<MySql>::new("DROP DATABASE ");
-        drop.push(&db);
-        sqlx::raw_sql(&drop.into_sql())
-            .execute(&admin)
-            .await
-            .unwrap();
-        let error = result.expect_err("duplicate primary key must fail the INSERT");
-        assert!(
-            error.to_string().to_lowercase().contains("duplicate"),
-            "{error}"
-        );
-        assert_eq!(
-            rows,
-            vec![(1, "current".into())],
-            "DELETE must be rolled back with the failed INSERT"
-        );
-    }
-}
-
 // A staging table is private to one restore, never registered as a user branch.
 // Drop also schedules cleanup when the request future is cancelled.
 struct RestoreStage {
@@ -101,9 +33,18 @@ impl RestoreStage {
 
 impl Drop for RestoreStage {
     fn drop(&mut self) {
-        if let (Some(sql), Ok(runtime)) =
-            (self.drop_sql.take(), tokio::runtime::Handle::try_current())
-        {
+        if let Some(sql) = self.drop_sql.as_ref() {
+            let runtime = match tokio::runtime::Handle::try_current() {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    tracing::warn!(%error, cleanup = %sql,
+                        "restore staging cleanup unavailable without a runtime; offline cleanup required");
+                    return;
+                }
+            };
+            // Best effort only: runtime shutdown may cancel this task. Never
+            // delete tables by prefix to compensate for an interrupted cleanup.
+            let sql = self.drop_sql.take().expect("checked above");
             let pool = self.pool.clone();
             runtime.spawn(async move {
                 if let Err(error) = exec_ddl(&pool, &sql).await {
@@ -112,6 +53,17 @@ impl Drop for RestoreStage {
             });
         }
     }
+}
+
+fn restore_statement_error(
+    original: sqlx::Error,
+    rollback: Result<(), sqlx::Error>,
+) -> MemoriaError {
+    if let Err(error) = rollback {
+        tracing::warn!(%error, original_error = %original,
+            "restore transaction rollback failed; preserving the original statement error");
+    }
+    db_err(original)
 }
 
 /// Both statements operate on live tables: MatrixOne forbids historical snapshot
@@ -123,12 +75,10 @@ async fn replace_from_stage(
 ) -> Result<(), MemoriaError> {
     let mut tx = pool.begin().await.map_err(db_err)?;
     if let Err(error) = sqlx::query(delete).execute(&mut *tx).await {
-        tx.rollback().await.map_err(db_err)?;
-        return Err(db_err(error));
+        return Err(restore_statement_error(error, tx.rollback().await));
     }
     if let Err(error) = sqlx::query(insert).execute(&mut *tx).await {
-        tx.rollback().await.map_err(db_err)?;
-        return Err(db_err(error));
+        return Err(restore_statement_error(error, tx.rollback().await));
     }
     // Do not retry individual statements or compensate after an ambiguous commit.
     // The database commits the entire replacement or retains the original rows.
@@ -146,6 +96,8 @@ async fn prepare_and_replace(
     let mut create = QueryBuilder::<MySql>::new("CREATE TABLE ");
     create.push(&stage_table).push(" LIKE ").push(&target_table);
     exec_ddl(&pool, &create.into_sql()).await?;
+    // Retain copied indexes until stripping them is validated against historical
+    // clones with secondary indexes on every supported MatrixOne build.
     let mut prepare = QueryBuilder::<MySql>::new("INSERT INTO ");
     prepare
         .push(&stage_table)
@@ -159,7 +111,12 @@ async fn prepare_and_replace(
         .push(snapshot)
         .push("'}");
     // All source reads and constraint validation finish before live-row deletion.
-    exec_ddl(&pool, &prepare.into_sql()).await?;
+    // This INSERT is not idempotent (some restored tables have no unique key).
+    // Do not route it through the DDL retry helper, even for MO retry errors.
+    sqlx::raw_sql(&prepare.into_sql())
+        .execute(&pool)
+        .await
+        .map_err(db_err)?;
     let mut delete = QueryBuilder::<MySql>::new("DELETE FROM ");
     delete.push(&target_table);
     let mut insert = QueryBuilder::<MySql>::new("INSERT INTO ");
@@ -237,7 +194,7 @@ async fn exec_ddl(pool: &MySqlPool, sql: &str) -> Result<(), MemoriaError> {
 
 /// Validate identifier — alphanumeric + underscore only, prevents SQL injection in DDL.
 fn validate_identifier(name: &str) -> Result<&str, MemoriaError> {
-    if name.chars().all(|c| c.is_alphanumeric() || c == '_') && !name.is_empty() {
+    if memoria_core::is_safe_sql_identifier(name) {
         Ok(name)
     } else {
         Err(MemoriaError::Internal(format!(
@@ -248,6 +205,12 @@ fn validate_identifier(name: &str) -> Result<&str, MemoriaError> {
 
 fn quote_identifier(name: &str) -> String {
     format!("`{}`", name.replace('`', "``"))
+}
+
+fn qualified_identifier(schema: &str, table: &str) -> String {
+    let mut sql = QueryBuilder::<MySql>::new(quote_identifier(schema));
+    sql.push(".").push(quote_identifier(table));
+    sql.into_sql()
 }
 
 fn quote_sql_literal(value: &str) -> String {
@@ -800,6 +763,11 @@ impl GitForDataService {
     /// Restore historical data into the current schema. Prepare and validate all
     /// rows in a private table first, then atomically replace live rows. New
     /// columns receive the current schema's defaults (subject_id defaults to NULL).
+    ///
+    /// Callers must serialize snapshot operations and quiesce concurrent writes.
+    /// MO#23860 (write conflicts) / MO#23861 (FULLTEXT secondary-table loss)
+    /// motivated this restriction; atomic row replacement does not remove it.
+    /// Never retry individual statements in the replacement transaction.
     pub async fn restore_table_from_snapshot(
         &self,
         table: &str,
@@ -808,20 +776,13 @@ impl GitForDataService {
         let safe_table = validate_identifier(table)?;
         let safe_snap = validate_identifier(snapshot_name)?;
         let db = quote_identifier(&self.db_name);
-        let qualified_table = format!("{db}.{safe_table}");
+        let qualified_table = qualified_identifier(&self.db_name, safe_table);
 
         // Verify snapshot exists
         self.get_snapshot(snapshot_name)
             .await?
             .ok_or_else(|| MemoriaError::NotFound(format!("Snapshot {snapshot_name}")))?;
 
-        let mut current_query = QueryBuilder::<MySql>::new("SELECT * FROM ");
-        current_query.push(&qualified_table).push(" LIMIT 0");
-        let current = self
-            .pool
-            .describe(&current_query.into_sql())
-            .await
-            .map_err(db_err)?;
         let mut historical_query = QueryBuilder::<MySql>::new("SELECT * FROM ");
         historical_query
             .push(&qualified_table)
@@ -835,39 +796,36 @@ impl GitForDataService {
             .map_err(db_err)?;
         // Reject missing required fields explicitly: permissive MySQL SQL modes
         // can otherwise invent implicit zero/empty values for NOT NULL columns.
-        let requirements: Vec<(String, String, Option<String>, String)> = sqlx::query_as(
-            "SELECT COLUMN_NAME, IS_NULLABLE, COLUMN_DEFAULT, EXTRA \
-             FROM information_schema.columns WHERE table_schema = ? AND table_name = ?",
+        let requirements = memoria_storage::table_schema::read_table_columns(
+            &self.pool,
+            &self.db_name,
+            safe_table,
         )
-        .bind(&self.db_name)
-        .bind(safe_table)
-        .fetch_all(&self.pool)
-        .await
-        .map_err(db_err)?;
-        for (name, nullable, default, extra) in requirements {
-            if !historical
-                .columns()
-                .iter()
-                .any(|old| old.name().eq_ignore_ascii_case(&name))
-                && nullable == "NO"
-                && default.is_none()
-                && !extra.to_lowercase().contains("auto_increment")
-            {
+        .await?;
+        let historical_names: Vec<String> = historical
+            .columns()
+            .iter()
+            .map(|c| c.name().to_owned())
+            .collect();
+        for column in
+            memoria_storage::table_schema::missing_columns(&requirements, &historical_names)
+        {
+            if column.needs_snapshot_value() {
                 return Err(MemoriaError::Validation(format!(
-                    "Snapshot is missing required column '{name}' without a default"
+                    "Snapshot is missing required column '{}' without a default",
+                    column.name
                 )));
             }
         }
-        let columns: Vec<_> = current
-            .columns()
+        let columns: Vec<_> = requirements
             .iter()
             .filter(|column| {
                 historical
                     .columns()
                     .iter()
-                    .any(|old| old.name().eq_ignore_ascii_case(column.name()))
+                    .any(|old| old.name().eq_ignore_ascii_case(&column.name))
             })
-            .map(|column| quote_identifier(column.name()))
+            .map(|column| quote_identifier(&column.name))
             .collect();
         if columns.is_empty() {
             return Err(MemoriaError::Validation(
@@ -875,10 +833,9 @@ impl GitForDataService {
             ));
         }
         let column_list = columns.join(", ");
-        let all_columns = current
-            .columns()
+        let all_columns = requirements
             .iter()
-            .map(|c| quote_identifier(c.name()))
+            .map(|column| quote_identifier(&column.name))
             .collect::<Vec<_>>()
             .join(", ");
         let stage_name = format!("mem_restore_{}", uuid::Uuid::new_v4().simple());
@@ -910,8 +867,8 @@ impl GitForDataService {
         branch_name: &str,
         source_table: &str,
     ) -> Result<(), MemoriaError> {
-        let safe_branch = validate_identifier(branch_name)?;
-        let safe_source = validate_identifier(source_table)?;
+        let safe_branch = quote_identifier(validate_identifier(branch_name)?);
+        let safe_source = quote_identifier(validate_identifier(source_table)?);
         let db = quote_identifier(&self.db_name);
         exec_ddl(
             &self.pool,
@@ -928,8 +885,8 @@ impl GitForDataService {
         source_table: &str,
         snapshot_name: &str,
     ) -> Result<(), MemoriaError> {
-        let safe_branch = validate_identifier(branch_name)?;
-        let safe_source = validate_identifier(source_table)?;
+        let safe_branch = quote_identifier(validate_identifier(branch_name)?);
+        let safe_source = quote_identifier(validate_identifier(source_table)?);
         let safe_snap = validate_identifier(snapshot_name)?;
         let db = quote_identifier(&self.db_name);
         exec_ddl(
@@ -942,7 +899,7 @@ impl GitForDataService {
     }
 
     pub async fn drop_branch(&self, branch_name: &str) -> Result<(), MemoriaError> {
-        let safe = validate_identifier(branch_name)?;
+        let safe = quote_identifier(validate_identifier(branch_name)?);
         let db = quote_identifier(&self.db_name);
         exec_ddl(&self.pool, &format!("data branch delete table {db}.{safe}")).await
     }
@@ -955,8 +912,8 @@ impl GitForDataService {
         branch_table: &str,
         main_table: &str,
     ) -> Result<(), MemoriaError> {
-        let safe_branch = validate_identifier(branch_table)?;
-        let safe_main = validate_identifier(main_table)?;
+        let safe_branch = quote_identifier(validate_identifier(branch_table)?);
+        let safe_main = quote_identifier(validate_identifier(main_table)?);
         let db = quote_identifier(&self.db_name);
         exec_ddl(
             &self.pool,
@@ -979,8 +936,8 @@ impl GitForDataService {
                 "key_list selector requires at least one key".into(),
             ));
         }
-        let safe_source = validate_identifier(source_table)?;
-        let safe_target = validate_identifier(target_table)?;
+        let safe_source = quote_identifier(validate_identifier(source_table)?);
+        let safe_target = quote_identifier(validate_identifier(target_table)?);
         let conflict = pick_conflict_clause(strategy)?;
         let db = quote_identifier(&self.db_name);
         let key_list = keys
@@ -1005,8 +962,8 @@ impl GitForDataService {
         to_snapshot: &str,
         strategy: &str,
     ) -> Result<(), MemoriaError> {
-        let safe_source = validate_identifier(source_table)?;
-        let safe_target = validate_identifier(target_table)?;
+        let safe_source = quote_identifier(validate_identifier(source_table)?);
+        let safe_target = quote_identifier(validate_identifier(target_table)?);
         let safe_from = validate_identifier(from_snapshot)?;
         let safe_to = validate_identifier(to_snapshot)?;
         let conflict = pick_conflict_clause(strategy)?;
@@ -1067,8 +1024,8 @@ impl GitForDataService {
         limit: i64,
     ) -> Result<Vec<DiffRow>, MemoriaError> {
         let limit = limit.clamp(1, 5_000);
-        let safe_branch = validate_identifier(branch_table)?;
-        let safe_main = validate_identifier(main_table)?;
+        let safe_branch = quote_identifier(validate_identifier(branch_table)?);
+        let safe_main = quote_identifier(validate_identifier(main_table)?);
         let db = quote_identifier(&self.db_name);
         // Fetch more rows than requested to account for user_id filtering in Rust.
         let fetch_limit = limit * 10 + 100;
@@ -1188,9 +1145,8 @@ impl GitForDataService {
     ) -> Result<ApplyResult, MemoriaError> {
         let branch_table = validate_identifier(branch_table)?.to_string();
         let main_table = validate_identifier(main_table)?.to_string();
-        let db = quote_identifier(&self.db_name);
-        let branch_table_ref = format!("{db}.{branch_table}");
-        let main_table_ref = format!("{db}.{main_table}");
+        let branch_table_ref = qualified_identifier(&self.db_name, &branch_table);
+        let main_table_ref = qualified_identifier(&self.db_name, &main_table);
 
         let add_ids: Vec<String> = selection
             .adds
@@ -1647,8 +1603,7 @@ impl GitForDataService {
             return Ok(());
         }
         let main_table = validate_identifier(main_table)?;
-        let db = quote_identifier(&self.db_name);
-        let main_table_ref = format!("{db}.{main_table}");
+        let main_table_ref = qualified_identifier(&self.db_name, main_table);
         let remove_ids: Vec<String> = classified
             .removed
             .iter()
@@ -1696,7 +1651,7 @@ impl GitForDataService {
         snapshot_name: &str,
         user_id: &str,
     ) -> Result<i64, MemoriaError> {
-        let safe_table = validate_identifier(table)?;
+        let safe_table = quote_identifier(validate_identifier(table)?);
         let safe_snap = validate_identifier(snapshot_name)?;
         let row = sqlx::query(&format!(
             "SELECT COUNT(*) AS cnt FROM {safe_table} {{SNAPSHOT = '{safe_snap}'}} WHERE user_id = ?"
@@ -1706,5 +1661,98 @@ impl GitForDataService {
         .await
         .map_err(db_err)?;
         row.try_get::<i64, _>("cnt").map_err(db_err)
+    }
+}
+
+#[cfg(test)]
+mod restore_tests {
+    use super::*;
+
+    #[test]
+    fn restore_future_is_send() {
+        fn assert_send<T: Send>(_: T) {}
+        // Compile-check the futures required by Axum without constructing a pool,
+        // starting a runtime, polling a future, or depending on a database URL.
+        let _check = |git: &GitForDataService| {
+            assert_send(replace_from_stage(
+                &git.pool,
+                "DELETE FROM target",
+                "INSERT INTO target SELECT * FROM stage",
+            ));
+            assert_send(git.restore_table_from_snapshot("memories", "snapshot"));
+        };
+    }
+
+    #[test]
+    fn rollback_failure_preserves_original_statement_error() {
+        for rollback in [Ok(()), Err(sqlx::Error::PoolClosed)] {
+            let error = restore_statement_error(
+                sqlx::Error::Protocol("duplicate key: original failure".into()),
+                rollback,
+            );
+            assert!(error
+                .to_string()
+                .contains("duplicate key: original failure"));
+        }
+    }
+
+    #[test]
+    fn dropping_stage_without_runtime_does_not_panic() {
+        let pool = sqlx::mysql::MySqlPoolOptions::new()
+            .max_lifetime(None)
+            .idle_timeout(None)
+            .connect_lazy_with(sqlx::mysql::MySqlConnectOptions::new());
+        drop(RestoreStage {
+            pool,
+            drop_sql: Some("DROP TABLE IF EXISTS mem_restore_test".into()),
+        });
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a disposable MatrixOne server via DATABASE_URL"]
+    async fn failed_insert_rolls_back_preceding_delete() {
+        let url = std::env::var("DATABASE_URL").expect("DATABASE_URL required");
+        let options: sqlx::mysql::MySqlConnectOptions = url.parse().unwrap();
+        let admin = MySqlPool::connect_with(options.clone().database("mo_catalog"))
+            .await
+            .unwrap();
+        let db = format!("restore_atomic_{}", uuid::Uuid::new_v4().simple());
+        let mut ddl = QueryBuilder::<MySql>::new("CREATE DATABASE ");
+        ddl.push(&db);
+        sqlx::raw_sql(&ddl.into_sql())
+            .execute(&admin)
+            .await
+            .unwrap();
+        let pool = MySqlPool::connect_with(options.database(&db))
+            .await
+            .unwrap();
+        sqlx::raw_sql("CREATE TABLE target (id INT PRIMARY KEY, content VARCHAR(100)); CREATE TABLE stage (id INT, content VARCHAR(100)); INSERT INTO target VALUES (1, 'current'); INSERT INTO stage VALUES (2, 'first'), (2, 'duplicate')").execute(&pool).await.unwrap();
+        let result = replace_from_stage(
+            &pool,
+            "DELETE FROM target",
+            "INSERT INTO target SELECT * FROM stage",
+        )
+        .await;
+        let rows: Vec<(i32, String)> = sqlx::query_as("SELECT id, content FROM target")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        pool.close().await;
+        let mut drop = QueryBuilder::<MySql>::new("DROP DATABASE ");
+        drop.push(&db);
+        sqlx::raw_sql(&drop.into_sql())
+            .execute(&admin)
+            .await
+            .unwrap();
+        let error = result.expect_err("duplicate primary key must fail the INSERT");
+        assert!(
+            error.to_string().to_lowercase().contains("duplicate"),
+            "{error}"
+        );
+        assert_eq!(
+            rows,
+            vec![(1, "current".into())],
+            "DELETE must be rolled back with the failed INSERT"
+        );
     }
 }

--- a/memoria/crates/memoria-git/src/service.rs
+++ b/memoria/crates/memoria-git/src/service.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 use memoria_core::MemoriaError;
 use serde::{Deserialize, Serialize};
-use sqlx::{mysql::MySqlPool, Column, Row};
+use sqlx::{mysql::MySqlPool, Column, Executor, MySql, QueryBuilder, Row};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -9,6 +9,169 @@ use std::sync::{
 
 fn db_err(e: sqlx::Error) -> MemoriaError {
     MemoriaError::Database(e.to_string())
+}
+
+#[cfg(test)]
+mod restore_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn restore_future_is_send() {
+        fn assert_send<T: Send>(_: T) {}
+        let pool = sqlx::mysql::MySqlPoolOptions::new()
+            .connect_lazy("mysql://root:111@127.0.0.1:6001/test")
+            .unwrap();
+        let git = GitForDataService::new(pool, "test");
+        assert_send(replace_from_stage(
+            &git.pool,
+            "DELETE FROM target",
+            "INSERT INTO target SELECT * FROM stage",
+        ));
+        assert_send(git.restore_table_from_snapshot("memories", "snapshot"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a disposable MatrixOne server via DATABASE_URL"]
+    async fn failed_insert_rolls_back_preceding_delete() {
+        let url = std::env::var("DATABASE_URL").expect("DATABASE_URL required");
+        let options: sqlx::mysql::MySqlConnectOptions = url.parse().unwrap();
+        let admin = MySqlPool::connect_with(options.clone().database("mo_catalog"))
+            .await
+            .unwrap();
+        let db = format!("restore_atomic_{}", uuid::Uuid::new_v4().simple());
+        let mut ddl = QueryBuilder::<MySql>::new("CREATE DATABASE ");
+        ddl.push(&db);
+        sqlx::raw_sql(&ddl.into_sql())
+            .execute(&admin)
+            .await
+            .unwrap();
+        let pool = MySqlPool::connect_with(options.database(&db))
+            .await
+            .unwrap();
+        sqlx::raw_sql("CREATE TABLE target (id INT PRIMARY KEY, content VARCHAR(100)); CREATE TABLE stage (id INT, content VARCHAR(100)); INSERT INTO target VALUES (1, 'current'); INSERT INTO stage VALUES (2, 'first'), (2, 'duplicate')").execute(&pool).await.unwrap();
+        let result = replace_from_stage(
+            &pool,
+            "DELETE FROM target",
+            "INSERT INTO target SELECT * FROM stage",
+        )
+        .await;
+        let rows: Vec<(i32, String)> = sqlx::query_as("SELECT id, content FROM target")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        pool.close().await;
+        let mut drop = QueryBuilder::<MySql>::new("DROP DATABASE ");
+        drop.push(&db);
+        sqlx::raw_sql(&drop.into_sql())
+            .execute(&admin)
+            .await
+            .unwrap();
+        let error = result.expect_err("duplicate primary key must fail the INSERT");
+        assert!(
+            error.to_string().to_lowercase().contains("duplicate"),
+            "{error}"
+        );
+        assert_eq!(
+            rows,
+            vec![(1, "current".into())],
+            "DELETE must be rolled back with the failed INSERT"
+        );
+    }
+}
+
+// A staging table is private to one restore, never registered as a user branch.
+// Drop also schedules cleanup when the request future is cancelled.
+struct RestoreStage {
+    pool: MySqlPool,
+    drop_sql: Option<String>,
+}
+
+impl RestoreStage {
+    async fn cleanup(&mut self) {
+        if let Some(sql) = self.drop_sql.as_ref() {
+            match exec_ddl(&self.pool, sql).await {
+                Ok(()) => self.drop_sql = None,
+                Err(error) => {
+                    tracing::warn!(%error, cleanup = %sql, "restore staging cleanup failed")
+                }
+            }
+        }
+    }
+}
+
+impl Drop for RestoreStage {
+    fn drop(&mut self) {
+        if let (Some(sql), Ok(runtime)) =
+            (self.drop_sql.take(), tokio::runtime::Handle::try_current())
+        {
+            let pool = self.pool.clone();
+            runtime.spawn(async move {
+                if let Err(error) = exec_ddl(&pool, &sql).await {
+                    tracing::warn!(%error, cleanup = %sql, "cancelled restore staging cleanup failed");
+                }
+            });
+        }
+    }
+}
+
+/// Both statements operate on live tables: MatrixOne forbids historical snapshot
+/// reads inside a transaction. Materialize those reads before entering here.
+async fn replace_from_stage(
+    pool: &MySqlPool,
+    delete: &str,
+    insert: &str,
+) -> Result<(), MemoriaError> {
+    let mut tx = pool.begin().await.map_err(db_err)?;
+    if let Err(error) = sqlx::query(delete).execute(&mut *tx).await {
+        tx.rollback().await.map_err(db_err)?;
+        return Err(db_err(error));
+    }
+    if let Err(error) = sqlx::query(insert).execute(&mut *tx).await {
+        tx.rollback().await.map_err(db_err)?;
+        return Err(db_err(error));
+    }
+    // Do not retry individual statements or compensate after an ambiguous commit.
+    // The database commits the entire replacement or retains the original rows.
+    tx.commit().await.map_err(db_err)
+}
+
+async fn prepare_and_replace(
+    pool: MySqlPool,
+    stage_table: String,
+    target_table: String,
+    column_list: String,
+    all_columns: String,
+    snapshot: String,
+) -> Result<(), MemoriaError> {
+    let mut create = QueryBuilder::<MySql>::new("CREATE TABLE ");
+    create.push(&stage_table).push(" LIKE ").push(&target_table);
+    exec_ddl(&pool, &create.into_sql()).await?;
+    let mut prepare = QueryBuilder::<MySql>::new("INSERT INTO ");
+    prepare
+        .push(&stage_table)
+        .push(" (")
+        .push(&column_list)
+        .push(") SELECT ")
+        .push(&column_list)
+        .push(" FROM ")
+        .push(&target_table)
+        .push(" {SNAPSHOT = '")
+        .push(snapshot)
+        .push("'}");
+    // All source reads and constraint validation finish before live-row deletion.
+    exec_ddl(&pool, &prepare.into_sql()).await?;
+    let mut delete = QueryBuilder::<MySql>::new("DELETE FROM ");
+    delete.push(&target_table);
+    let mut insert = QueryBuilder::<MySql>::new("INSERT INTO ");
+    insert
+        .push(&target_table)
+        .push(" (")
+        .push(&all_columns)
+        .push(") SELECT ")
+        .push(&all_columns)
+        .push(" FROM ")
+        .push(&stage_table);
+    replace_from_stage(&pool, &delete.into_sql(), &insert.into_sql()).await
 }
 
 /// Look up a column index by name, case-insensitively.
@@ -634,9 +797,9 @@ impl GitForDataService {
         exec_ddl(&self.pool, &format!("DROP SNAPSHOT {safe}")).await
     }
 
-    /// Restore a single table from snapshot (non-destructive alternative to full account restore).
-    /// DELETE current rows + INSERT SELECT from snapshot.
-    /// Workaround for MO#23860: retry on w-w conflict.
+    /// Restore historical data into the current schema. Prepare and validate all
+    /// rows in a private table first, then atomically replace live rows. New
+    /// columns receive the current schema's defaults (subject_id defaults to NULL).
     pub async fn restore_table_from_snapshot(
         &self,
         table: &str,
@@ -652,23 +815,91 @@ impl GitForDataService {
             .await?
             .ok_or_else(|| MemoriaError::NotFound(format!("Snapshot {snapshot_name}")))?;
 
-        // MO#23860: concurrent snapshot restore causes w-w conflict
-        // MO#23861: concurrent snapshot restore loses FULLTEXT INDEX secondary tables
-        // Callers must serialize snapshot operations until these are fixed.
-        //
-        // Note: ideally this would be transactional, but MatrixOne does not
-        // support {SNAPSHOT = '...'} syntax inside transactions. The DELETE+INSERT
-        // is non-atomic; callers should create a safety snapshot before rollback.
-        exec_ddl(&self.pool, &format!("DELETE FROM {qualified_table}")).await?;
-        exec_ddl(
-            &self.pool,
-            &format!(
-                "INSERT INTO {qualified_table} SELECT * FROM {qualified_table} {{SNAPSHOT = '{safe_snap}'}}"
-            ),
+        let mut current_query = QueryBuilder::<MySql>::new("SELECT * FROM ");
+        current_query.push(&qualified_table).push(" LIMIT 0");
+        let current = self
+            .pool
+            .describe(&current_query.into_sql())
+            .await
+            .map_err(db_err)?;
+        let mut historical_query = QueryBuilder::<MySql>::new("SELECT * FROM ");
+        historical_query
+            .push(&qualified_table)
+            .push(" {SNAPSHOT = '")
+            .push(safe_snap)
+            .push("'} LIMIT 0");
+        let historical = self
+            .pool
+            .describe(&historical_query.into_sql())
+            .await
+            .map_err(db_err)?;
+        // Reject missing required fields explicitly: permissive MySQL SQL modes
+        // can otherwise invent implicit zero/empty values for NOT NULL columns.
+        let requirements: Vec<(String, String, Option<String>, String)> = sqlx::query_as(
+            "SELECT COLUMN_NAME, IS_NULLABLE, COLUMN_DEFAULT, EXTRA \
+             FROM information_schema.columns WHERE table_schema = ? AND table_name = ?",
         )
-        .await?;
-
-        Ok(())
+        .bind(&self.db_name)
+        .bind(safe_table)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(db_err)?;
+        for (name, nullable, default, extra) in requirements {
+            if !historical
+                .columns()
+                .iter()
+                .any(|old| old.name().eq_ignore_ascii_case(&name))
+                && nullable == "NO"
+                && default.is_none()
+                && !extra.to_lowercase().contains("auto_increment")
+            {
+                return Err(MemoriaError::Validation(format!(
+                    "Snapshot is missing required column '{name}' without a default"
+                )));
+            }
+        }
+        let columns: Vec<_> = current
+            .columns()
+            .iter()
+            .filter(|column| {
+                historical
+                    .columns()
+                    .iter()
+                    .any(|old| old.name().eq_ignore_ascii_case(column.name()))
+            })
+            .map(|column| quote_identifier(column.name()))
+            .collect();
+        if columns.is_empty() {
+            return Err(MemoriaError::Validation(
+                "Snapshot and current table have no common columns".into(),
+            ));
+        }
+        let column_list = columns.join(", ");
+        let all_columns = current
+            .columns()
+            .iter()
+            .map(|c| quote_identifier(c.name()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let stage_name = format!("mem_restore_{}", uuid::Uuid::new_v4().simple());
+        let stage_table = [db.as_str(), ".", quote_identifier(&stage_name).as_str()].concat();
+        let mut drop_query = QueryBuilder::<MySql>::new("DROP TABLE IF EXISTS ");
+        drop_query.push(&stage_table);
+        let mut stage = RestoreStage {
+            pool: self.pool.clone(),
+            drop_sql: Some(drop_query.sql().to_string()),
+        };
+        let result = prepare_and_replace(
+            self.pool.clone(),
+            stage_table,
+            qualified_table,
+            column_list,
+            all_columns,
+            safe_snap.to_owned(),
+        )
+        .await;
+        stage.cleanup().await;
+        result
     }
 
     // ── Branches ──────────────────────────────────────────────────────────────

--- a/memoria/crates/memoria-git/tests/legacy_snapshot.rs
+++ b/memoria/crates/memoria-git/tests/legacy_snapshot.rs
@@ -7,6 +7,75 @@ use sqlx::{
 };
 
 #[tokio::test]
+async fn native_operations_reject_incompatible_existing_branch_without_mutation() {
+    let f = Fixture::new().await;
+    sqlx::raw_sql("INSERT INTO memories VALUES (1, 'main')")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    f.git
+        .create_branch("br_schema_order", "memories")
+        .await
+        .unwrap();
+    // Simulate a previously registered branch whose startup migration could not
+    // reconcile its schema. Native operations must check it independently.
+    sqlx::raw_sql("ALTER TABLE memories ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL AFTER id")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    sqlx::raw_sql("ALTER TABLE br_schema_order ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    for result in [
+        f.git
+            .merge_branch("br_schema_order", "memories")
+            .await
+            .map(|_| ()),
+        f.git
+            .diff_branch_rows("br_schema_order", "memories", "user", 10)
+            .await
+            .map(|_| ()),
+    ] {
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Branch schema is incompatible"));
+    }
+    assert_eq!(f.rows().await, vec![(1, "main".into(), None)]);
+    f.git.drop_branch("br_schema_order").await.unwrap();
+    f.cleanup().await;
+}
+
+#[tokio::test]
+async fn chinese_snapshot_names_round_trip_without_changing_physical_names() {
+    let mut f = Fixture::new().await;
+    f.snapshot.push_str("_实验");
+    sqlx::raw_sql("INSERT INTO memories VALUES (1, 'historical')")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    f.snapshot().await;
+    assert!(f.git.get_snapshot(&f.snapshot).await.unwrap().is_some());
+    sqlx::raw_sql("UPDATE memories SET content='current'")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    f.git
+        .restore_table_from_snapshot("memories", &f.snapshot)
+        .await
+        .unwrap();
+    let content: String = sqlx::query_scalar("SELECT content FROM memories WHERE id=1")
+        .fetch_one(&f.pool)
+        .await
+        .unwrap();
+    assert_eq!(content, "historical");
+    f.git.drop_snapshot(&f.snapshot).await.unwrap();
+    assert!(f.git.get_snapshot(&f.snapshot).await.unwrap().is_none());
+    f.cleanup().await;
+}
+
+#[tokio::test]
 async fn indexed_snapshot_restores_512_embeddings_and_search_indexes() {
     let f = Fixture::new().await;
     sqlx::raw_sql("ALTER TABLE memories ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL; ALTER TABLE memories ADD COLUMN embedding VECF32(3); ALTER TABLE memories ADD FULLTEXT INDEX ft_content (content) WITH PARSER ngram; ALTER TABLE memories ADD UNIQUE INDEX unique_content (content)")

--- a/memoria/crates/memoria-git/tests/legacy_snapshot.rs
+++ b/memoria/crates/memoria-git/tests/legacy_snapshot.rs
@@ -1,0 +1,286 @@
+//! Cross-schema upgrade regressions. Each test owns a disposable database.
+//! SQLX_OFFLINE=true DATABASE_URL=mysql://root:111@127.0.0.1:16011/test cargo test -p memoria-git --test legacy_snapshot
+use memoria_git::GitForDataService;
+use sqlx::{
+    mysql::{MySqlConnectOptions, MySqlPoolOptions},
+    MySql, MySqlPool, QueryBuilder,
+};
+
+struct Fixture {
+    pool: MySqlPool,
+    admin: MySqlPool,
+    db: String,
+    snapshot: String,
+    git: GitForDataService,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let url = std::env::var("DATABASE_URL").expect("DATABASE_URL required");
+        let options: MySqlConnectOptions = url.parse().unwrap();
+        let admin = MySqlPoolOptions::new()
+            .max_connections(2)
+            .connect_with(options.clone().database("mo_catalog"))
+            .await
+            .unwrap();
+        let db = format!("legacy_restore_{}", uuid::Uuid::new_v4().simple());
+        let mut ddl = QueryBuilder::<MySql>::new("CREATE DATABASE ");
+        ddl.push(&db);
+        sqlx::raw_sql(ddl.sql()).execute(&admin).await.unwrap();
+        let pool = MySqlPoolOptions::new()
+            .max_connections(3)
+            .connect_with(options.database(&db))
+            .await
+            .unwrap();
+        sqlx::raw_sql("CREATE TABLE memories (id INT PRIMARY KEY, content VARCHAR(100) NOT NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let snapshot = format!("legacy_{}", uuid::Uuid::new_v4().simple());
+        let git = GitForDataService::new(pool.clone(), &db);
+        Self {
+            pool,
+            admin,
+            db,
+            snapshot,
+            git,
+        }
+    }
+
+    async fn snapshot(&self) {
+        self.git.create_snapshot(&self.snapshot).await.unwrap();
+    }
+
+    async fn rows(&self) -> Vec<(i32, String, Option<String>)> {
+        sqlx::query_as("SELECT id, content, subject_id FROM memories ORDER BY id")
+            .fetch_all(&self.pool)
+            .await
+            .unwrap()
+    }
+
+    async fn assert_no_stage(&self) {
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name LIKE 'mem_restore_%'")
+            .bind(&self.db).fetch_one(&self.pool).await.unwrap();
+        assert_eq!(count, 0, "restore must clean up private staging tables");
+    }
+
+    async fn cleanup(&self) {
+        let _ = self.git.drop_snapshot(&self.snapshot).await;
+        self.pool.close().await;
+        let mut ddl = QueryBuilder::<MySql>::new("DROP DATABASE IF EXISTS ");
+        ddl.push(&self.db);
+        sqlx::raw_sql(ddl.sql()).execute(&self.admin).await.unwrap();
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let pool = self.admin.clone();
+        let mut snap = QueryBuilder::<MySql>::new("DROP SNAPSHOT IF EXISTS ");
+        snap.push(&self.snapshot);
+        let snap = snap.sql().to_string();
+        let mut db = QueryBuilder::<MySql>::new("DROP DATABASE IF EXISTS ");
+        db.push(&self.db);
+        let db = db.sql().to_string();
+        tokio::spawn(async move {
+            let _ = sqlx::raw_sql(&snap).execute(&pool).await;
+            let _ = sqlx::raw_sql(&db).execute(&pool).await;
+        });
+    }
+}
+
+#[tokio::test]
+async fn legacy_snapshot_restores_by_column_name_and_current_defaults() {
+    let f = Fixture::new().await;
+    sqlx::query("INSERT INTO memories VALUES (1, 'historical')")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    f.snapshot().await;
+    sqlx::raw_sql("ALTER TABLE memories ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL AFTER id")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    sqlx::raw_sql("ALTER TABLE memories ADD COLUMN generation INT NOT NULL DEFAULT 7")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE memories SET content = 'current', subject_id = 'current-subject', generation = 9",
+    )
+    .execute(&f.pool)
+    .await
+    .unwrap();
+    for _ in 0..2 {
+        let result = f
+            .git
+            .restore_table_from_snapshot("memories", &f.snapshot)
+            .await;
+        assert!(
+            result.is_ok(),
+            "{result:?}; current rows: {:?}",
+            f.rows().await
+        );
+        assert_eq!(f.rows().await, vec![(1, "historical".into(), None)]);
+        let generation: i32 = sqlx::query_scalar("SELECT generation FROM memories WHERE id = 1")
+            .fetch_one(&f.pool)
+            .await
+            .unwrap();
+        assert_eq!(generation, 7);
+        f.assert_no_stage().await;
+    }
+    f.cleanup().await;
+}
+
+#[tokio::test]
+async fn legacy_empty_snapshot_restores_to_empty_table() {
+    let f = Fixture::new().await;
+    f.snapshot().await;
+    sqlx::raw_sql("ALTER TABLE memories ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO memories VALUES (1, 'current', 'subject')")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    f.git
+        .restore_table_from_snapshot("memories", &f.snapshot)
+        .await
+        .unwrap();
+    assert!(f.rows().await.is_empty());
+    f.assert_no_stage().await;
+    f.cleanup().await;
+}
+
+#[tokio::test]
+async fn legacy_snapshot_constraint_failure_keeps_current_rows() {
+    let f = Fixture::new().await;
+    sqlx::query("INSERT INTO memories VALUES (1, 'duplicate'), (2, 'duplicate')")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    f.snapshot().await;
+    sqlx::query("DELETE FROM memories")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    sqlx::raw_sql("ALTER TABLE memories ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    sqlx::raw_sql("ALTER TABLE memories ADD UNIQUE KEY unique_content (content)")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO memories VALUES (3, 'keep current', 'subject')")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    assert!(f
+        .git
+        .restore_table_from_snapshot("memories", &f.snapshot)
+        .await
+        .is_err());
+    assert_eq!(
+        f.rows().await,
+        vec![(3, "keep current".into(), Some("subject".into()))]
+    );
+    f.assert_no_stage().await;
+    f.cleanup().await;
+}
+
+#[tokio::test]
+async fn missing_snapshot_keeps_current_rows() {
+    let f = Fixture::new().await;
+    sqlx::raw_sql("ALTER TABLE memories ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO memories VALUES (1, 'keep current', NULL)")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    assert!(f
+        .git
+        .restore_table_from_snapshot("memories", &f.snapshot)
+        .await
+        .is_err());
+    assert_eq!(f.rows().await, vec![(1, "keep current".into(), None)]);
+    f.assert_no_stage().await;
+    f.cleanup().await;
+}
+
+#[tokio::test]
+async fn legacy_snapshot_missing_required_column_fails_before_deletion() {
+    let f = Fixture::new().await;
+    sqlx::query("INSERT INTO memories VALUES (1, 'historical')")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    f.snapshot().await;
+    sqlx::query("DELETE FROM memories")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    sqlx::raw_sql("ALTER TABLE memories ADD COLUMN subject_id VARCHAR(128) NOT NULL")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO memories VALUES (2, 'current', 'must keep')")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    let error = f
+        .git
+        .restore_table_from_snapshot("memories", &f.snapshot)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("required column"), "{error}");
+    assert_eq!(
+        f.rows().await,
+        vec![(2, "current".into(), Some("must keep".into()))]
+    );
+    f.assert_no_stage().await;
+    f.cleanup().await;
+}
+
+#[tokio::test]
+async fn old_select_star_restore_reproduces_column_mismatch() {
+    let f = Fixture::new().await;
+    sqlx::query("INSERT INTO memories VALUES (1, 'historical')")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    f.snapshot().await;
+    sqlx::raw_sql("ALTER TABLE memories ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    // Reproduce the old path only on this test-owned table, then recover it.
+    sqlx::query("DELETE FROM memories")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    let mut old_insert =
+        QueryBuilder::<MySql>::new("INSERT INTO memories SELECT * FROM memories {SNAPSHOT = '");
+    old_insert.push(&f.snapshot).push("'}");
+    let error = sqlx::raw_sql(old_insert.sql())
+        .execute(&f.pool)
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().to_lowercase().contains("column"),
+        "{error}"
+    );
+    assert!(
+        f.rows().await.is_empty(),
+        "old path left the current table empty"
+    );
+    f.git
+        .restore_table_from_snapshot("memories", &f.snapshot)
+        .await
+        .unwrap();
+    assert_eq!(f.rows().await, vec![(1, "historical".into(), None)]);
+    f.cleanup().await;
+}

--- a/memoria/crates/memoria-git/tests/legacy_snapshot.rs
+++ b/memoria/crates/memoria-git/tests/legacy_snapshot.rs
@@ -6,12 +6,180 @@ use sqlx::{
     MySql, MySqlPool, QueryBuilder,
 };
 
+#[tokio::test]
+async fn indexed_snapshot_restores_512_embeddings_and_search_indexes() {
+    let f = Fixture::new().await;
+    sqlx::raw_sql("ALTER TABLE memories ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL; ALTER TABLE memories ADD COLUMN embedding VECF32(3); ALTER TABLE memories ADD FULLTEXT INDEX ft_content (content) WITH PARSER ngram; ALTER TABLE memories ADD UNIQUE INDEX unique_content (content)")
+        .execute(&f.pool).await.unwrap();
+    let mut insert = QueryBuilder::<MySql>::new("INSERT INTO memories (id, content, embedding) ");
+    insert.push_values(0..512, |mut row, id| {
+        row.push_bind(id)
+            .push_bind(format!("historical searchable memory {id}"))
+            .push_bind(format!(
+                "[{}, {}, 0.5]",
+                id as f32 / 512.0,
+                (512 - id) as f32 / 512.0
+            ));
+    });
+    insert.build().execute(&f.pool).await.unwrap();
+    sqlx::raw_sql("CREATE INDEX memories_embedding_ivf USING ivfflat ON memories(embedding) LISTS 10 op_type 'vector_l2_ops'")
+        .execute(&f.pool).await.unwrap();
+    let types: Vec<String> = sqlx::query_scalar("SELECT DISTINCT INDEX_TYPE FROM information_schema.statistics WHERE table_schema = ? AND table_name = 'memories'")
+        .bind(&f.db).fetch_all(&f.pool).await.unwrap();
+    assert!(
+        types.iter().any(|t| t.eq_ignore_ascii_case("ivfflat")),
+        "{types:?}"
+    );
+    assert!(
+        types.iter().any(|t| t.eq_ignore_ascii_case("fulltext")),
+        "{types:?}"
+    );
+    let baseline: Vec<i32> = sqlx::query_scalar(
+        "SELECT id FROM memories WHERE MATCH(content) AGAINST ('+historical' IN BOOLEAN MODE)",
+    )
+    .fetch_all(&f.pool)
+    .await
+    .expect("fulltext search before restore");
+    assert_eq!(baseline.len(), 512);
+    f.snapshot().await;
+    sqlx::raw_sql("UPDATE memories SET content = CONCAT('current ', id), subject_id = 'current'")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    let current: Vec<i32> = sqlx::query_scalar(
+        "SELECT id FROM memories WHERE MATCH(content) AGAINST ('+current' IN BOOLEAN MODE)",
+    )
+    .fetch_all(&f.pool)
+    .await
+    .expect("fulltext search before restore");
+    assert_eq!(current.len(), 512);
+    f.git
+        .restore_table_from_snapshot("memories", &f.snapshot)
+        .await
+        .unwrap();
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM memories WHERE embedding IS NOT NULL AND subject_id IS NULL AND content LIKE 'historical%'")
+        .fetch_one(&f.pool).await.unwrap();
+    assert_eq!(count, 512);
+    let matches: Vec<i32> = sqlx::query_scalar(
+        "SELECT id FROM memories WHERE MATCH(content) AGAINST ('+historical' IN BOOLEAN MODE)",
+    )
+    .fetch_all(&f.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        matches.len(),
+        512,
+        "restored fulltext index must remain searchable"
+    );
+    let nearest: i32 = sqlx::query_scalar(
+        "SELECT id FROM memories ORDER BY l2_distance(embedding, '[0, 1, 0.5]') ASC LIMIT 1",
+    )
+    .fetch_one(&f.pool)
+    .await
+    .unwrap();
+    assert_eq!(nearest, 0);
+    let after: Vec<String> = sqlx::query_scalar("SELECT DISTINCT INDEX_TYPE FROM information_schema.statistics WHERE table_schema = ? AND table_name = 'memories'")
+        .bind(&f.db).fetch_all(&f.pool).await.unwrap();
+    assert!(after.iter().any(|t| t.eq_ignore_ascii_case("ivfflat")));
+    assert!(after.iter().any(|t| t.eq_ignore_ascii_case("fulltext")));
+    // Staging index removal must not relax the live UNIQUE constraint.
+    assert!(sqlx::query(
+        "INSERT INTO memories (id, content) VALUES (900, 'historical searchable memory 0')"
+    )
+    .execute(&f.pool)
+    .await
+    .is_err());
+    f.assert_no_stage().await;
+    f.cleanup().await;
+}
+
 struct Fixture {
     pool: MySqlPool,
     admin: MySqlPool,
     db: String,
     snapshot: String,
     git: GitForDataService,
+}
+
+#[tokio::test]
+async fn branch_index_permission_failure_is_nonfatal_but_missing_column_is_fatal() {
+    let f = Fixture::new().await;
+    sqlx::raw_sql("CREATE TABLE mem_memories (memory_id VARCHAR(64) PRIMARY KEY, user_id VARCHAR(64), subject_id VARCHAR(128), is_active TINYINT, memory_type VARCHAR(20), content TEXT); CREATE TABLE br_index_optional LIKE mem_memories; CREATE TABLE br_column_required LIKE br_index_optional; ALTER TABLE br_column_required DROP COLUMN subject_id")
+        .execute(&f.pool).await.unwrap();
+    let role = format!("restore_role_{}", uuid::Uuid::new_v4().simple());
+    let user = format!("restore_user_{}", uuid::Uuid::new_v4().simple());
+    let mut create_role = QueryBuilder::<MySql>::new("CREATE ROLE ");
+    create_role.push(&role);
+    sqlx::raw_sql(&create_role.into_sql())
+        .execute(&f.admin)
+        .await
+        .unwrap();
+    let mut create_user = QueryBuilder::<MySql>::new("CREATE USER ");
+    create_user
+        .push(&user)
+        .push(" IDENTIFIED BY 'disposable_test_only' DEFAULT ROLE ")
+        .push(&role);
+    sqlx::raw_sql(&create_user.into_sql())
+        .execute(&f.admin)
+        .await
+        .unwrap();
+    for privilege in ["SELECT", "INSERT"] {
+        let mut grant = QueryBuilder::<MySql>::new("GRANT ");
+        grant
+            .push(privilege)
+            .push(" ON TABLE ")
+            .push(&f.db)
+            .push(".* TO ")
+            .push(&role);
+        sqlx::raw_sql(&grant.into_sql())
+            .execute(&f.admin)
+            .await
+            .unwrap();
+    }
+    let options: MySqlConnectOptions = std::env::var("DATABASE_URL").unwrap().parse().unwrap();
+    let limited = MySqlPool::connect_with(
+        options
+            .database(&f.db)
+            .username(&user)
+            .password("disposable_test_only"),
+    )
+    .await
+    .unwrap();
+    // Prove the real DDL failure, not a mock or an already-created index.
+    let denied = sqlx::raw_sql("ALTER TABLE br_index_optional ADD INDEX idx_scope_subject_active (user_id, subject_id, is_active, memory_type)")
+        .execute(&limited).await.unwrap_err();
+    assert!(denied.to_string().contains("privilege"), "{denied}");
+    let store = memoria_storage::SqlMemoryStore::new(limited.clone(), 3, "test".into());
+    let optional = store.ensure_branch_subject_id("br_index_optional").await;
+    let required = store.ensure_branch_subject_id("br_column_required").await;
+    let write = sqlx::query("INSERT INTO br_index_optional VALUES ('memory', 'user', 'subject', 1, 'semantic', 'usable branch')")
+        .execute(&limited).await;
+    let content: String =
+        sqlx::query_scalar("SELECT content FROM br_index_optional WHERE subject_id = 'subject'")
+            .fetch_one(&limited)
+            .await
+            .unwrap();
+    limited.close().await;
+    let mut drop_user = QueryBuilder::<MySql>::new("DROP USER ");
+    drop_user.push(&user);
+    sqlx::raw_sql(&drop_user.into_sql())
+        .execute(&f.admin)
+        .await
+        .unwrap();
+    let mut drop_role = QueryBuilder::<MySql>::new("DROP ROLE ");
+    drop_role.push(&role);
+    sqlx::raw_sql(&drop_role.into_sql())
+        .execute(&f.admin)
+        .await
+        .unwrap();
+    f.cleanup().await;
+    assert!(
+        optional.is_ok(),
+        "index failure must not reject a usable branch: {optional:?}"
+    );
+    assert!(required.is_err(), "missing subject_id must remain fatal");
+    assert!(write.is_ok());
+    assert_eq!(content, "usable branch");
 }
 
 impl Fixture {
@@ -150,6 +318,31 @@ async fn legacy_empty_snapshot_restores_to_empty_table() {
         .unwrap();
     assert!(f.rows().await.is_empty());
     f.assert_no_stage().await;
+    f.cleanup().await;
+}
+
+#[tokio::test]
+async fn restore_without_unique_keys_preserves_duplicate_row_count() {
+    let f = Fixture::new().await;
+    sqlx::raw_sql("CREATE TABLE unkeyed (content VARCHAR(100) NOT NULL); INSERT INTO unkeyed VALUES ('historical'), ('historical')")
+        .execute(&f.pool).await.unwrap();
+    f.snapshot().await;
+    sqlx::raw_sql("DELETE FROM unkeyed; INSERT INTO unkeyed VALUES ('current')")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    for _ in 0..2 {
+        f.git
+            .restore_table_from_snapshot("unkeyed", &f.snapshot)
+            .await
+            .unwrap();
+        let rows: Vec<String> = sqlx::query_scalar("SELECT content FROM unkeyed")
+            .fetch_all(&f.pool)
+            .await
+            .unwrap();
+        assert_eq!(rows, vec!["historical", "historical"]);
+        f.assert_no_stage().await;
+    }
     f.cleanup().await;
 }
 

--- a/memoria/crates/memoria-git/tests/legacy_snapshot.rs
+++ b/memoria/crates/memoria-git/tests/legacy_snapshot.rs
@@ -171,6 +171,122 @@ struct Fixture {
 }
 
 #[tokio::test]
+async fn branch_alter_probe_success_cleans_up_and_keeps_user_rows() {
+    let f = Fixture::new().await;
+    sqlx::raw_sql("INSERT INTO memories VALUES (1, 'user data')")
+        .execute(&f.pool)
+        .await
+        .unwrap();
+    let store = memoria_storage::SqlMemoryStore::new(f.pool.clone(), 3, "probe-test".into());
+    // Concurrent callers share a probe; repeated callers reuse its result.
+    let (a, b) = tokio::join!(
+        store.ensure_native_branch_alter_capability(),
+        store.ensure_native_branch_alter_capability()
+    );
+    a.unwrap();
+    b.unwrap();
+    store.ensure_native_branch_alter_capability().await.unwrap();
+    let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name LIKE 'mem_lineage_probe_%'")
+        .bind(&f.db).fetch_one(&f.pool).await.unwrap();
+    assert_eq!(remaining, 0);
+    let content: String = sqlx::query_scalar("SELECT content FROM memories WHERE id=1")
+        .fetch_one(&f.pool)
+        .await
+        .unwrap();
+    assert_eq!(content, "user data");
+    f.cleanup().await;
+}
+
+#[tokio::test]
+async fn failed_probe_prevents_permitted_user_branch_alter() {
+    let f = Fixture::new().await;
+    sqlx::raw_sql("CREATE TABLE mem_memories (memory_id VARCHAR(64) PRIMARY KEY,user_id VARCHAR(64),is_active TINYINT,memory_type VARCHAR(20),content TEXT); INSERT INTO mem_memories VALUES ('old','user',1,'semantic','untouched')")
+        .execute(&f.pool).await.unwrap();
+    f.git
+        .create_branch("br_guarded", "mem_memories")
+        .await
+        .unwrap();
+    sqlx::raw_sql(
+        "ALTER TABLE mem_memories ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL AFTER user_id",
+    )
+    .execute(&f.pool)
+    .await
+    .unwrap();
+    let role = format!("probe_role_{}", uuid::Uuid::new_v4().simple());
+    let user = format!("probe_user_{}", uuid::Uuid::new_v4().simple());
+    sqlx::raw_sql(&format!("CREATE ROLE {role}"))
+        .execute(&f.admin)
+        .await
+        .unwrap();
+    sqlx::raw_sql(&format!(
+        "CREATE USER {user} IDENTIFIED BY 'disposable_test_only' DEFAULT ROLE {role}"
+    ))
+    .execute(&f.admin)
+    .await
+    .unwrap();
+    // ALTER is deliberately allowed. Failure must come from the preflight,
+    // not from permission-denied on the actual user branch mutation.
+    for privilege in ["SELECT", "INSERT"] {
+        sqlx::raw_sql(&format!("GRANT {privilege} ON TABLE {}.* TO {role}", f.db))
+            .execute(&f.admin)
+            .await
+            .unwrap();
+    }
+    sqlx::raw_sql(&format!("GRANT ALTER TABLE ON DATABASE {} TO {role}", f.db))
+        .execute(&f.admin)
+        .await
+        .unwrap();
+    let options: MySqlConnectOptions = std::env::var("DATABASE_URL").unwrap().parse().unwrap();
+    let limited = MySqlPool::connect_with(
+        options
+            .database(&f.db)
+            .username(&user)
+            .password("disposable_test_only"),
+    )
+    .await
+    .unwrap();
+    sqlx::raw_sql("ALTER TABLE memories ADD COLUMN allowed_control INT")
+        .execute(&limited)
+        .await
+        .expect("role really can ALTER existing tables");
+    let store = memoria_storage::SqlMemoryStore::new(limited.clone(), 3, "guard-test".into());
+    let error = store
+        .ensure_branch_subject_id("br_guarded")
+        .await
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("Native branch ALTER capability could not be verified"),
+        "{error}"
+    );
+    let subject_columns: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema=? AND table_name='br_guarded' AND column_name='subject_id'")
+        .bind(&f.db).fetch_one(&f.pool).await.unwrap();
+    assert_eq!(
+        subject_columns, 0,
+        "must not ALTER the user branch before capability is known"
+    );
+    let content: String =
+        sqlx::query_scalar("SELECT content FROM br_guarded WHERE memory_id='old'")
+            .fetch_one(&f.pool)
+            .await
+            .unwrap();
+    assert_eq!(content, "untouched");
+    // Its lineage is intact and native cleanup remains available.
+    f.git.drop_branch("br_guarded").await.unwrap();
+    limited.close().await;
+    sqlx::raw_sql(&format!("DROP USER {user}"))
+        .execute(&f.admin)
+        .await
+        .unwrap();
+    sqlx::raw_sql(&format!("DROP ROLE {role}"))
+        .execute(&f.admin)
+        .await
+        .unwrap();
+    f.cleanup().await;
+}
+
+#[tokio::test]
 async fn branch_index_permission_failure_is_nonfatal_but_missing_column_is_fatal() {
     let f = Fixture::new().await;
     sqlx::raw_sql("CREATE TABLE mem_memories (memory_id VARCHAR(64) PRIMARY KEY, user_id VARCHAR(64), subject_id VARCHAR(128), is_active TINYINT, memory_type VARCHAR(20), content TEXT); CREATE TABLE br_index_optional LIKE mem_memories; CREATE TABLE br_column_required LIKE br_index_optional; ALTER TABLE br_column_required DROP COLUMN subject_id")

--- a/memoria/crates/memoria-mcp/src/git_tools.rs
+++ b/memoria/crates/memoria-mcp/src/git_tools.rs
@@ -33,7 +33,7 @@ fn git_err(e: impl std::fmt::Display) -> MemoriaError {
 }
 
 fn validate_identifier(name: &str) -> Result<&str, MemoriaError> {
-    if !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+    if memoria_core::is_safe_sql_identifier(name) {
         Ok(name)
     } else {
         Err(MemoriaError::Internal(format!(
@@ -98,6 +98,23 @@ fn sanitize_name(name: &str) -> String {
         clean = format!("s_{clean}");
     }
     clean
+}
+
+fn sanitize_branch_table_suffix(name: &str) -> String {
+    // Keep the previous spelling for ASCII names; only physical branch suffixes
+    // change for Unicode names. The random prefix disambiguates equal suffixes.
+    let ascii: String = name
+        .chars()
+        .take(40)
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    sanitize_name(&ascii)
 }
 
 fn sanitize_snapshot_scope(scope: &str) -> String {
@@ -1046,7 +1063,10 @@ pub async fn call(
                 return Ok(mcp_text(&format!("Branch '{branch_name}' already exists.")));
             }
 
-            let safe = sanitize_name(branch_name);
+            // Physical branch names are ASCII; the registry preserves the user's
+            // original display name. Do not change sanitize_name: snapshots use
+            // its historical Unicode mapping when resolving existing names.
+            let safe = sanitize_branch_table_suffix(branch_name);
             let table_name = format!("br_{}_{}", &Uuid::new_v4().simple().to_string()[..8], safe);
 
             if let Some(snap) = from_snapshot {
@@ -2516,6 +2536,21 @@ fn parse_apply_updates(args: &Value) -> Result<Vec<memoria_git::ApplyUpdatePair>
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn branch_suffix_is_ascii_without_changing_unicode_snapshot_names() {
+        for name in ["实验", "café", "分支 / 测试", "🚀"] {
+            let suffix = super::sanitize_branch_table_suffix(name);
+            assert!(suffix.is_ascii());
+            assert!(memoria_core::is_safe_sql_identifier(&suffix));
+        }
+        assert_eq!(
+            super::sanitize_branch_table_suffix("my_branch-1"),
+            super::sanitize_name("my_branch-1")
+        );
+        assert_eq!(super::sanitize_name("实验"), "实验");
+        assert!(super::snap_internal("test", "实验").ends_with("_实验"));
+    }
+
     use super::{
         expect_tool_args, is_pick_conflict_error_message, is_pick_parser_error_message,
         map_pick_conflict, normalize_keys, parse_apply_string_array, parse_apply_updates,

--- a/memoria/crates/memoria-mcp/src/git_tools.rs
+++ b/memoria/crates/memoria-mcp/src/git_tools.rs
@@ -1223,10 +1223,10 @@ pub async fn call(
                 "INSERT INTO {main_table} \
                     (memory_id, user_id, memory_type, content, embedding, session_id, \
                      source_event_ids, extra_metadata, is_active, superseded_by, \
-                     trust_tier, initial_confidence, observed_at, created_at, updated_at) \
+                     trust_tier, initial_confidence, observed_at, created_at, updated_at, author_id, subject_id) \
                   SELECT b.memory_id, b.user_id, b.memory_type, b.content, b.embedding, b.session_id, \
                       b.source_event_ids, b.extra_metadata, b.is_active, b.superseded_by, \
-                      b.trust_tier, b.initial_confidence, b.observed_at, b.created_at, b.updated_at \
+                      b.trust_tier, b.initial_confidence, b.observed_at, b.created_at, b.updated_at, b.author_id, b.subject_id \
                   FROM {branch_table} b \
                   WHERE b.user_id = ? AND b.is_active = 1 \
                     AND NOT EXISTS (SELECT 1 FROM {main_table} m WHERE m.memory_id = b.memory_id) \
@@ -1237,6 +1237,7 @@ pub async fn call(
                         WHERE m.user_id = ? AND m.is_active = 1 \
                           AND m.embedding IS NOT NULL AND vector_dims(m.embedding) > 0 \
                           AND m.memory_type = b.memory_type \
+                          AND m.subject_id <=> b.subject_id \
                           AND l2_distance(m.embedding, b.embedding) < {L2_CONFLICT} \
                       ) \
                    )"
@@ -1776,6 +1777,7 @@ async fn collect_replace_candidates(
            ON b.user_id = ? AND b.is_active = 1 \
            AND b.content IS NOT NULL \
            AND b.memory_type = m.memory_type \
+           AND b.subject_id <=> m.subject_id \
            AND b.embedding IS NOT NULL AND vector_dims(b.embedding) > 0 \
          WHERE m.user_id = ? AND m.is_active = 1 \
            AND m.embedding IS NOT NULL AND vector_dims(m.embedding) > 0 \

--- a/memoria/crates/memoria-mcp/src/git_tools.rs
+++ b/memoria/crates/memoria-mcp/src/git_tools.rs
@@ -1050,15 +1050,20 @@ pub async fn call(
             let table_name = format!("br_{}_{}", &Uuid::new_v4().simple().to_string()[..8], safe);
 
             if let Some(snap) = from_snapshot {
-                // Create branch from snapshot: restore snapshot to temp, then branch.
-                // Source is always mem_memories — new branch inherits its schema including
-                // subject_id, so no post-create column migration is needed.
+                // Snapshot clones inherit the historical schema, which may predate
+                // subject_id. Reconcile it before the branch becomes visible.
                 let internal = resolve_snapshot_for_user(svc, user_id, snap)
                     .await?
                     .ok_or_else(|| MemoriaError::NotFound(format!("Snapshot '{snap}'")))?;
                 git.create_branch_from_snapshot(&table_name, "mem_memories", &internal)
                     .await
                     .map_err(git_err)?;
+                if let Err(error) = sql.ensure_branch_subject_id(&table_name).await {
+                    if let Err(cleanup_error) = git.drop_branch(&table_name).await {
+                        tracing::warn!(%cleanup_error, table = %table_name, "failed to clean up incompatible snapshot branch");
+                    }
+                    return Err(error);
+                }
             } else {
                 // Source is always mem_memories (never another branch table).
                 // schema.subject_id is guaranteed present after migrate_user(), so MO's

--- a/memoria/crates/memoria-mcp/tests/branch_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/branch_e2e.rs
@@ -233,8 +233,8 @@ async fn test_legacy_snapshot_branch_migration_failure_does_not_register_clone()
         .execute(&pool)
         .await
         .unwrap();
-    // An incompatible historical type column forces the branch-index migration
-    // to fail after cloning; the registered current schema remains valid.
+    // A missing base column must be rejected independently of the best-effort
+    // subject index. The current schema remains valid throughout the clone.
     sqlx::raw_sql(
         "ALTER TABLE mem_memories CHANGE COLUMN memory_type historical_type VARCHAR(20) NOT NULL",
     )
@@ -265,7 +265,11 @@ async fn test_legacy_snapshot_branch_migration_failure_does_not_register_clone()
         &uid,
     )
     .await;
-    assert!(result.is_err(), "incompatible clone must not be exposed");
+    let error = result.expect_err("incompatible clone must not be exposed");
+    assert!(
+        error.to_string().contains("required column 'memory_type'"),
+        "{error}"
+    );
     assert!(store.list_branches(&uid).await.unwrap().is_empty());
     let clones: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name LIKE 'br_%'").fetch_one(&pool).await.unwrap();
     assert_eq!(clones, 0, "failed migration must clean up its clone");
@@ -311,6 +315,180 @@ async fn test_basic_branch_workflow() {
         &uid,
     )
     .await;
+}
+
+#[tokio::test]
+async fn test_unicode_branch_names_work_with_and_without_snapshot() {
+    let (svc, git, uid, ctx) = setup().await;
+    let store = ctx.user_store(&uid).await;
+    store_mem("main original", &svc, &uid).await;
+    gc(
+        "memory_snapshot",
+        json!({"name":"unicode_branch_source"}),
+        &git,
+        &svc,
+        &uid,
+    )
+    .await;
+    for (name, from_snapshot) in [("实验", false), ("测试", true)] {
+        let args = if from_snapshot {
+            json!({"name":name, "from_snapshot":"unicode_branch_source"})
+        } else {
+            json!({"name":name})
+        };
+        let result = gc("memory_branch", args, &git, &svc, &uid).await;
+        assert!(text(&result).contains("Created"), "{result}");
+        let branches = store.list_branches(&uid).await.unwrap();
+        let (_, physical, _) = branches
+            .iter()
+            .find(|(display, _, _)| display == name)
+            .unwrap();
+        assert!(physical.is_ascii(), "{physical}");
+        gc("memory_checkout", json!({"name":name}), &git, &svc, &uid).await;
+        assert_eq!(svc.list_active(&uid, 10).await.unwrap().len(), 1);
+        store_mem("branch write", &svc, &uid).await;
+        assert_eq!(svc.list_active(&uid, 10).await.unwrap().len(), 2);
+        gc("memory_checkout", json!({"name":"main"}), &git, &svc, &uid).await;
+        assert_eq!(svc.list_active(&uid, 10).await.unwrap().len(), 1);
+    }
+    let branches = store.list_branches(&uid).await.unwrap();
+    assert_eq!(branches.len(), 2);
+    assert_ne!(
+        branches[0].1, branches[1].1,
+        "equal sanitized suffixes must not collide"
+    );
+}
+
+#[tokio::test]
+async fn test_existing_unicode_physical_branch_migrates_and_remains_usable() {
+    let (svc, git, uid, ctx) = setup().await;
+    let store = ctx.user_store(&uid).await;
+    let pool = ctx.user_db_pool(&uid).await;
+    // Model an already-existing quoted physical table. New branches must never
+    // ask MO's native clone operation to generate a Unicode destination name.
+    sqlx::raw_sql("CREATE TABLE `br_1234abcd_实验` LIKE mem_memories; ALTER TABLE `br_1234abcd_实验` DROP INDEX idx_scope_subject_active; ALTER TABLE `br_1234abcd_实验` DROP COLUMN subject_id")
+        .execute(&pool).await.unwrap();
+    // Validate the historical-clone path, then the startup path for an already
+    // registered old table. Neither may reject Unicode physical identifiers.
+    store
+        .ensure_branch_subject_id("br_1234abcd_实验")
+        .await
+        .unwrap();
+    sqlx::raw_sql("ALTER TABLE `br_1234abcd_实验` DROP INDEX idx_scope_subject_active; ALTER TABLE `br_1234abcd_实验` DROP COLUMN subject_id")
+        .execute(&pool).await.unwrap();
+    store
+        .register_branch(&uid, "已有实验", "br_1234abcd_实验")
+        .await
+        .unwrap();
+    store.migrate_user().await.unwrap();
+    gc(
+        "memory_checkout",
+        json!({"name":"已有实验"}),
+        &git,
+        &svc,
+        &uid,
+    )
+    .await;
+    store_mem("write after legacy Unicode migration", &svc, &uid).await;
+    assert_eq!(svc.list_active(&uid, 10).await.unwrap().len(), 1);
+    gc("memory_checkout", json!({"name":"main"}), &git, &svc, &uid).await;
+    gc(
+        "memory_merge",
+        json!({"source":"已有实验"}),
+        &git,
+        &svc,
+        &uid,
+    )
+    .await;
+    assert_eq!(svc.list_active(&uid, 10).await.unwrap().len(), 1);
+    gc(
+        "memory_branch_delete",
+        json!({"name":"已有实验"}),
+        &git,
+        &svc,
+        &uid,
+    )
+    .await;
+    assert!(store.list_branches(&uid).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_historical_branch_rejects_all_missing_live_columns_before_registration() {
+    for column in [
+        "source_event_ids",
+        "observed_at",
+        "created_at",
+        "embedding",
+        "updated_at",
+        "extra_metadata",
+        "trust_tier",
+    ] {
+        let (svc, git, uid, ctx) = setup().await;
+        let store = ctx.user_store(&uid).await;
+        let pool = ctx.user_db_pool(&uid).await;
+        // Rename rather than remove data; schema is deliberately broken only
+        // while taking the snapshot, then restored before the user operation.
+        let definition = match column {
+            "source_event_ids" => "JSON NOT NULL",
+            "observed_at" | "created_at" => "DATETIME(6) NOT NULL",
+            "updated_at" => "DATETIME(6)",
+            "embedding" => "VECF32(8)",
+            "extra_metadata" => "JSON",
+            "trust_tier" => "VARCHAR(10) DEFAULT 'T1'",
+            _ => unreachable!(),
+        };
+        // Obtain the actual vector dimension from the test environment.
+        let mut vector_type = sqlx::QueryBuilder::<sqlx::MySql>::new("VECF32(");
+        vector_type.push(test_dim()).push(")");
+        let vector_definition = vector_type.into_sql();
+        let definition = if column == "embedding" {
+            &vector_definition
+        } else {
+            definition
+        };
+        let mut rename =
+            sqlx::QueryBuilder::<sqlx::MySql>::new("ALTER TABLE mem_memories CHANGE COLUMN ");
+        rename
+            .push(column)
+            .push(" historical_missing ")
+            .push(definition);
+        sqlx::raw_sql(&rename.into_sql())
+            .execute(&pool)
+            .await
+            .unwrap();
+        gc(
+            "memory_snapshot",
+            json!({"name":"missing_column"}),
+            &git,
+            &svc,
+            &uid,
+        )
+        .await;
+        let mut restore = sqlx::QueryBuilder::<sqlx::MySql>::new(
+            "ALTER TABLE mem_memories CHANGE COLUMN historical_missing ",
+        );
+        restore.push(column).push(" ").push(definition);
+        sqlx::raw_sql(&restore.into_sql())
+            .execute(&pool)
+            .await
+            .unwrap();
+        let result = memoria_mcp::git_tools::call(
+            "memory_branch",
+            json!({"name":"rejected", "from_snapshot":"missing_column"}),
+            &git,
+            &svc,
+            &uid,
+        )
+        .await;
+        let error = result.expect_err("must reject an incomplete clone before registration");
+        assert!(error.to_string().contains(column), "{column}: {error}");
+        assert!(store.list_branches(&uid).await.unwrap().is_empty());
+        let clones: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name LIKE 'br_%'")
+            .fetch_one(&pool).await.unwrap();
+        assert_eq!(clones, 0, "{column}: rejected clone must be cleaned");
+        store_mem("main remains usable", &svc, &uid).await;
+        assert_eq!(svc.list_active(&uid, 10).await.unwrap().len(), 1);
+    }
 }
 
 #[tokio::test]

--- a/memoria/crates/memoria-mcp/tests/branch_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/branch_e2e.rs
@@ -137,6 +137,142 @@ fn pick_result_or_skip(result: Result<Value, MemoriaError>, test_name: &str) -> 
 // ── 1. Basic workflow: create → checkout → store → checkout main → merge ──────
 
 #[tokio::test]
+async fn test_legacy_snapshot_branch_and_rollback_after_subject_migration() {
+    let (svc, git, uid, ctx) = setup().await;
+    let store = ctx.user_store(&uid).await;
+    let pool = ctx.user_db_pool(&uid).await;
+    store_mem("historical memory before schema upgrade", &svc, &uid).await;
+    // Reconstruct the v0.4 memory schema before taking the historical snapshot.
+    sqlx::raw_sql("ALTER TABLE mem_memories DROP INDEX idx_scope_subject_active")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::raw_sql("ALTER TABLE mem_memories DROP COLUMN subject_id")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let snapshot = bname("legacy");
+    gc(
+        "memory_snapshot",
+        json!({"name": snapshot}),
+        &git,
+        &svc,
+        &uid,
+    )
+    .await;
+    store.migrate_user().await.unwrap();
+    store_mem("current memory after schema upgrade", &svc, &uid).await;
+    let branch = bname("legacybranch");
+    let result = gc(
+        "memory_branch",
+        json!({"name": branch, "from_snapshot": snapshot}),
+        &git,
+        &svc,
+        &uid,
+    )
+    .await;
+    assert!(text(&result).contains("Created"), "{result}");
+    gc("memory_checkout", json!({"name": branch}), &git, &svc, &uid).await;
+    let memories = svc.list_active(&uid, 10).await.unwrap();
+    assert_eq!(memories.len(), 1);
+    assert_eq!(
+        memories[0].content,
+        "historical memory before schema upgrade"
+    );
+    assert_eq!(memories[0].subject_id, None);
+    memoria_mcp::tools::call(
+        "memory_store",
+        json!({"content":"branch write after migration", "subject_id":"restored-subject"}),
+        &svc,
+        &uid,
+    )
+    .await
+    .unwrap();
+    let memories = svc.list_active(&uid, 10).await.unwrap();
+    assert_eq!(memories.len(), 2);
+    assert_eq!(
+        memories
+            .iter()
+            .find(|m| m.content == "branch write after migration")
+            .unwrap()
+            .subject_id
+            .as_deref(),
+        Some("restored-subject")
+    );
+    gc("memory_checkout", json!({"name": "main"}), &git, &svc, &uid).await;
+    assert_eq!(svc.list_active(&uid, 10).await.unwrap().len(), 2);
+    gc(
+        "memory_rollback",
+        json!({"name": snapshot}),
+        &git,
+        &svc,
+        &uid,
+    )
+    .await;
+    let memories = svc.list_active(&uid, 10).await.unwrap();
+    assert_eq!(memories.len(), 1);
+    assert_eq!(
+        memories[0].content,
+        "historical memory before schema upgrade"
+    );
+    store_mem("main write after legacy rollback", &svc, &uid).await;
+    assert_eq!(svc.list_active(&uid, 10).await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn test_legacy_snapshot_branch_migration_failure_does_not_register_clone() {
+    let (svc, git, uid, ctx) = setup().await;
+    let store = ctx.user_store(&uid).await;
+    let pool = ctx.user_db_pool(&uid).await;
+    store_mem("keep current memory on migration failure", &svc, &uid).await;
+    sqlx::raw_sql("ALTER TABLE mem_memories DROP INDEX idx_scope_subject_active")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::raw_sql("ALTER TABLE mem_memories DROP COLUMN subject_id")
+        .execute(&pool)
+        .await
+        .unwrap();
+    // An incompatible historical type column forces the branch-index migration
+    // to fail after cloning; the registered current schema remains valid.
+    sqlx::raw_sql(
+        "ALTER TABLE mem_memories CHANGE COLUMN memory_type historical_type VARCHAR(20) NOT NULL",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    let snapshot = bname("incompatible");
+    gc(
+        "memory_snapshot",
+        json!({"name":snapshot}),
+        &git,
+        &svc,
+        &uid,
+    )
+    .await;
+    sqlx::raw_sql(
+        "ALTER TABLE mem_memories CHANGE COLUMN historical_type memory_type VARCHAR(20) NOT NULL",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    store.migrate_user().await.unwrap();
+    let result = memoria_mcp::git_tools::call(
+        "memory_branch",
+        json!({"name":"rejected", "from_snapshot":snapshot}),
+        &git,
+        &svc,
+        &uid,
+    )
+    .await;
+    assert!(result.is_err(), "incompatible clone must not be exposed");
+    assert!(store.list_branches(&uid).await.unwrap().is_empty());
+    let clones: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name LIKE 'br_%'").fetch_one(&pool).await.unwrap();
+    assert_eq!(clones, 0, "failed migration must clean up its clone");
+    assert_eq!(svc.list_active(&uid, 10).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
 async fn test_basic_branch_workflow() {
     let (svc, git, uid, _ctx) = setup().await;
     let branch = bname("basic");

--- a/memoria/crates/memoria-mcp/tests/branch_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/branch_e2e.rs
@@ -364,9 +364,11 @@ async fn test_existing_unicode_physical_branch_migrates_and_remains_usable() {
     let (svc, git, uid, ctx) = setup().await;
     let store = ctx.user_store(&uid).await;
     let pool = ctx.user_db_pool(&uid).await;
-    // Model an already-existing quoted physical table. New branches must never
-    // ask MO's native clone operation to generate a Unicode destination name.
-    sqlx::raw_sql("CREATE TABLE `br_1234abcd_实验` LIKE mem_memories; ALTER TABLE `br_1234abcd_实验` DROP INDEX idx_scope_subject_active; ALTER TABLE `br_1234abcd_实验` DROP COLUMN subject_id")
+    // Model a real native branch with a legacy Unicode physical name. A plain
+    // CREATE TABLE LIKE has no branch lineage and newer MO correctly rejects
+    // DATA BRANCH DELETE on it. Clone to ASCII first, then rename: older MO's
+    // native clone parser cannot create a Unicode destination directly.
+    sqlx::raw_sql("DATA BRANCH CREATE TABLE br_1234abcd_legacy FROM mem_memories; ALTER TABLE br_1234abcd_legacy RENAME TO `br_1234abcd_实验`; ALTER TABLE `br_1234abcd_实验` DROP INDEX idx_scope_subject_active; ALTER TABLE `br_1234abcd_实验` DROP COLUMN subject_id")
         .execute(&pool).await.unwrap();
     // Validate the historical-clone path, then the startup path for an already
     // registered old table. Neither may reject Unicode physical identifiers.
@@ -410,6 +412,13 @@ async fn test_existing_unicode_physical_branch_migrates_and_remains_usable() {
     )
     .await;
     assert!(store.list_branches(&uid).await.unwrap().is_empty());
+    let remaining: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'br_1234abcd_实验'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(remaining, 0, "native branch deletion must remove the table");
 }
 
 #[tokio::test]

--- a/memoria/crates/memoria-mcp/tests/branch_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/branch_e2e.rs
@@ -368,16 +368,28 @@ async fn test_existing_unicode_physical_branch_migrates_and_remains_usable() {
     // CREATE TABLE LIKE has no branch lineage and newer MO correctly rejects
     // DATA BRANCH DELETE on it. Clone to ASCII first, then rename: older MO's
     // native clone parser cannot create a Unicode destination directly.
-    sqlx::raw_sql("DATA BRANCH CREATE TABLE br_1234abcd_legacy FROM mem_memories; ALTER TABLE br_1234abcd_legacy RENAME TO `br_1234abcd_实验`; ALTER TABLE `br_1234abcd_实验` DROP INDEX idx_scope_subject_active; ALTER TABLE `br_1234abcd_实验` DROP COLUMN subject_id")
-        .execute(&pool).await.unwrap();
+    // Execute native DDL separately: MO 3.0.11's branch parser inspects the
+    // original SQL text and cannot handle it inside a multi-statement request.
+    for statement in [
+        "DATA BRANCH CREATE TABLE br_1234abcd_legacy FROM mem_memories",
+        "ALTER TABLE br_1234abcd_legacy RENAME TO `br_1234abcd_实验`",
+        "ALTER TABLE `br_1234abcd_实验` DROP INDEX idx_scope_subject_active",
+        "ALTER TABLE `br_1234abcd_实验` DROP COLUMN subject_id",
+    ] {
+        sqlx::raw_sql(statement).execute(&pool).await.unwrap();
+    }
     // Validate the historical-clone path, then the startup path for an already
     // registered old table. Neither may reject Unicode physical identifiers.
     store
         .ensure_branch_subject_id("br_1234abcd_实验")
         .await
         .unwrap();
-    sqlx::raw_sql("ALTER TABLE `br_1234abcd_实验` DROP INDEX idx_scope_subject_active; ALTER TABLE `br_1234abcd_实验` DROP COLUMN subject_id")
-        .execute(&pool).await.unwrap();
+    for statement in [
+        "ALTER TABLE `br_1234abcd_实验` DROP INDEX idx_scope_subject_active",
+        "ALTER TABLE `br_1234abcd_实验` DROP COLUMN subject_id",
+    ] {
+        sqlx::raw_sql(statement).execute(&pool).await.unwrap();
+    }
     store
         .register_branch(&uid, "已有实验", "br_1234abcd_实验")
         .await

--- a/memoria/crates/memoria-mcp/tests/branch_scope_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/branch_scope_e2e.rs
@@ -312,6 +312,66 @@ async fn existing_parent_and_branch_migrate_with_lineage_intact() {
 }
 
 #[tokio::test]
+async fn unicode_pre_author_branch_migrates_and_remains_usable() {
+    let (ctx, pool, _) = fixture(false).await;
+    call(&ctx, "memory_branch_delete", json!({"name":"工作分支"})).await;
+    // Reconstruct a pre-author/pre-subject deployment BEFORE cloning, so both
+    // tables inherit the same native column identities and legacy data.
+    for ddl in [
+        "ALTER TABLE mem_memories DROP INDEX idx_author",
+        "ALTER TABLE mem_memories DROP COLUMN author_id",
+        "ALTER TABLE mem_memories DROP INDEX idx_scope_subject_active",
+        "ALTER TABLE mem_memories DROP COLUMN subject_id",
+        "UPDATE mem_schema_meta SET schema_version=1 WHERE schema_key='user_schema'",
+        "DATA BRANCH CREATE TABLE br_1234abcd_legacy FROM mem_memories",
+        "ALTER TABLE br_1234abcd_legacy RENAME TO `br_1234abcd_实验`",
+    ] {
+        sqlx::raw_sql(ddl).execute(&pool).await.unwrap();
+    }
+    let branch = "br_1234abcd_实验";
+    let store = ctx.user_store(&ctx.user).await;
+    store.register_branch(&ctx.user, "工作分支", branch).await.unwrap();
+    store.migrate_user().await.unwrap();
+    // Check the first upgrade, not just a later restart that could mask a
+    // skipped compatibility migration by seeing a current schema version.
+    for table in ["mem_memories", branch] {
+        let count: i64 = sqlx::query_scalar(&format!(
+            "SELECT COUNT(*) FROM `{table}` WHERE subject_id IS NULL AND author_id IS NULL"
+        ))
+        .fetch_one(&pool).await.unwrap();
+        assert_eq!(count, 4, "legacy data must remain on {table}");
+        let index: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema=DATABASE() AND table_name=? AND index_name='idx_author'"
+        ).bind(table).fetch_one(&pool).await.unwrap();
+        assert!(index > 0, "author index missing on {table}");
+    }
+    store.migrate_user().await.unwrap();
+    let added = scoped_write(&ctx, "scoped write after Unicode author migration").await;
+    sqlx::query(&format!("UPDATE `{branch}` SET author_id='new-author' WHERE memory_id=?"))
+        .bind(&added).execute(&pool).await.unwrap();
+    call(&ctx, "memory_checkout", json!({"name":"工作分支"})).await;
+    let memories = ctx.service().list_active(&ctx.user, 100).await.unwrap();
+    assert_eq!(memories.len(), 5);
+    let memory = memories.iter().find(|m| m.memory_id == added).unwrap();
+    assert_eq!(memory.author_id.as_deref(), Some("new-author"));
+    assert_eq!(memory.subject_id.as_deref(), Some("subject-a"));
+    call(&ctx, "memory_checkout", json!({"name":"main"})).await;
+    let git = memoria_git::GitForDataService::new(pool.clone(), ctx.user_db_name(&ctx.user).await);
+    let diff = git.diff_branch_rows(branch, "mem_memories", &ctx.user, 100).await.unwrap();
+    assert!(diff.iter().any(|row| row.memory_id == added));
+    git.merge_branch(branch, "mem_memories").await.unwrap();
+    let merged: (Option<String>, Option<String>) = sqlx::query_as(
+        "SELECT author_id,subject_id FROM mem_memories WHERE memory_id=?"
+    ).bind(&added).fetch_one(&pool).await.unwrap();
+    assert_eq!(merged, (Some("new-author".into()), Some("subject-a".into())));
+    call(&ctx, "memory_branch_delete", json!({"name":"工作分支"})).await;
+    let remaining: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=?"
+    ).bind(branch).fetch_one(&pool).await.unwrap();
+    assert_eq!(remaining, 0);
+}
+
+#[tokio::test]
 async fn incompatible_historical_type_is_not_registered() {
     let (ctx, pool, _) = fixture(true).await;
     call(&ctx, "memory_branch_delete", json!({"name":"工作分支"})).await;

--- a/memoria/crates/memoria-mcp/tests/branch_scope_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/branch_scope_e2e.rs
@@ -269,6 +269,49 @@ async fn merge_preserves_scope_on_legacy_branch() {
 }
 
 #[tokio::test]
+async fn existing_parent_and_branch_migrate_with_lineage_intact() {
+    let (ctx, pool, _) = fixture(false).await;
+    call(&ctx, "memory_branch_delete", json!({"name":"工作分支"})).await;
+    // The legacy branch must be created AFTER reconstructing the old main
+    // schema. Dropping/re-adding a column on an already-new-schema branch tests
+    // a different operation: MO intentionally distinguishes that column identity.
+    for ddl in [
+        "ALTER TABLE mem_memories DROP INDEX idx_scope_subject_active",
+        "ALTER TABLE mem_memories DROP COLUMN subject_id",
+    ] {
+        sqlx::raw_sql(ddl).execute(&pool).await.unwrap();
+    }
+    let branch = "br_pre_subject";
+    let git = memoria_git::GitForDataService::new(pool.clone(), ctx.user_db_name(&ctx.user).await);
+    git.create_branch(branch, "mem_memories").await.unwrap();
+    let store = ctx.user_store(&ctx.user).await;
+    store
+        .register_branch(&ctx.user, "old-deployment", branch)
+        .await
+        .unwrap();
+    store.migrate_user().await.unwrap();
+    for table in ["mem_memories", branch] {
+        let count: i64 = sqlx::query_scalar(&format!(
+            "SELECT COUNT(*) FROM `{table}` WHERE subject_id IS NULL AND author_id='author-a'"
+        ))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 4, "legacy data must remain on {table}");
+    }
+    call(&ctx, "memory_diff", json!({"source":"old-deployment"})).await;
+    call(
+        &ctx,
+        "memory_branch_delete",
+        json!({"name":"old-deployment"}),
+    )
+    .await;
+    let probes: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name LIKE 'mem_lineage_probe_%'")
+        .fetch_one(&pool).await.unwrap();
+    assert_eq!(probes, 0);
+}
+
+#[tokio::test]
 async fn incompatible_historical_type_is_not_registered() {
     let (ctx, pool, _) = fixture(true).await;
     call(&ctx, "memory_branch_delete", json!({"name":"工作分支"})).await;

--- a/memoria/crates/memoria-mcp/tests/branch_scope_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/branch_scope_e2e.rs
@@ -1,0 +1,370 @@
+//! Field preservation across ordinary and pre-subject snapshot branches.
+//! Uses the actual MCP dispatch and disposable per-test databases, no LLM service.
+mod support;
+
+use serde_json::{json, Value};
+use sqlx::MySqlPool;
+
+struct Context {
+    inner: support::multi_db::McpTestContext,
+    user: String,
+}
+
+impl std::ops::Deref for Context {
+    type Target = support::multi_db::McpTestContext;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+async fn call(ctx: &Context, tool: &str, args: Value) -> Value {
+    memoria_mcp::git_tools::call(tool, args, &ctx.git(), &ctx.service(), &ctx.user)
+        .await
+        .unwrap_or_else(|error| panic!("{tool}: {error}"))
+}
+
+async fn seed(pool: &MySqlPool, table: &str, id: &str, user: &str) {
+    // The table is obtained from our branch registry, not test/user input.
+    sqlx::query(&format!(
+        "INSERT INTO `{table}` (memory_id,user_id,memory_type,content,source_event_ids,observed_at,created_at)
+         VALUES (?, ?, 'semantic', ?, '[]', NOW(), NOW())"
+    ))
+    .bind(id).bind(user).bind(id).execute(pool).await.unwrap();
+}
+
+async fn fixture(historical: bool) -> (Context, MySqlPool, String) {
+    let dim = std::env::var("EMBEDDING_DIM")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1024);
+    let ctx = Context {
+        inner: support::multi_db::setup_mcp_context("branch_scope", dim, None, None).await,
+        user: uuid::Uuid::new_v4().to_string(),
+    };
+    ctx.user_store(&ctx.user).await;
+    let pool = ctx.user_db_pool(&ctx.user).await;
+    for id in ["restore", "update-old", "remove", "conflict"] {
+        seed(&pool, "mem_memories", id, &ctx.user).await;
+    }
+    if historical {
+        for ddl in [
+            "ALTER TABLE mem_memories DROP INDEX idx_scope_subject_active",
+            "ALTER TABLE mem_memories DROP COLUMN subject_id",
+        ] {
+            sqlx::raw_sql(ddl).execute(&pool).await.unwrap();
+        }
+        call(&ctx, "memory_snapshot", json!({"name":"历史快照"})).await;
+        // Deliberately put the new column in the middle. The clone must match it,
+        // not append the column and rely on version-dependent native behavior.
+        sqlx::raw_sql("ALTER TABLE mem_memories ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL AFTER user_id")
+            .execute(&pool).await.unwrap();
+        ctx.user_store(&ctx.user)
+            .await
+            .migrate_user()
+            .await
+            .unwrap();
+    }
+    let args = if historical {
+        json!({"name":"工作分支", "from_snapshot":"历史快照"})
+    } else {
+        json!({"name":"工作分支"})
+    };
+    call(&ctx, "memory_branch", args).await;
+    let table: String =
+        sqlx::query_scalar("SELECT table_name FROM mem_branches WHERE name = '工作分支'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    for target in ["mem_memories", &table] {
+        sqlx::raw_sql(&format!(
+            "UPDATE `{target}` SET subject_id='subject-a', author_id='author-a'"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    (ctx, pool, table)
+}
+
+async fn scoped_write(ctx: &Context, content: &str) -> String {
+    call(ctx, "memory_checkout", json!({"name":"工作分支"})).await;
+    memoria_mcp::tools::call(
+        "memory_store",
+        json!({"content":content,"subject_id":"subject-a"}),
+        &ctx.service(),
+        &ctx.user,
+    )
+    .await
+    .unwrap();
+    let memory = ctx
+        .service()
+        .list_active(&ctx.user, 100)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|m| m.content == content)
+        .unwrap();
+    assert_eq!(memory.subject_id.as_deref(), Some("subject-a"));
+    call(ctx, "memory_checkout", json!({"name":"main"})).await;
+    memory.memory_id
+}
+
+async fn assert_scoped_read(ctx: &Context, id: &str) {
+    let store = ctx.user_store(&ctx.user).await;
+    for (subject, expected) in [("subject-a", true), ("other-subject", false)] {
+        let rows = store
+            .search_fulltext_from_scoped(
+                &store.t("mem_memories"),
+                &ctx.user,
+                "scoped",
+                100,
+                None,
+                Some(subject),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.iter().any(|m| m.memory_id == id),
+            expected,
+            "{subject}"
+        );
+    }
+}
+
+async fn apply_preserves_scope(historical: bool) {
+    let (ctx, pool, table) = fixture(historical).await;
+    let added = scoped_write(&ctx, "scoped branch addition").await;
+    seed(&pool, &table, "update-new", &ctx.user).await;
+    seed(&pool, &table, "null-scope-add", &ctx.user).await;
+    for statement in [
+        "UPDATE mem_memories SET is_active=0 WHERE memory_id='restore'".to_string(),
+        "UPDATE mem_memories SET content='main conflict version' WHERE memory_id='conflict'".into(),
+        format!("UPDATE `{table}` SET is_active=0, superseded_by='update-new' WHERE memory_id='update-old'"),
+        format!("UPDATE `{table}` SET is_active=0 WHERE memory_id='remove'"),
+        format!("UPDATE `{table}` SET content='branch conflict version' WHERE memory_id='conflict'"),
+        format!("UPDATE `{table}` SET subject_id='subject-a', author_id='branch-author' WHERE memory_id <> 'null-scope-add'"),
+    ] {
+        sqlx::raw_sql(&statement).execute(&pool).await.unwrap();
+    }
+    let result = call(
+        &ctx,
+        "memory_apply",
+        json!({
+            "source":"工作分支", "adds":[added, "restore", "null-scope-add"],
+            "updates":[{"old_id":"update-old","new_id":"update-new"}],
+            "removes":["remove"], "accept_branch_conflicts":["conflict"]
+        }),
+    )
+    .await;
+    let report = result["content"][0]["text"].as_str().unwrap();
+    for expected in ["3 added", "1 updated", "1 removed", "1 conflicts accepted"] {
+        assert!(report.contains(expected), "{report}");
+    }
+    // Assert inactive history as well as active reads: remove/update reinsert
+    // the old record and must not erase its ownership metadata either.
+    let rows: Vec<(String, Option<String>, Option<String>, i8)> = sqlx::query_as(
+        "SELECT memory_id,subject_id,author_id,is_active FROM mem_memories ORDER BY memory_id",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(rows.len(), 7);
+    for (id, subject, author, active) in rows {
+        if id == "null-scope-add" {
+            assert_eq!((subject, author, active), (None, None, 1));
+        } else {
+            assert_eq!(subject.as_deref(), Some("subject-a"), "{id}");
+            assert_eq!(author.as_deref(), Some("branch-author"), "{id}");
+            assert_eq!(
+                active,
+                if id == "remove" || id == "update-old" {
+                    0
+                } else {
+                    1
+                }
+            );
+        }
+    }
+    for (subject, expected) in [("subject-a", 4), ("other-subject", 0)] {
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM mem_memories WHERE subject_id=? AND is_active=1",
+        )
+        .bind(subject)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, expected);
+    }
+    let memories = ctx.service().list_active(&ctx.user, 100).await.unwrap();
+    assert_eq!(
+        memories
+            .iter()
+            .filter(|m| m.subject_id.as_deref() == Some("subject-a"))
+            .count(),
+        4
+    );
+    assert_scoped_read(&ctx, &added).await;
+    call(&ctx, "memory_branch_delete", json!({"name":"工作分支"})).await;
+    if historical {
+        call(&ctx, "memory_snapshot_delete", json!({"name":"历史快照"})).await;
+    }
+}
+
+#[tokio::test]
+async fn apply_preserves_scope_on_current_branch() {
+    apply_preserves_scope(false).await;
+}
+
+#[tokio::test]
+async fn apply_preserves_scope_on_legacy_branch() {
+    apply_preserves_scope(true).await;
+}
+
+async fn merge_preserves_scope(historical: bool) {
+    let (ctx, pool, table) = fixture(historical).await;
+    let added = scoped_write(&ctx, "scoped merge addition").await;
+    sqlx::query(&format!(
+        "UPDATE `{table}` SET author_id='branch-author' WHERE memory_id=?"
+    ))
+    .bind(&added)
+    .execute(&pool)
+    .await
+    .unwrap();
+    call(&ctx, "memory_merge", json!({"source":"工作分支"})).await;
+    let row: (Option<String>, Option<String>) =
+        sqlx::query_as("SELECT subject_id,author_id FROM mem_memories WHERE memory_id=?")
+            .bind(&added)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        row,
+        (Some("subject-a".into()), Some("branch-author".into()))
+    );
+    let memory = ctx
+        .service()
+        .list_active(&ctx.user, 100)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|m| m.memory_id == added)
+        .unwrap();
+    assert_eq!(memory.subject_id.as_deref(), Some("subject-a"));
+    assert_scoped_read(&ctx, &added).await;
+    call(&ctx, "memory_branch_delete", json!({"name":"工作分支"})).await;
+    if historical {
+        call(&ctx, "memory_snapshot_delete", json!({"name":"历史快照"})).await;
+    }
+}
+
+#[tokio::test]
+async fn merge_preserves_scope_on_current_branch() {
+    merge_preserves_scope(false).await;
+}
+
+#[tokio::test]
+async fn merge_preserves_scope_on_legacy_branch() {
+    merge_preserves_scope(true).await;
+}
+
+#[tokio::test]
+async fn incompatible_historical_type_is_not_registered() {
+    let (ctx, pool, _) = fixture(true).await;
+    call(&ctx, "memory_branch_delete", json!({"name":"工作分支"})).await;
+    // Current schema has evolved beyond the one supported subject migration.
+    sqlx::raw_sql("ALTER TABLE mem_memories MODIFY COLUMN content VARCHAR(4096) NOT NULL")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let error = memoria_mcp::git_tools::call(
+        "memory_branch",
+        json!({"name":"incompatible", "from_snapshot":"历史快照"}),
+        &ctx.git(),
+        &ctx.service(),
+        &ctx.user,
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        error.to_string().contains("Branch schema is incompatible"),
+        "{error}"
+    );
+    let registered: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM mem_branches WHERE name='incompatible'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(registered, 0);
+    let tables: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name LIKE 'br_%'")
+        .fetch_one(&pool).await.unwrap();
+    assert_eq!(tables, 0, "failed clone must be cleaned up");
+    call(&ctx, "memory_snapshot_delete", json!({"name":"历史快照"})).await;
+}
+
+#[tokio::test]
+async fn default_merge_does_not_replace_similar_memories_in_other_subjects() {
+    let (ctx, pool, table) = fixture(false).await;
+    let dim = std::env::var("EMBEDDING_DIM")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1024);
+    let mut vector = vec![0.0_f32; dim];
+    vector[0] = 1.0;
+    let vector = serde_json::to_string(&vector).unwrap();
+    sqlx::query(
+        "UPDATE mem_memories SET subject_id='subject-b', embedding=? WHERE memory_id='restore'",
+    )
+    .bind(&vector)
+    .execute(&pool)
+    .await
+    .unwrap();
+    for (id, subject) in [("scoped-new", Some("subject-a")), ("unscoped-new", None)] {
+        seed(&pool, &table, id, &ctx.user).await;
+        sqlx::query(&format!(
+            "UPDATE `{table}` SET subject_id=?, embedding=? WHERE memory_id=?"
+        ))
+        .bind(subject)
+        .bind(&vector)
+        .bind(id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    call(&ctx, "memory_merge", json!({"source":"工作分支"})).await;
+    let content: String =
+        sqlx::query_scalar("SELECT content FROM mem_memories WHERE memory_id='restore'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        content, "restore",
+        "another subject must not replace this row"
+    );
+    let rows: Vec<(String, Option<String>)> = sqlx::query_as("SELECT memory_id,subject_id FROM mem_memories WHERE memory_id IN ('scoped-new','unscoped-new') ORDER BY memory_id")
+        .fetch_all(&pool).await.unwrap();
+    assert_eq!(
+        rows,
+        vec![
+            ("scoped-new".into(), Some("subject-a".into())),
+            ("unscoped-new".into(), None)
+        ]
+    );
+    // Same-subject replacement still works, without selecting either the
+    // NULL-subject row or the subject-b row as additional conflict candidates.
+    seed(&pool, &table, "scoped-replacement", &ctx.user).await;
+    sqlx::query(&format!("UPDATE `{table}` SET subject_id='subject-a', embedding=? WHERE memory_id='scoped-replacement'"))
+        .bind(&vector).execute(&pool).await.unwrap();
+    call(&ctx, "memory_merge", json!({"source":"工作分支"})).await;
+    let contents: Vec<(String, String)> = sqlx::query_as("SELECT memory_id,content FROM mem_memories WHERE memory_id IN ('restore','scoped-new','unscoped-new') ORDER BY memory_id")
+        .fetch_all(&pool).await.unwrap();
+    assert_eq!(
+        contents,
+        vec![
+            ("restore".into(), "restore".into()),
+            ("scoped-new".into(), "scoped-replacement".into()),
+            ("unscoped-new".into(), "unscoped-new".into()),
+        ]
+    );
+    call(&ctx, "memory_branch_delete", json!({"name":"工作分支"})).await;
+}

--- a/memoria/crates/memoria-mcp/tests/branch_scope_e2e.rs
+++ b/memoria/crates/memoria-mcp/tests/branch_scope_e2e.rs
@@ -312,33 +312,44 @@ async fn existing_parent_and_branch_migrate_with_lineage_intact() {
 }
 
 #[tokio::test]
-async fn unicode_pre_author_branch_migrates_and_remains_usable() {
+async fn unicode_branch_skipped_by_old_author_migration_is_repaired_at_version_2() {
     let (ctx, pool, _) = fixture(false).await;
     call(&ctx, "memory_branch_delete", json!({"name":"工作分支"})).await;
-    // Reconstruct a pre-author/pre-subject deployment BEFORE cloning, so both
-    // tables inherit the same native column identities and legacy data.
+    // Reconstruct the state left by the old migration: it added author_id to
+    // main, skipped the Unicode branch, and still recorded schema version 2.
     for ddl in [
         "ALTER TABLE mem_memories DROP INDEX idx_author",
         "ALTER TABLE mem_memories DROP COLUMN author_id",
-        "ALTER TABLE mem_memories DROP INDEX idx_scope_subject_active",
-        "ALTER TABLE mem_memories DROP COLUMN subject_id",
-        "UPDATE mem_schema_meta SET schema_version=1 WHERE schema_key='user_schema'",
         "DATA BRANCH CREATE TABLE br_1234abcd_legacy FROM mem_memories",
         "ALTER TABLE br_1234abcd_legacy RENAME TO `br_1234abcd_实验`",
+        "ALTER TABLE mem_memories ADD COLUMN author_id VARCHAR(64) DEFAULT NULL",
+        "ALTER TABLE mem_memories ADD INDEX idx_author (author_id)",
+        "UPDATE mem_schema_meta SET schema_version=2 WHERE schema_key='user_schema'",
     ] {
         sqlx::raw_sql(ddl).execute(&pool).await.unwrap();
     }
     let branch = "br_1234abcd_实验";
     let store = ctx.user_store(&ctx.user).await;
-    store.register_branch(&ctx.user, "工作分支", branch).await.unwrap();
+    store
+        .register_branch(&ctx.user, "工作分支", branch)
+        .await
+        .unwrap();
+    let missing_before: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=? AND column_name='author_id'"
+    ).bind(branch).fetch_one(&pool).await.unwrap();
+    assert_eq!(
+        missing_before, 0,
+        "fixture must model the skipped old migration"
+    );
     store.migrate_user().await.unwrap();
-    // Check the first upgrade, not just a later restart that could mask a
-    // skipped compatibility migration by seeing a current schema version.
+    // The targeted repair must run despite the current schema-version marker.
     for table in ["mem_memories", branch] {
         let count: i64 = sqlx::query_scalar(&format!(
-            "SELECT COUNT(*) FROM `{table}` WHERE subject_id IS NULL AND author_id IS NULL"
+            "SELECT COUNT(*) FROM `{table}` WHERE subject_id='subject-a' AND author_id IS NULL"
         ))
-        .fetch_one(&pool).await.unwrap();
+        .fetch_one(&pool)
+        .await
+        .unwrap();
         assert_eq!(count, 4, "legacy data must remain on {table}");
         let index: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema=DATABASE() AND table_name=? AND index_name='idx_author'"
@@ -347,8 +358,13 @@ async fn unicode_pre_author_branch_migrates_and_remains_usable() {
     }
     store.migrate_user().await.unwrap();
     let added = scoped_write(&ctx, "scoped write after Unicode author migration").await;
-    sqlx::query(&format!("UPDATE `{branch}` SET author_id='new-author' WHERE memory_id=?"))
-        .bind(&added).execute(&pool).await.unwrap();
+    sqlx::query(&format!(
+        "UPDATE `{branch}` SET author_id='new-author' WHERE memory_id=?"
+    ))
+    .bind(&added)
+    .execute(&pool)
+    .await
+    .unwrap();
     call(&ctx, "memory_checkout", json!({"name":"工作分支"})).await;
     let memories = ctx.service().list_active(&ctx.user, 100).await.unwrap();
     assert_eq!(memories.len(), 5);
@@ -357,13 +373,22 @@ async fn unicode_pre_author_branch_migrates_and_remains_usable() {
     assert_eq!(memory.subject_id.as_deref(), Some("subject-a"));
     call(&ctx, "memory_checkout", json!({"name":"main"})).await;
     let git = memoria_git::GitForDataService::new(pool.clone(), ctx.user_db_name(&ctx.user).await);
-    let diff = git.diff_branch_rows(branch, "mem_memories", &ctx.user, 100).await.unwrap();
+    let diff = git
+        .diff_branch_rows(branch, "mem_memories", &ctx.user, 100)
+        .await
+        .unwrap();
     assert!(diff.iter().any(|row| row.memory_id == added));
     git.merge_branch(branch, "mem_memories").await.unwrap();
-    let merged: (Option<String>, Option<String>) = sqlx::query_as(
-        "SELECT author_id,subject_id FROM mem_memories WHERE memory_id=?"
-    ).bind(&added).fetch_one(&pool).await.unwrap();
-    assert_eq!(merged, (Some("new-author".into()), Some("subject-a".into())));
+    let merged: (Option<String>, Option<String>) =
+        sqlx::query_as("SELECT author_id,subject_id FROM mem_memories WHERE memory_id=?")
+            .bind(&added)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        merged,
+        (Some("new-author".into()), Some("subject-a".into()))
+    );
     call(&ctx, "memory_branch_delete", json!({"name":"工作分支"})).await;
     let remaining: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name=?"

--- a/memoria/crates/memoria-storage/src/branch_capability.rs
+++ b/memoria/crates/memoria-storage/src/branch_capability.rs
@@ -1,0 +1,339 @@
+//! Verify ALTER lineage behavior using only disposable tables with synthetic data.
+//! Never infer capability from a version label or from rel_createsql (_copy_).
+use memoria_core::MemoriaError;
+use sqlx::{MySqlPool, Row};
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+#[derive(Default)]
+pub(crate) struct BranchAlterCapability {
+    cached: Mutex<Option<(Instant, Result<(), String>)>>,
+}
+
+impl BranchAlterCapability {
+    pub(crate) async fn ensure(&self, pool: &MySqlPool, schema: &str) -> Result<(), MemoriaError> {
+        let pool = pool.clone();
+        let schema = schema.to_owned();
+        self.ensure_with(move || async move { probe(pool, &schema).await })
+            .await
+    }
+
+    async fn ensure_with<F, Fut>(&self, run: F) -> Result<(), MemoriaError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<(), String>> + Send + 'static,
+    {
+        let mut cache = self.cached.lock().await;
+        if let Some((until, result)) = cache.as_ref() {
+            if Instant::now() < *until {
+                return result.clone().map_err(capability_error);
+            }
+        }
+        // Request cancellation must not cancel the probe's cleanup. Only the
+        // disposable probe task is detached; no user ALTER happens in it.
+        let result = tokio::spawn(run())
+            .await
+            .map_err(|e| format!("capability probe task failed: {e}"))
+            .and_then(|r| r);
+        let ttl = if result.is_ok() { 300 } else { 30 };
+        *cache = Some((Instant::now() + Duration::from_secs(ttl), result.clone()));
+        result.map_err(capability_error)
+    }
+}
+
+fn capability_error(reason: String) -> MemoriaError {
+    MemoriaError::Database(format!(
+        "Native branch ALTER capability could not be verified; user branch migration was not performed. Use a validated MatrixOne build (4.2.1-d2393868a) and check DDL permissions/connectivity. Probe: {reason}"
+    ))
+}
+
+fn quote(name: &str) -> String {
+    format!("`{}`", name.replace('`', "``"))
+}
+
+struct Probe {
+    pool: MySqlPool,
+    schema: String,
+    base_name: String,
+    branch_name: String,
+    base: String,
+    branch: String,
+    base_created: bool,
+    branch_created: bool,
+}
+
+impl Probe {
+    fn new(pool: MySqlPool, schema: &str) -> Self {
+        let id = uuid::Uuid::new_v4().simple().to_string();
+        let base_name = format!("mem_lineage_probe_{id}_s");
+        let branch_name = format!("mem_lineage_probe_{id}_b");
+        Self {
+            pool,
+            schema: schema.into(),
+            base: format!("{}.{}", quote(schema), quote(&base_name)),
+            branch: format!("{}.{}", quote(schema), quote(&branch_name)),
+            base_name,
+            branch_name,
+            base_created: false,
+            branch_created: false,
+        }
+    }
+
+    async fn exec(&self, sql: &str) -> Result<(), String> {
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            sqlx::raw_sql(sql).execute(&self.pool),
+        )
+        .await
+        .map_err(|_| "probe statement timed out".to_string())?
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+    }
+
+    async fn verify(&mut self) -> Result<(), String> {
+        // No IF NOT EXISTS: only a successful CREATE gives us cleanup ownership.
+        self.exec(&format!("CREATE TABLE {} (id INT PRIMARY KEY, user_id VARCHAR(64), content TEXT, is_active TINYINT DEFAULT 1, FULLTEXT INDEX ft_content (content) WITH PARSER ngram)", self.base)).await?;
+        self.base_created = true;
+        self.exec(&format!(
+            "INSERT INTO {} VALUES (1, 'probe', 'base', 1)",
+            self.base
+        ))
+        .await?;
+        self.exec(&format!(
+            "DATA BRANCH CREATE TABLE {} FROM {}",
+            self.branch, self.base
+        ))
+        .await?;
+        self.branch_created = true;
+        // Both parent and child ALTER must preserve lineage. These operations
+        // exercise the same copy/swap machinery used by historical clone migration.
+        for table in [&self.base, &self.branch] {
+            self.exec(&format!(
+                "ALTER TABLE {table} ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL AFTER user_id"
+            ))
+            .await?;
+        }
+        self.exec(&format!(
+            "ALTER TABLE {} ADD INDEX idx_scope_subject_active (user_id,subject_id,is_active)",
+            self.branch
+        ))
+        .await?;
+        self.exec(&format!(
+            "INSERT INTO {} (id,user_id,subject_id,content) VALUES (2,'probe','scope','branch')",
+            self.branch
+        ))
+        .await?;
+        let rows = sqlx::raw_sql(&format!(
+            "DATA BRANCH DIFF {} AGAINST {} OUTPUT LIMIT 10",
+            self.branch, self.base
+        ))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| e.to_string())?;
+        if !rows.iter().any(|r| {
+            r.try_get::<i32, _>("id").ok() == Some(2)
+                && r.try_get::<String, _>("subject_id").ok().as_deref() == Some("scope")
+                && r.try_get::<String, _>("content").ok().as_deref() == Some("branch")
+        }) {
+            return Err("native diff did not preserve field mapping after ALTER".into());
+        }
+        self.exec(&format!(
+            "DATA BRANCH MERGE {} INTO {} WHEN CONFLICT SKIP",
+            self.branch, self.base
+        ))
+        .await?;
+        let value: Option<(String, String)> = sqlx::query_as(&format!(
+            "SELECT subject_id,content FROM {} WHERE id=2",
+            self.base
+        ))
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| e.to_string())?;
+        if value != Some(("scope".into(), "branch".into())) {
+            return Err("native merge did not preserve fields after ALTER".into());
+        }
+        self.exec(&format!("DATA BRANCH DELETE TABLE {}", self.branch))
+            .await?;
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name=?",
+        )
+        .bind(&self.schema)
+        .bind(&self.branch_name)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| e.to_string())?;
+        if count != 0 {
+            return Err("native delete left a probe table behind".into());
+        }
+        self.branch_created = false;
+        Ok(())
+    }
+
+    async fn cleanup(&mut self) -> Result<(), String> {
+        if self.branch_created {
+            let native = self
+                .exec(&format!("DATA BRANCH DELETE TABLE {}", self.branch))
+                .await;
+            if let Err(error) = native {
+                // Strictly local to this freshly-created probe, never exposed to
+                // user/registry table names. Old builds may have materialized it.
+                if !error.contains("is not an active branch table") {
+                    return Err(error);
+                }
+                self.exec(&format!("DROP TABLE {}", self.branch)).await?;
+            }
+            self.branch_created = false;
+        }
+        if self.base_created {
+            self.exec(&format!("DROP TABLE {}", self.base)).await?;
+            self.base_created = false;
+        }
+        Ok(())
+    }
+}
+
+async fn probe(pool: MySqlPool, schema: &str) -> Result<(), String> {
+    let mut probe = Probe::new(pool, schema);
+    let result = tokio::time::timeout(Duration::from_secs(60), probe.verify())
+        .await
+        .unwrap_or_else(|_| Err("capability probe timed out".into()));
+    let cleanup = probe.cleanup().await;
+    if result.is_err() || cleanup.is_err() {
+        // An ambiguous CREATE response or process/DB failure may leave only
+        // these named probe artifacts. Never scan/delete a broad table prefix.
+        tracing::warn!(schema, base = %probe.base_name, branch = %probe.branch_name,
+            error = ?result.as_ref().err(), cleanup_error = ?cleanup.as_ref().err(),
+            "branch ALTER probe failed; inspect exact probe names if cleanup was interrupted");
+    }
+    // Never cache success if cleanup failed; preserve the original failure.
+    result.and(cleanup)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    #[tokio::test]
+    async fn concurrent_checks_share_success_and_expired_failures_retry() {
+        let capability = BranchAlterCapability::default();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let run = || {
+            let calls = calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        };
+        let (a, b) = tokio::join!(capability.ensure_with(run), capability.ensure_with(run));
+        a.unwrap();
+        b.unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        *capability.cached.lock().await = Some((
+            Instant::now() + Duration::from_secs(30),
+            Err("unavailable".into()),
+        ));
+        assert!(capability.ensure_with(run).await.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        capability.cached.lock().await.as_mut().unwrap().0 = Instant::now();
+        capability.ensure_with(run).await.unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn cancelled_waiter_does_not_cancel_probe_cleanup() {
+        let capability = Arc::new(BranchAlterCapability::default());
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (resume_tx, resume_rx) = tokio::sync::oneshot::channel();
+        let (cleaned_tx, cleaned_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            capability
+                .ensure_with(|| async move {
+                    started_tx.send(()).unwrap();
+                    resume_rx.await.unwrap();
+                    cleaned_tx.send(()).unwrap();
+                    Ok(())
+                })
+                .await
+        });
+        started_rx.await.unwrap();
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        resume_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(1), cleaned_rx)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    #[test]
+    fn probe_names_are_private_unique_and_qualified() {
+        let pool = sqlx::mysql::MySqlPoolOptions::new()
+            .max_lifetime(None)
+            .idle_timeout(None)
+            .connect_lazy_with(sqlx::mysql::MySqlConnectOptions::new());
+        let a = Probe::new(pool.clone(), "db`name");
+        let b = Probe::new(pool, "db`name");
+        assert_ne!(a.branch_name, b.branch_name);
+        assert!(a.branch.starts_with("`db``name`.`mem_lineage_probe_"));
+        assert!(memoria_core::is_safe_sql_identifier(&a.branch_name));
+        assert!(!a.base_created && !a.branch_created);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires disposable MatrixOne via DATABASE_URL; run explicitly in DB CI"]
+    async fn materialized_probe_cleanup_preserves_unrelated_tables() {
+        let options: sqlx::mysql::MySqlConnectOptions =
+            std::env::var("DATABASE_URL").unwrap().parse().unwrap();
+        let admin = MySqlPool::connect_with(options.clone().database("mo_catalog"))
+            .await
+            .unwrap();
+        let schema = format!("probe_cleanup_{}", uuid::Uuid::new_v4().simple());
+        sqlx::raw_sql(&format!("CREATE DATABASE {}", quote(&schema)))
+            .execute(&admin)
+            .await
+            .unwrap();
+        let pool = MySqlPool::connect_with(options.database(&schema))
+            .await
+            .unwrap();
+        let mut probe = Probe::new(pool.clone(), &schema);
+        probe
+            .exec(&format!("CREATE TABLE {} (id INT PRIMARY KEY)", probe.base))
+            .await
+            .unwrap();
+        probe.base_created = true;
+        // Emulate an old engine materializing the branch into a regular table.
+        // It is still owned solely by this probe, never a user branch.
+        probe
+            .exec(&format!(
+                "CREATE TABLE {} (id INT PRIMARY KEY)",
+                probe.branch
+            ))
+            .await
+            .unwrap();
+        probe.branch_created = true;
+        sqlx::raw_sql(
+            "CREATE TABLE user_data (id INT PRIMARY KEY); INSERT INTO user_data VALUES (1)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        probe.cleanup().await.unwrap();
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name IN (?,?)")
+            .bind(&schema).bind(&probe.base_name).bind(&probe.branch_name).fetch_one(&pool).await.unwrap();
+        assert_eq!(remaining, 0);
+        let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM user_data")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(rows, 1);
+        pool.close().await;
+        sqlx::raw_sql(&format!("DROP DATABASE {}", quote(&schema)))
+            .execute(&admin)
+            .await
+            .unwrap();
+    }
+}

--- a/memoria/crates/memoria-storage/src/lib.rs
+++ b/memoria/crates/memoria-storage/src/lib.rs
@@ -1,3 +1,4 @@
+mod branch_capability;
 pub mod graph;
 pub mod migration;
 pub mod pool_config;

--- a/memoria/crates/memoria-storage/src/lib.rs
+++ b/memoria/crates/memoria-storage/src/lib.rs
@@ -3,6 +3,7 @@ pub mod migration;
 pub mod pool_config;
 pub mod router;
 pub mod store;
+pub mod table_schema;
 
 pub use graph::types::{GraphEdge, GraphNode, NodeType};
 pub use graph::{

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -1840,11 +1840,9 @@ impl SqlMemoryStore {
         // helper instead of plain sqlx::query().execute().
         for bt_raw in &branch_table_names {
             // bt_raw is the raw table name (e.g. br_abc123_my_branch) without DB prefix.
-            // Validate against a strict allowlist before interpolating into DDL.
-            if !bt_raw
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_')
-            {
+            // Use the same allowlist as subject migration: existing physical
+            // names may contain Unicode. self.t() quotes those identifiers.
+            if !memoria_core::is_safe_sql_identifier(bt_raw) {
                 tracing::warn!(
                     "migration: skipping branch table with invalid identifier '{bt_raw}'"
                 );

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -2014,10 +2014,27 @@ impl SqlMemoryStore {
         if !memoria_core::is_safe_sql_identifier(table) {
             return Err(MemoriaError::Validation("Invalid branch table name".into()));
         }
+        let current =
+            crate::table_schema::read_table_columns(&self.pool, schema, "mem_memories").await?;
         if !info_schema_column_exists(&self.pool, schema, table, "subject_id").await {
+            let position = current
+                .iter()
+                .position(|column| column.name.eq_ignore_ascii_case("subject_id"))
+                .ok_or_else(|| {
+                    MemoriaError::Database("Current table is missing subject_id".into())
+                })?;
             let mut ddl = sqlx::QueryBuilder::<sqlx::MySql>::new("ALTER TABLE ");
             ddl.push(self.t(table))
                 .push(" ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL");
+            // Match the live ordinal, not merely the name: some MO versions
+            // silently misinterpret native diffs between differently ordered tables.
+            if position == 0 {
+                ddl.push(" FIRST");
+            } else {
+                ddl.push(" AFTER `")
+                    .push(current[position - 1].name.replace('`', "``"))
+                    .push("`");
+            }
             if let Err(error) = exec_ddl_with_retry(&self.pool, &ddl.into_sql()).await {
                 if !is_duplicate_column(&error) && !is_mo_concurrent_ddl_race(&error) {
                     return Err(db_err(error));
@@ -2029,7 +2046,7 @@ impl SqlMemoryStore {
         // Require ALL live column names afterwards, including nullable/defaulted
         // columns: current INSERT/SELECT statements explicitly reference them.
         let columns = crate::table_schema::read_table_columns(&self.pool, schema, table).await?;
-        let present: Vec<String> = columns.into_iter().map(|c| c.name).collect();
+        let present: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
         if !present
             .iter()
             .any(|name| name.eq_ignore_ascii_case("subject_id"))
@@ -2038,14 +2055,13 @@ impl SqlMemoryStore {
                 "Branch subject_id migration did not complete".into(),
             ));
         }
-        let current =
-            crate::table_schema::read_table_columns(&self.pool, schema, "mem_memories").await?;
         if let Some(column) = crate::table_schema::missing_columns(&current, &present).first() {
             return Err(MemoriaError::Database(format!(
                 "Branch schema is missing required column '{}'",
                 column.name
             )));
         }
+        crate::table_schema::validate_native_branch_schema(&current, &columns)?;
         if !info_schema_index_exists(&self.pool, schema, table, "idx_scope_subject_active").await {
             let mut ddl = sqlx::QueryBuilder::<sqlx::MySql>::new("ALTER TABLE ");
             ddl.push(self.t(table)).push(

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -1773,120 +1773,151 @@ impl SqlMemoryStore {
         .execute(pool)
         .await;
 
-        // author_id column — tracks the real human author in group mode
-        // Guard with existence check so the migration is idempotent (safe to run
-        // on both fresh and already-migrated databases).
-        let has_author_id =
-            info_schema_column_exists(pool, schema_name, "mem_memories", "author_id").await;
-        if !has_author_id {
-            let add_col = sqlx::query(&format!(
-                "ALTER TABLE {memories_table} ADD COLUMN author_id VARCHAR(64) DEFAULT NULL"
-            ))
-            .execute(pool)
-            .await;
-            match &add_col {
-                Ok(_) => tracing::info!("migration: added author_id column to {memories_table}"),
-                Err(e) if is_duplicate_column(e) => tracing::info!(
-                    "migration: author_id column already exists in {memories_table}, skipping"
-                ),
-                Err(e) => {
-                    tracing::error!("migration: failed to add author_id to {memories_table}: {e}")
-                }
-            }
-        } else {
-            tracing::debug!(
-                "migration: author_id column already exists in {memories_table}, skipping"
-            );
-        }
-        // Ensure the index exists even when the column already existed before this migration.
-        // This covers partially-migrated databases where `author_id` is present but
-        // `idx_author` is missing.
-        let has_memories_author_idx =
-            info_schema_index_exists(pool, schema_name, "mem_memories", "idx_author").await;
-        if !has_memories_author_idx {
-            let add_idx = sqlx::query(&format!(
-                "ALTER TABLE {memories_table} ADD INDEX idx_author (author_id)"
-            ))
-            .execute(pool)
-            .await;
-            if let Err(e) = add_idx {
-                tracing::warn!(
-                    "migration: failed to add idx_author on {memories_table} (may already exist): {e}"
-                );
-            }
-        }
-
-        // Also add author_id to any existing branch tables (which are separate physical tables).
-        // Branch tables are created as copies of mem_memories and need the same schema.
-        let branch_table_names: Vec<String> = match sqlx::query_scalar(&format!(
-            "SELECT table_name FROM {branches_table} WHERE status = 'active' AND table_name != ''"
-        ))
-        .fetch_all(pool)
-        .await
-        {
-            Ok(names) => names,
-            Err(e) => {
-                tracing::warn!(
-                    "migration: failed to load branch table names from {branches_table}, \
-                     skipping author_id/idx_author migration for branch tables: {e}"
-                );
-                vec![]
-            }
-        };
-
-        // Branch tables are physically separate copies of mem_memories; they need
-        // the same author_id column/index. ALTER TABLE here can race with a concurrent
-        // `data branch merge` (MatrixOne 20631 "def changed"), so we use a retrying
-        // helper instead of plain sqlx::query().execute().
-        for bt_raw in &branch_table_names {
-            // bt_raw is the raw table name (e.g. br_abc123_my_branch) without DB prefix.
-            // Use the same allowlist as subject migration: existing physical
-            // names may contain Unicode. self.t() quotes those identifiers.
-            if !memoria_core::is_safe_sql_identifier(bt_raw) {
-                tracing::warn!(
-                    "migration: skipping branch table with invalid identifier '{bt_raw}'"
-                );
-                continue;
-            }
-            let bt_full = self.t(bt_raw);
-            let has_col = info_schema_column_exists(pool, schema_name, bt_raw, "author_id").await;
-            if !has_col {
-                let r = exec_ddl_with_retry(
-                    pool,
-                    &format!("ALTER TABLE {bt_full} ADD COLUMN author_id VARCHAR(64) DEFAULT NULL"),
-                )
-                .await;
-                match r {
-                    Ok(_) => tracing::info!("migration: added author_id to branch table {bt_full}"),
-                    Err(e) => {
-                        // Propagate the error so that migrate_user() does NOT write the
-                        // schema version. The migration will be retried on the next startup
-                        // rather than being silently marked as complete.
-                        tracing::error!(
-                            "migration: failed to add author_id to branch table {bt_full}: {e}"
-                        );
-                        return Err(db_err(e));
-                    }
-                }
-            }
-            // Always ensure the index exists regardless of whether the column was just
-            // added or was already present (handles "column exists but index is missing"
-            // on older databases). The error is expected when the index already exists.
-            let has_idx = info_schema_index_exists(pool, schema_name, bt_raw, "idx_author").await;
-            if !has_idx {
-                let _ = exec_ddl_with_retry(
-                    pool,
-                    &format!("ALTER TABLE {bt_full} ADD INDEX idx_author (author_id)"),
-                )
-                .await;
-            }
-        }
+        self.ensure_author_id_column(pool, schema_name).await?;
 
         // subject_id migration is handled unconditionally by ensure_subject_id_column(),
         // which is called before the schema-version short-circuit in migrate_user().
         // Do NOT add subject_id DDL here — it would duplicate work and use an older,
         // less robust implementation (no exec_ddl_with_retry / is_mo_concurrent_ddl_race).
 
+        Ok(())
+    }
+
+    /// Idempotently repair `author_id` on the parent and registered branches.
+    ///
+    /// This must run before the schema-version short-circuit: an older migration
+    /// skipped Unicode branch names but still stored schema version 2.
+    async fn ensure_author_id_column(
+        &self,
+        pool: &MySqlPool,
+        schema_name: &str,
+    ) -> Result<(), MemoriaError> {
+        let memories_exists: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name='mem_memories'",
+        )
+        .bind(schema_name)
+        .fetch_one(pool)
+        .await
+        .map_err(db_err)?;
+        if memories_exists == 0 {
+            return Ok(());
+        }
+        let memories_table = self.t("mem_memories");
+        let branches_table = self.t("mem_branches");
+        // Very old/partial schemas are repaired by apply_user_compat_migrations
+        // after bootstrap. A version-2 registry has both of these columns.
+        let registry_columns: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema=? AND table_name='mem_branches' AND column_name IN ('table_name','status')",
+        )
+        .bind(schema_name)
+        .fetch_one(pool)
+        .await
+        .map_err(db_err)?;
+        let registry_ready = registry_columns == 2;
+        let branch_table_names: Vec<String> = if registry_ready {
+            sqlx::query_scalar(&format!(
+                "SELECT table_name FROM {branches_table} WHERE status='active' AND table_name != ''"
+            ))
+            .fetch_all(pool)
+            .await
+            .map_err(db_err)?
+        } else {
+            Vec::new()
+        };
+        let has_registered_branches = !branch_table_names.is_empty();
+
+        if !info_schema_column_exists(pool, schema_name, "mem_memories", "author_id").await {
+            if has_registered_branches {
+                self.ensure_native_branch_alter_capability().await?;
+            }
+            let ddl = format!(
+                "ALTER TABLE {memories_table} ADD COLUMN author_id VARCHAR(64) DEFAULT NULL"
+            );
+            if let Err(error) = exec_ddl_with_retry(pool, &ddl).await {
+                if !is_duplicate_column(&error) && !is_mo_concurrent_ddl_race(&error) {
+                    return Err(db_err(error));
+                }
+                tracing::debug!(%error, "rechecking parent author_id after concurrent DDL");
+            }
+        }
+        if !info_schema_column_exists(pool, schema_name, "mem_memories", "author_id").await {
+            return Err(MemoriaError::Database(
+                "Parent author_id migration did not complete".into(),
+            ));
+        }
+
+        if !info_schema_index_exists(pool, schema_name, "mem_memories", "idx_author").await {
+            let may_alter = if has_registered_branches {
+                match self.ensure_native_branch_alter_capability().await {
+                    Ok(()) => true,
+                    Err(error) => {
+                        tracing::warn!(%error, "skipping optional parent author index: ALTER capability unverified");
+                        false
+                    }
+                }
+            } else {
+                true
+            };
+            if may_alter {
+                let ddl = format!("ALTER TABLE {memories_table} ADD INDEX idx_author (author_id)");
+                if let Err(error) = exec_ddl_with_retry(pool, &ddl).await {
+                    tracing::warn!(%error, "parent author index unavailable; continuing without it");
+                }
+            }
+        }
+        if branch_table_names.is_empty() {
+            return Ok(());
+        }
+
+        let current =
+            crate::table_schema::read_table_columns(pool, schema_name, "mem_memories").await?;
+        let position = current
+            .iter()
+            .position(|column| column.name.eq_ignore_ascii_case("author_id"))
+            .ok_or_else(|| MemoriaError::Database("Current table is missing author_id".into()))?;
+        for table in branch_table_names {
+            if !memoria_core::is_safe_sql_identifier(&table) {
+                tracing::warn!(%table, "skipping branch with invalid physical identifier");
+                continue;
+            }
+            if !info_schema_column_exists(pool, schema_name, &table, "author_id").await {
+                self.ensure_native_branch_alter_capability().await?;
+                let mut ddl = sqlx::QueryBuilder::<sqlx::MySql>::new("ALTER TABLE ");
+                ddl.push(self.t(&table))
+                    .push(" ADD COLUMN author_id VARCHAR(64) DEFAULT NULL");
+                if position == 0 {
+                    ddl.push(" FIRST");
+                } else {
+                    ddl.push(" AFTER `")
+                        .push(current[position - 1].name.replace('`', "``"))
+                        .push("`");
+                }
+                if let Err(error) = exec_ddl_with_retry(pool, &ddl.into_sql()).await {
+                    if !is_duplicate_column(&error) && !is_mo_concurrent_ddl_race(&error) {
+                        return Err(db_err(error));
+                    }
+                    tracing::debug!(%error, %table, "rechecking branch author_id after concurrent DDL");
+                }
+            }
+            if !info_schema_column_exists(pool, schema_name, &table, "author_id").await {
+                return Err(MemoriaError::Database(format!(
+                    "Branch author_id migration did not complete for '{table}'"
+                )));
+            }
+            if !info_schema_index_exists(pool, schema_name, &table, "idx_author").await {
+                if let Err(error) = self.ensure_native_branch_alter_capability().await {
+                    tracing::warn!(%error, %table, "skipping optional branch author index: ALTER capability unverified");
+                    continue;
+                }
+                let ddl = format!(
+                    "ALTER TABLE {} ADD INDEX idx_author (author_id)",
+                    self.t(&table)
+                );
+                if let Err(error) = exec_ddl_with_retry(pool, &ddl).await {
+                    tracing::warn!(%error, %table, "branch author index unavailable; continuing without it");
+                }
+            }
+        }
         Ok(())
     }
 
@@ -2194,8 +2225,10 @@ impl SqlMemoryStore {
         if let Err(e) = self.ensure_snapshot_extra_column(pool, schema_name).await {
             tracing::warn!("migration: ensure_snapshot_extra_column failed (non-fatal): {e}");
         }
-        // Always run subject_id migration regardless of schema version, because it was added
-        // after CURRENT_USER_SCHEMA_VERSION was already set to 2 for live deployments.
+        // These repairs must run regardless of schema version. author_id was
+        // previously skipped on Unicode physical branch names even though the
+        // migration stored version 2; subject_id was added after version 2.
+        self.ensure_author_id_column(pool, schema_name).await?;
         self.ensure_subject_id_column(pool, schema_name).await?;
         // Short-circuit only when the schema version is current AND the main table
         // actually exists. If mem_memories is somehow missing on a non-fresh database

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -865,6 +865,7 @@ fn mo_to_vec(s: &str) -> Result<Vec<f32>, MemoriaError> {
 #[derive(Clone)]
 pub struct SqlMemoryStore {
     pool: MySqlPool,
+    branch_alter_capability: Arc<crate::branch_capability::BranchAlterCapability>,
     embedding_dim: usize,
     instance_id: String,
     database_url: Option<String>,
@@ -960,6 +961,9 @@ impl SqlMemoryStore {
     pub fn new(pool: MySqlPool, embedding_dim: usize, instance_id: String) -> Self {
         Self {
             pool,
+            branch_alter_capability: Arc::new(
+                crate::branch_capability::BranchAlterCapability::default(),
+            ),
             embedding_dim,
             instance_id,
             database_url: None,
@@ -1050,10 +1054,14 @@ impl SqlMemoryStore {
     }
 
     pub fn set_db_name(&mut self, name: String) {
+        self.branch_alter_capability =
+            Arc::new(crate::branch_capability::BranchAlterCapability::default());
         self.db_name = Some(name);
     }
 
     pub fn set_database_url(&mut self, url: String) {
+        self.branch_alter_capability =
+            Arc::new(crate::branch_capability::BranchAlterCapability::default());
         self.database_url = Some(url);
     }
 
@@ -1519,6 +1527,11 @@ impl SqlMemoryStore {
     }
 
     async fn apply_user_compat_migrations(&self, pool: &MySqlPool) -> Result<(), MemoriaError> {
+        // This legacy migration may ALTER both the parent and its branches.
+        // Check before any such DDL, not after an older engine materializes them.
+        if self.has_registered_branches().await? {
+            self.ensure_native_branch_alter_capability().await?;
+        }
         let schema_name = self.current_schema_name().await?;
         let schema_name = schema_name.as_ref();
         let memories_stats_table = self.t("mem_memories_stats");
@@ -1910,6 +1923,9 @@ impl SqlMemoryStore {
         let has_col =
             info_schema_column_exists(pool, schema_name, "mem_memories", "subject_id").await;
         if !has_col {
+            if self.has_registered_branches().await? {
+                self.ensure_native_branch_alter_capability().await?;
+            }
             match exec_ddl_with_retry(
                 pool,
                 &format!(
@@ -1943,28 +1959,41 @@ impl SqlMemoryStore {
         )
         .await;
         if !has_idx {
-            match exec_ddl_with_retry(
-                pool,
-                &format!(
-                    "ALTER TABLE {memories_table} ADD INDEX idx_scope_subject_active \
-                     (user_id, subject_id, is_active, memory_type)"
-                ),
-            )
-            .await
-            {
-                Ok(_) => tracing::info!(
-                    "migration: added idx_scope_subject_active on {memories_table}"
-                ),
-                Err(e) if is_duplicate_index(&e) => tracing::debug!(
-                    "migration: idx_scope_subject_active already exists on {memories_table}, skipping"
-                ),
-                Err(e) if is_mo_concurrent_ddl_race(&e) => tracing::warn!(
-                    "migration: concurrent DDL race for idx_scope_subject_active on \
-                     {memories_table}: {e}"
-                ),
-                Err(e) => tracing::warn!(
-                    "migration: failed to add idx_scope_subject_active on {memories_table}: {e}"
-                ),
+            let may_alter = if self.has_registered_branches().await? {
+                match self.ensure_native_branch_alter_capability().await {
+                    Ok(()) => true,
+                    Err(error) => {
+                        tracing::warn!(%error, "skipping optional parent index: ALTER capability unverified");
+                        false
+                    }
+                }
+            } else {
+                true
+            };
+            if may_alter {
+                match exec_ddl_with_retry(
+                    pool,
+                    &format!(
+                        "ALTER TABLE {memories_table} ADD INDEX idx_scope_subject_active \
+                         (user_id, subject_id, is_active, memory_type)"
+                    ),
+                )
+                .await
+                {
+                    Ok(_) => tracing::info!(
+                        "migration: added idx_scope_subject_active on {memories_table}"
+                    ),
+                    Err(e) if is_duplicate_index(&e) => tracing::debug!(
+                        "migration: idx_scope_subject_active already exists on {memories_table}, skipping"
+                    ),
+                    Err(e) if is_mo_concurrent_ddl_race(&e) => tracing::warn!(
+                        "migration: concurrent DDL race for idx_scope_subject_active on \
+                         {memories_table}: {e}"
+                    ),
+                    Err(e) => tracing::warn!(
+                        "migration: failed to add idx_scope_subject_active on {memories_table}: {e}"
+                    ),
+                }
             }
         }
 
@@ -2006,6 +2035,34 @@ impl SqlMemoryStore {
         self.migrate_branch_subject_id(table, schema.as_ref()).await
     }
 
+    /// Check on disposable tables before ALTER may affect native branch lineage.
+    pub async fn ensure_native_branch_alter_capability(&self) -> Result<(), MemoriaError> {
+        let schema = self.current_schema_name().await?;
+        self.branch_alter_capability
+            .ensure(&self.pool, &schema)
+            .await
+    }
+
+    async fn has_registered_branches(&self) -> Result<bool, MemoriaError> {
+        let schema = self.current_schema_name().await?;
+        // Unlike best-effort metadata helpers, a safety gate must not turn a
+        // catalog read failure into "no branches" and allow an unchecked ALTER.
+        let exists: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=? AND table_name='mem_branches'",
+        ).bind(schema.as_ref()).fetch_one(&self.pool).await.map_err(db_err)?;
+        if exists == 0 {
+            return Ok(false);
+        }
+        let count: i64 = sqlx::query_scalar(&format!(
+            "SELECT COUNT(*) FROM {} WHERE status='active' AND table_name != ''",
+            self.t("mem_branches")
+        ))
+        .fetch_one(&self.pool)
+        .await
+        .map_err(db_err)?;
+        Ok(count != 0)
+    }
+
     async fn migrate_branch_subject_id(
         &self,
         table: &str,
@@ -2017,6 +2074,7 @@ impl SqlMemoryStore {
         let current =
             crate::table_schema::read_table_columns(&self.pool, schema, "mem_memories").await?;
         if !info_schema_column_exists(&self.pool, schema, table, "subject_id").await {
+            self.ensure_native_branch_alter_capability().await?;
             let position = current
                 .iter()
                 .position(|column| column.name.eq_ignore_ascii_case("subject_id"))
@@ -2063,6 +2121,10 @@ impl SqlMemoryStore {
         }
         crate::table_schema::validate_native_branch_schema(&current, &columns)?;
         if !info_schema_index_exists(&self.pool, schema, table, "idx_scope_subject_active").await {
+            if let Err(error) = self.ensure_native_branch_alter_capability().await {
+                tracing::warn!(%error, %table, "skipping optional branch index: ALTER capability unverified");
+                return Ok(());
+            }
             let mut ddl = sqlx::QueryBuilder::<sqlx::MySql>::new("ALTER TABLE ");
             ddl.push(self.t(table)).push(
                 " ADD INDEX idx_scope_subject_active (user_id, subject_id, is_active, memory_type)",

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -2060,6 +2060,53 @@ impl SqlMemoryStore {
         Ok(())
     }
 
+    /// A branch cloned from a historical snapshot inherits the historical schema,
+    /// not today's mem_memories schema. Call before registering the new branch.
+    pub async fn ensure_branch_subject_id(&self, table: &str) -> Result<(), MemoriaError> {
+        if !table.starts_with("br_")
+            || !table
+                .bytes()
+                .all(|c| c.is_ascii_alphanumeric() || c == b'_')
+        {
+            return Err(MemoriaError::Validation("Invalid branch table name".into()));
+        }
+        let schema = self.current_schema_name().await?;
+        if !info_schema_column_exists(&self.pool, schema.as_ref(), table, "subject_id").await {
+            let mut ddl = sqlx::QueryBuilder::<sqlx::MySql>::new("ALTER TABLE ");
+            ddl.push(self.t(table))
+                .push(" ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL");
+            if let Err(error) = exec_ddl_with_retry(&self.pool, &ddl.into_sql()).await {
+                if !is_duplicate_column(&error) {
+                    return Err(db_err(error));
+                }
+            }
+        }
+        if !info_schema_column_exists(&self.pool, schema.as_ref(), table, "subject_id").await {
+            return Err(MemoriaError::Database(
+                "Branch subject_id migration did not complete".into(),
+            ));
+        }
+        if !info_schema_index_exists(
+            &self.pool,
+            schema.as_ref(),
+            table,
+            "idx_scope_subject_active",
+        )
+        .await
+        {
+            let mut ddl = sqlx::QueryBuilder::<sqlx::MySql>::new("ALTER TABLE ");
+            ddl.push(self.t(table)).push(
+                " ADD INDEX idx_scope_subject_active (user_id, subject_id, is_active, memory_type)",
+            );
+            if let Err(error) = exec_ddl_with_retry(&self.pool, &ddl.into_sql()).await {
+                if !is_duplicate_index(&error) {
+                    return Err(db_err(error));
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn ensure_snapshot_extra_column(
         &self,
         pool: &MySqlPool,

--- a/memoria/crates/memoria-storage/src/store.rs
+++ b/memoria/crates/memoria-storage/src/store.rs
@@ -1063,8 +1063,15 @@ impl SqlMemoryStore {
         if table.contains('.') || table.contains('`') {
             return table.to_string();
         }
+        // Legacy Unicode physical names need identifier quoting on older MO
+        // parsers. Preserve the existing representation of ASCII table names.
+        let table = if table.is_ascii() {
+            std::borrow::Cow::Borrowed(table)
+        } else {
+            std::borrow::Cow::Owned(quote_ident(table))
+        };
         match &self.db_name {
-            None => table.to_string(),
+            None => table.into_owned(),
             Some(db) => format!("`{}`.{}", db.replace('`', "``"), table),
         }
     }
@@ -1978,130 +1985,77 @@ impl SqlMemoryStore {
             }
         };
 
-        for bt_raw in &branch_table_names {
-            if !bt_raw
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_')
-            {
-                tracing::warn!(
-                    "migration: skipping branch table with invalid identifier '{bt_raw}'"
-                );
-                continue;
-            }
-            let bt_full = self.t(bt_raw);
-
-            let has_bt_col =
-                info_schema_column_exists(pool, schema_name, bt_raw, "subject_id").await;
-            if !has_bt_col {
-                match exec_ddl_with_retry(
-                    pool,
-                    &format!(
-                        "ALTER TABLE {bt_full} ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL"
-                    ),
-                )
-                .await
-                {
-                    Ok(_) => {
-                        tracing::info!("migration: added subject_id to branch table {bt_full}")
-                    }
-                    Err(e) if is_duplicate_column(&e) => tracing::debug!(
-                        "migration: subject_id already exists in branch table {bt_full}, skipping"
-                    ),
-                    Err(e) if is_mo_concurrent_ddl_race(&e) => tracing::warn!(
-                        "migration: concurrent DDL race for subject_id on branch table {bt_full} \
-                         (column was added by a concurrent request): {e}"
-                    ),
-                    Err(e) => tracing::error!(
-                        // Non-fatal: startup continues, but any INSERT/SELECT that
-                        // references subject_id on this branch table will fail at
-                        // runtime with 'unknown column'.  Fix the DDL permission or
-                        // drop-and-recreate the branch, then restart.
-                        "migration: failed to add subject_id to branch table {bt_full}: {e}"
-                    ),
-                }
-            }
-
-            let has_bt_idx = info_schema_index_exists(
-                pool,
-                schema_name,
-                bt_raw,
-                "idx_scope_subject_active",
-            )
-            .await;
-            if !has_bt_idx {
-                match exec_ddl_with_retry(
-                    pool,
-                    &format!(
-                        "ALTER TABLE {bt_full} ADD INDEX idx_scope_subject_active \
-                         (user_id, subject_id, is_active, memory_type)"
-                    ),
-                )
-                .await
-                {
-                    Ok(_) => tracing::info!(
-                        "migration: added idx_scope_subject_active to branch table {bt_full}"
-                    ),
-                    Err(e) if is_duplicate_index(&e) => tracing::debug!(
-                        "migration: idx_scope_subject_active already exists on branch table \
-                         {bt_full}, skipping"
-                    ),
-                    Err(e) if is_mo_concurrent_ddl_race(&e) => tracing::warn!(
-                        "migration: concurrent DDL race for idx_scope_subject_active on \
-                         branch table {bt_full}: {e}"
-                    ),
-                    Err(e) => tracing::warn!(
-                        "migration: failed to add idx_scope_subject_active to branch table \
-                         {bt_full}: {e}"
-                    ),
-                }
+        for table in &branch_table_names {
+            // Existing branches remain best-effort at startup. New clones use
+            // the same migration below, but must pass it before registration.
+            if let Err(error) = self.migrate_branch_subject_id(table, schema_name).await {
+                tracing::error!(%error, %table, "branch subject_id migration failed");
             }
         }
 
         Ok(())
     }
 
-    /// A branch cloned from a historical snapshot inherits the historical schema,
-    /// not today's mem_memories schema. Call before registering the new branch.
+    /// A historical clone must have usable columns before it can be registered.
+    /// The subject index is a best-effort performance optimization.
     pub async fn ensure_branch_subject_id(&self, table: &str) -> Result<(), MemoriaError> {
-        if !table.starts_with("br_")
-            || !table
-                .bytes()
-                .all(|c| c.is_ascii_alphanumeric() || c == b'_')
-        {
+        if !table.starts_with("br_") {
             return Err(MemoriaError::Validation("Invalid branch table name".into()));
         }
         let schema = self.current_schema_name().await?;
-        if !info_schema_column_exists(&self.pool, schema.as_ref(), table, "subject_id").await {
+        self.migrate_branch_subject_id(table, schema.as_ref()).await
+    }
+
+    async fn migrate_branch_subject_id(
+        &self,
+        table: &str,
+        schema: &str,
+    ) -> Result<(), MemoriaError> {
+        if !memoria_core::is_safe_sql_identifier(table) {
+            return Err(MemoriaError::Validation("Invalid branch table name".into()));
+        }
+        if !info_schema_column_exists(&self.pool, schema, table, "subject_id").await {
             let mut ddl = sqlx::QueryBuilder::<sqlx::MySql>::new("ALTER TABLE ");
             ddl.push(self.t(table))
                 .push(" ADD COLUMN subject_id VARCHAR(128) DEFAULT NULL");
             if let Err(error) = exec_ddl_with_retry(&self.pool, &ddl.into_sql()).await {
-                if !is_duplicate_column(&error) {
+                if !is_duplicate_column(&error) && !is_mo_concurrent_ddl_race(&error) {
                     return Err(db_err(error));
                 }
+                tracing::debug!(%error, %table, "rechecking branch column after concurrent DDL");
             }
         }
-        if !info_schema_column_exists(&self.pool, schema.as_ref(), table, "subject_id").await {
+        // Subject migration is the only schema change this path performs.
+        // Require ALL live column names afterwards, including nullable/defaulted
+        // columns: current INSERT/SELECT statements explicitly reference them.
+        let columns = crate::table_schema::read_table_columns(&self.pool, schema, table).await?;
+        let present: Vec<String> = columns.into_iter().map(|c| c.name).collect();
+        if !present
+            .iter()
+            .any(|name| name.eq_ignore_ascii_case("subject_id"))
+        {
             return Err(MemoriaError::Database(
                 "Branch subject_id migration did not complete".into(),
             ));
         }
-        if !info_schema_index_exists(
-            &self.pool,
-            schema.as_ref(),
-            table,
-            "idx_scope_subject_active",
-        )
-        .await
-        {
+        let current =
+            crate::table_schema::read_table_columns(&self.pool, schema, "mem_memories").await?;
+        if let Some(column) = crate::table_schema::missing_columns(&current, &present).first() {
+            return Err(MemoriaError::Database(format!(
+                "Branch schema is missing required column '{}'",
+                column.name
+            )));
+        }
+        if !info_schema_index_exists(&self.pool, schema, table, "idx_scope_subject_active").await {
             let mut ddl = sqlx::QueryBuilder::<sqlx::MySql>::new("ALTER TABLE ");
             ddl.push(self.t(table)).push(
                 " ADD INDEX idx_scope_subject_active (user_id, subject_id, is_active, memory_type)",
             );
             if let Err(error) = exec_ddl_with_retry(&self.pool, &ddl.into_sql()).await {
-                if !is_duplicate_index(&error) {
-                    return Err(db_err(error));
-                }
+                // Missing columns have already failed above. Index creation
+                // errors, including MO concurrent-DDL races, must not discard a
+                // usable branch. A subsequent migration can retry the index.
+                tracing::warn!(%error, %table, "branch subject index unavailable; continuing without it");
             }
         }
         Ok(())

--- a/memoria/crates/memoria-storage/src/table_schema.rs
+++ b/memoria/crates/memoria-storage/src/table_schema.rs
@@ -7,6 +7,7 @@ use sqlx::MySqlPool;
 #[derive(Debug)]
 pub struct TableColumn {
     pub name: String,
+    pub column_type: String,
     pub nullable: bool,
     pub default: Option<String>,
     pub extra: String,
@@ -27,8 +28,8 @@ pub async fn read_table_columns(
     schema: &str,
     table: &str,
 ) -> Result<Vec<TableColumn>, MemoriaError> {
-    let rows: Vec<(String, String, Option<String>, String)> = sqlx::query_as(
-        "SELECT COLUMN_NAME, IS_NULLABLE, COLUMN_DEFAULT, EXTRA \
+    let rows: Vec<(String, String, String, Option<String>, String)> = sqlx::query_as(
+        "SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT, EXTRA \
          FROM information_schema.columns WHERE table_schema = ? AND table_name = ? \
          ORDER BY ORDINAL_POSITION",
     )
@@ -44,12 +45,15 @@ pub async fn read_table_columns(
     }
     Ok(rows
         .into_iter()
-        .map(|(name, nullable, default, extra)| TableColumn {
-            name,
-            nullable: nullable == "YES",
-            default,
-            extra,
-        })
+        .map(
+            |(name, column_type, nullable, default, extra)| TableColumn {
+                name,
+                column_type,
+                nullable: nullable == "YES",
+                default,
+                extra,
+            },
+        )
         .collect())
 }
 
@@ -67,33 +71,111 @@ pub fn missing_columns<'a>(
         .collect()
 }
 
+/// Native DATA BRANCH operations on older MatrixOne builds can silently pair
+/// fields by ordinal. Be conservative across supported versions, even if a
+/// newer build accepts a particular order difference. Explicit row restoration
+/// has a separate compatibility rule and must not use this check.
+pub fn validate_native_branch_schema(
+    current: &[TableColumn],
+    branch: &[TableColumn],
+) -> Result<(), MemoriaError> {
+    // MO CREATE TABLE LIKE reports an implicit nullable default as SQL text
+    // "null", while the source metadata can use SQL NULL. They are equivalent;
+    // a quoted string default ('null') must remain distinct.
+    fn normalized_default(column: &TableColumn) -> Option<&str> {
+        column
+            .default
+            .as_deref()
+            .filter(|value| !value.trim().eq_ignore_ascii_case("null"))
+    }
+    if current.len() != branch.len()
+        || current.iter().zip(branch).any(|(a, b)| {
+            !a.name.eq_ignore_ascii_case(&b.name)
+                || !a.column_type.eq_ignore_ascii_case(&b.column_type)
+                || a.nullable != b.nullable
+                || normalized_default(a) != normalized_default(b)
+                || !a.extra.eq_ignore_ascii_case(&b.extra)
+        })
+    {
+        return Err(MemoriaError::Database(
+            "Branch schema is incompatible with the current table (column order, type, or constraints differ); native branch operations are disabled. Preserve the branch data and recreate a compatible branch before retrying".into(),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn column(name: &str, ty: &str) -> TableColumn {
+        TableColumn {
+            name: name.into(),
+            column_type: ty.into(),
+            nullable: true,
+            default: None,
+            extra: String::new(),
+        }
+    }
+
+    #[test]
+    fn native_schema_requires_matching_order_types_and_constraints() {
+        let current = vec![column("id", "INT"), column("embedding", "VECF32(3)")];
+        assert!(validate_native_branch_schema(
+            &current,
+            &[column("ID", "int"), column("embedding", "vecf32(3)")]
+        )
+        .is_ok());
+        for branch in [
+            vec![column("id", "INT")],
+            vec![column("embedding", "VECF32(3)"), column("id", "INT")],
+            vec![
+                column("id", "VARCHAR(32)"),
+                column("embedding", "VECF32(3)"),
+            ],
+            vec![column("id", "INT"), column("embedding", "VECF32(4)")],
+        ] {
+            assert!(validate_native_branch_schema(&current, &branch).is_err());
+        }
+        let mut branch = vec![column("id", "INT"), column("embedding", "VECF32(3)")];
+        branch[0].nullable = false;
+        assert!(validate_native_branch_schema(&current, &branch).is_err());
+        branch[0].nullable = true;
+        branch[0].default = Some("0".into());
+        assert!(validate_native_branch_schema(&current, &branch).is_err());
+        branch[0].default = Some("null".into());
+        assert!(validate_native_branch_schema(&current, &branch).is_ok());
+        branch[0].default = Some("'null'".into());
+        assert!(validate_native_branch_schema(&current, &branch).is_err());
+    }
 
     #[test]
     fn row_defaults_do_not_make_missing_table_columns_safe() {
         let expected = vec![
             TableColumn {
                 name: "source_event_ids".into(),
+                column_type: "TEXT".into(),
                 nullable: false,
                 default: None,
                 extra: String::new(),
             },
             TableColumn {
                 name: "embedding".into(),
+                column_type: "VECF32(3)".into(),
                 nullable: true,
                 default: None,
                 extra: String::new(),
             },
             TableColumn {
                 name: "is_active".into(),
+                column_type: "TINYINT".into(),
                 nullable: false,
                 default: Some("1".into()),
                 extra: String::new(),
             },
             TableColumn {
                 name: "id".into(),
+                column_type: "INT".into(),
                 nullable: false,
                 default: None,
                 extra: "auto_increment".into(),

--- a/memoria/crates/memoria-storage/src/table_schema.rs
+++ b/memoria/crates/memoria-storage/src/table_schema.rs
@@ -1,0 +1,125 @@
+//! Shared schema metadata, with separate rules for restoring rows and validating
+//! a cloned table. A nullable column may be omitted from historical row data,
+//! but cannot be absent from a table when current application SQL references it.
+use memoria_core::MemoriaError;
+use sqlx::MySqlPool;
+
+#[derive(Debug)]
+pub struct TableColumn {
+    pub name: String,
+    pub nullable: bool,
+    pub default: Option<String>,
+    pub extra: String,
+}
+
+impl TableColumn {
+    /// Whether historical row data must supply this column. This does NOT decide
+    /// whether application SQL can operate on a table that lacks the column.
+    pub fn needs_snapshot_value(&self) -> bool {
+        !self.nullable
+            && self.default.is_none()
+            && !self.extra.to_ascii_lowercase().contains("auto_increment")
+    }
+}
+
+pub async fn read_table_columns(
+    pool: &MySqlPool,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<TableColumn>, MemoriaError> {
+    let rows: Vec<(String, String, Option<String>, String)> = sqlx::query_as(
+        "SELECT COLUMN_NAME, IS_NULLABLE, COLUMN_DEFAULT, EXTRA \
+         FROM information_schema.columns WHERE table_schema = ? AND table_name = ? \
+         ORDER BY ORDINAL_POSITION",
+    )
+    .bind(schema)
+    .bind(table)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| MemoriaError::Database(e.to_string()))?;
+    if rows.is_empty() {
+        return Err(MemoriaError::Database(format!(
+            "No column metadata available for {schema}.{table}"
+        )));
+    }
+    Ok(rows
+        .into_iter()
+        .map(|(name, nullable, default, extra)| TableColumn {
+            name,
+            nullable: nullable == "YES",
+            default,
+            extra,
+        })
+        .collect())
+}
+
+pub fn missing_columns<'a>(
+    expected: &'a [TableColumn],
+    present: &[String],
+) -> Vec<&'a TableColumn> {
+    expected
+        .iter()
+        .filter(|column| {
+            !present
+                .iter()
+                .any(|name| name.eq_ignore_ascii_case(&column.name))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_defaults_do_not_make_missing_table_columns_safe() {
+        let expected = vec![
+            TableColumn {
+                name: "source_event_ids".into(),
+                nullable: false,
+                default: None,
+                extra: String::new(),
+            },
+            TableColumn {
+                name: "embedding".into(),
+                nullable: true,
+                default: None,
+                extra: String::new(),
+            },
+            TableColumn {
+                name: "is_active".into(),
+                nullable: false,
+                default: Some("1".into()),
+                extra: String::new(),
+            },
+            TableColumn {
+                name: "id".into(),
+                nullable: false,
+                default: None,
+                extra: "auto_increment".into(),
+            },
+        ];
+        let missing = missing_columns(&expected, &[]);
+        assert_eq!(
+            missing.len(),
+            4,
+            "cloned tables must contain all referenced columns"
+        );
+        let required: Vec<_> = missing
+            .into_iter()
+            .filter(|c| c.needs_snapshot_value())
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(required, vec!["source_event_ids"]);
+        assert!(missing_columns(
+            &expected,
+            &[
+                "SOURCE_EVENT_IDS".into(),
+                "embedding".into(),
+                "is_active".into(),
+                "id".into()
+            ]
+        )
+        .is_empty());
+    }
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [x] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [x] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Fixes #246

## What this PR does / why we need it

Restoring a snapshot created before `subject_id` was introduced previously ran an
autocommitted DELETE followed by `INSERT ... SELECT *`. The INSERT could fail on
the historical column count after live rows had already been deleted. Historical
snapshot branches also inherited an outdated schema.

This is a separate snapshot-safety fix, based on current `main` after #244. It does
not reintroduce that PR's scoped-key changes or modify MatrixOne source/deployment.

### Changes

- Map historical rows to current columns by name; honor current defaults/NULL and
  reject missing required values before touching live data.
- Materialize a private constrained staging table outside the write transaction;
  replace live rows with DELETE + INSERT in one transaction. Preserve the original
  statement error even if rollback fails. Do not retry the non-idempotent stage INSERT.
- Schedule best-effort stage cleanup, including cancellation/no-runtime diagnostics.
- Share startup/clone `subject_id` migration. Require all current memory-column
  names before registering a historical clone, while treating index creation as
  best-effort. Reject and clean up unusable clones.
- Generate ASCII physical branch names while preserving Unicode display names;
  retain quoted access/migration/cleanup for existing Unicode physical names.
- Add an offline-only, read-only-by-default cleanup example with exact-name and
  explicit all-writers-stopped requirements. Protect every registered branch and
  fail closed if the registry cannot be read; no online prefix-based reaper.
- Cover 512 real embeddings with FULLTEXT/IVF indexes, failure atomicity, historical
  schema gaps, Unicode names, permissions, and cleanup guardrails. Explicitly run
  ignored DB failure-injection tests and example tests in both CI test workflows.

### Validation

- Previous isolated runs passed on MatrixOne 3.0.11 (`6a0394c`) and 3.0.15 (`43e871c`):
  9 legacy snapshot tests, 1 transaction failure test, 1 DB cleanup test, 49 MCP
  branch tests, 21 MCP snapshot tests, and 20 storage compatibility tests per build.
- Post-rebase validation against 3.0.15 and database-free checks are recorded in
  the follow-up validation comment. These are regression baselines, not production
  upgrade approval. Remote CI results must be checked separately.
- `cargo clippy -p memoria-git -p memoria-storage -p memoria-mcp -p memoria-api --lib -- -D warnings`
  and `git diff --check` pass.

### Production upgrade status — not yet approved

The intended production target is **MatrixOne
`v4.2.1-d2393868a-2026-08-28`**, not 3.0.15. A separate 3.0.11-to-target rehearsal
using unchanged Memoria `apiserver-20260511-27107f5-df643526` hit an engine catalog
migration failure: `no such table mo_catalog.mo_feature_registry`. The internal
upgrade remained incomplete and `SHOW SNAPSHOTS` failed with
`column kind does not exist`. The target accepted SQL connections, so connectivity
and API liveness alone are not sufficient upgrade readiness checks.

This PR does **not** fix that MatrixOne upgrade failure, and its new Memoria DB
suites have not been validated on the target build. Resolve/rehearse the supported
MatrixOne upgrade path first, validate old Memoria, then validate/deploy new Memoria.

### Review focus / boundaries

- Atomicity is per restored table, not the whole memory/graph operation. Serialize
  snapshot operations and quiesce competing writes.
- Staging retains FULLTEXT/IVF indexes: additional storage/index writes and a
  whole-table transaction need capacity planning; 512 rows is not a scale limit.
- Abrupt shutdown can leave staging/orphan tables. Offline cleanup is an operator
  tool, not proof that an unregistered table is safe to delete while writers run.
- Column-presence checks do not normalize types/order or guarantee native Data
  Branch diff schema compatibility on every MatrixOne version.

See [the compatibility and verification notes](docs/legacy-snapshot-compatibility.md)
for the regression commands, operational constraints, and exact upgrade evidence.
