### PR TITLE
fix(auth): add owner-scoped master authority

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           shared-key: memoria-check
           save-if: false
       - name: Unit tests
-        run: cd memoria && cargo test --lib -p memoria-core -p memoria-service -p memoria-mcp
+        run: cd memoria && cargo test --lib -p memoria-api -p memoria-core -p memoria-service -p memoria-mcp
 
   test-db:
     name: DB Tests

--- a/memoria/crates/memoria-api/AUTH_CHANGES.md
+++ b/memoria/crates/memoria-api/AUTH_CHANGES.md
@@ -124,8 +124,10 @@ are visible in logs.
 Trusted multi-user proxies that hold the deployment master secret must use
 `Authorization: Memoria-Owner <master_key>` together with exactly one
 `X-User-Id` whose value is at most 64 bytes. Missing, duplicate, blank,
-whitespace-padded, or otherwise invalid owner headers are rejected. This
-scheme validates the master secret, then constructs a
+whitespace-padded, `grp_`-prefixed, or otherwise invalid owner headers are
+rejected. The `grp_` namespace is reserved for group-scoped API keys whose
+membership is verified separately; this personal owner scheme cannot route
+into a group database. This scheme validates the master secret, then constructs a
 non-master principal limited to identity and memory scopes. It therefore
 retains owner enforcement for ID-based reads and mutations and cannot access
 admin, key-management, group, or unclassified routes. `Bearer <master_key>`

--- a/memoria/crates/memoria-api/AUTH_CHANGES.md
+++ b/memoria/crates/memoria-api/AUTH_CHANGES.md
@@ -122,8 +122,10 @@ are visible in logs.
 ## Auth matrix
 
 Trusted multi-user proxies that hold the deployment master secret must use
-`Authorization: Memoria-Owner <master_key>` together with an exact
-`X-User-Id`. This scheme validates the master secret, then constructs a
+`Authorization: Memoria-Owner <master_key>` together with exactly one
+`X-User-Id` whose value is at most 64 bytes. Missing, duplicate, blank,
+whitespace-padded, or otherwise invalid owner headers are rejected. This
+scheme validates the master secret, then constructs a
 non-master principal limited to identity and memory scopes. It therefore
 retains owner enforcement for ID-based reads and mutations and cannot access
 admin, key-management, group, or unclassified routes. `Bearer <master_key>`

--- a/memoria/crates/memoria-api/AUTH_CHANGES.md
+++ b/memoria/crates/memoria-api/AUTH_CHANGES.md
@@ -121,6 +121,14 @@ are visible in logs.
 
 ## Auth matrix
 
+Trusted multi-user proxies that hold the deployment master secret must use
+`Authorization: Memoria-Owner <master_key>` together with an exact
+`X-User-Id`. This scheme validates the master secret, then constructs a
+non-master principal limited to identity and memory scopes. It therefore
+retains owner enforcement for ID-based reads and mutations and cannot access
+admin, key-management, group, or unclassified routes. `Bearer <master_key>`
+intentionally retains unrestricted administrator semantics.
+
 ### With `master_key` configured (production)
 
 | Request | `user_id` source | `is_master` | `/admin/*` | `/v1/*` |

--- a/memoria/crates/memoria-api/src/auth.rs
+++ b/memoria/crates/memoria-api/src/auth.rs
@@ -67,6 +67,7 @@ fn validate_owner_scoped_master_request(
             !value.is_empty()
                 && value.trim() == *value
                 && value.len() <= MAX_OWNER_SCOPED_USER_ID_LEN
+                && !value.starts_with("grp_")
                 && !value.chars().any(char::is_control)
         })
         .ok_or_else(|| {
@@ -1512,6 +1513,17 @@ mod tests {
         headers.insert("X-User-Id", oversized_owner.parse().unwrap());
         let rejection =
             validate_owner_scoped_master_request("master", "master", &headers).unwrap_err();
+        assert_eq!(rejection.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn owner_scoped_master_rejects_reserved_group_namespace() {
+        let rejection = validate_owner_scoped_master_request(
+            "master",
+            "master",
+            &owner_headers(&["grp_existing_group"]),
+        )
+        .unwrap_err();
         assert_eq!(rejection.0, StatusCode::BAD_REQUEST);
     }
 

--- a/memoria/crates/memoria-api/src/auth.rs
+++ b/memoria/crates/memoria-api/src/auth.rs
@@ -1075,12 +1075,64 @@ impl FromRequestParts<AppState> for AuthUser {
             request_tool_name(&parts.headers)
         };
 
-        let bearer = parts
+        let authorization = parts
             .headers
             .get("Authorization")
             .and_then(|v| v.to_str().ok())
-            .filter(|v| v.starts_with("Bearer "))
-            .map(|v| &v[7..]);
+            .unwrap_or_default();
+        let owner_scoped_master = authorization.strip_prefix("Memoria-Owner ");
+        let bearer = authorization.strip_prefix("Bearer ");
+
+        // A trusted proxy may authenticate with the deployment master secret
+        // while explicitly attenuating it to one owner.  This is a distinct
+        // scheme so older Memoria servers fail closed with 401 instead of
+        // silently treating the request as an unrestricted Bearer master key.
+        if let Some(token) = owner_scoped_master {
+            let master_match = !state.master_key.is_empty()
+                && token.len() == state.master_key.len()
+                && token.as_bytes().ct_eq(state.master_key.as_bytes()).into();
+            if !master_match {
+                crate::metrics::registry().security.auth_failures.inc();
+                return Err((StatusCode::UNAUTHORIZED, "Invalid token".to_string()));
+            }
+            let user_id = parts
+                .headers
+                .get("X-User-Id")
+                .and_then(|value| value.to_str().ok())
+                .filter(|value| {
+                    !value.is_empty()
+                        && value.trim() == *value
+                        && value.len() <= 128
+                        && !value.chars().any(char::is_control)
+                })
+                .ok_or_else(|| {
+                    (
+                        StatusCode::BAD_REQUEST,
+                        "Owner-scoped master authentication requires an exact X-User-Id"
+                            .to_string(),
+                    )
+                })?
+                .to_string();
+            let scopes = parse_scopes("identity:read,memory:read,memory:write");
+            authorize_api_key_route(&parts.method, parts.uri.path(), &scopes)?;
+            if let Some(tool) = tool_name {
+                state.tool_usage_batcher.mark_used(user_id.clone(), tool);
+            }
+            if let Some(ctx) = parts.extensions.get::<CallLogContext>() {
+                if let Ok(mut guard) = ctx.0.lock() {
+                    *guard = Some(user_id.clone());
+                }
+            }
+            return Ok(AuthUser {
+                scope_id: user_id.clone(),
+                group_id: None,
+                user_id,
+                is_master: false,
+                key_id: None,
+                key_prefix: None,
+                scopes,
+            });
+        }
 
         if let Some(token) = bearer {
             // 1) Master key — full access, fall through to X-User-Id extraction

--- a/memoria/crates/memoria-api/src/auth.rs
+++ b/memoria/crates/memoria-api/src/auth.rs
@@ -26,6 +26,9 @@ pub const SCOPE_MEMORY_READ: &str = "memory:read";
 pub const SCOPE_MEMORY_WRITE: &str = "memory:write";
 pub const SCOPE_KEYS_MANAGE: &str = "keys:manage";
 pub const DEFAULT_API_KEY_SCOPES: &str = "identity:read,memory:read,memory:write,keys:manage";
+const OWNER_SCOPED_MASTER_SCOPES: &[&str] =
+    &[SCOPE_IDENTITY_READ, SCOPE_MEMORY_READ, SCOPE_MEMORY_WRITE];
+const MAX_OWNER_SCOPED_USER_ID_LEN: usize = 64;
 
 pub fn parse_scopes(value: &str) -> Vec<String> {
     value
@@ -34,6 +37,47 @@ pub fn parse_scopes(value: &str) -> Vec<String> {
         .filter(|scope| !scope.is_empty())
         .map(str::to_string)
         .collect()
+}
+
+fn owner_scoped_master_scopes() -> Vec<String> {
+    OWNER_SCOPED_MASTER_SCOPES
+        .iter()
+        .map(|scope| (*scope).to_string())
+        .collect()
+}
+
+fn validate_owner_scoped_master_request(
+    token: &str,
+    master_key: &str,
+    headers: &axum::http::HeaderMap,
+) -> Result<String, (StatusCode, String)> {
+    let master_match = !master_key.is_empty()
+        && token.len() == master_key.len()
+        && token.as_bytes().ct_eq(master_key.as_bytes()).into();
+    if !master_match {
+        return Err((StatusCode::UNAUTHORIZED, "Invalid token".to_string()));
+    }
+
+    let mut owner_values = headers.get_all("X-User-Id").iter();
+    let owner = owner_values
+        .next()
+        .filter(|_| owner_values.next().is_none())
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| {
+            !value.is_empty()
+                && value.trim() == *value
+                && value.len() <= MAX_OWNER_SCOPED_USER_ID_LEN
+                && !value.chars().any(char::is_control)
+        })
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                "Owner-scoped master authentication requires exactly one valid X-User-Id"
+                    .to_string(),
+            )
+        })?;
+
+    Ok(owner.to_string())
 }
 
 /// Agent labels are recorded only after the request's scope admission. MCP
@@ -1088,32 +1132,25 @@ impl FromRequestParts<AppState> for AuthUser {
         // scheme so older Memoria servers fail closed with 401 instead of
         // silently treating the request as an unrestricted Bearer master key.
         if let Some(token) = owner_scoped_master {
-            let master_match = !state.master_key.is_empty()
-                && token.len() == state.master_key.len()
-                && token.as_bytes().ct_eq(state.master_key.as_bytes()).into();
-            if !master_match {
-                crate::metrics::registry().security.auth_failures.inc();
-                return Err((StatusCode::UNAUTHORIZED, "Invalid token".to_string()));
-            }
-            let user_id = parts
-                .headers
-                .get("X-User-Id")
-                .and_then(|value| value.to_str().ok())
-                .filter(|value| {
-                    !value.is_empty()
-                        && value.trim() == *value
-                        && value.len() <= 128
-                        && !value.chars().any(char::is_control)
-                })
-                .ok_or_else(|| {
-                    (
-                        StatusCode::BAD_REQUEST,
-                        "Owner-scoped master authentication requires an exact X-User-Id"
-                            .to_string(),
-                    )
-                })?
-                .to_string();
-            let scopes = parse_scopes("identity:read,memory:read,memory:write");
+            let user_id = match validate_owner_scoped_master_request(
+                token,
+                &state.master_key,
+                &parts.headers,
+            ) {
+                Ok(user_id) => user_id,
+                Err(rejection) => {
+                    if rejection.0 == StatusCode::UNAUTHORIZED {
+                        crate::metrics::registry().security.auth_failures.inc();
+                        warn!(
+                            scheme = "Memoria-Owner",
+                            path = %parts.uri.path(),
+                            "auth: invalid token"
+                        );
+                    }
+                    return Err(rejection);
+                }
+            };
+            let scopes = owner_scoped_master_scopes();
             authorize_api_key_route(&parts.method, parts.uri.path(), &scopes)?;
             if let Some(tool) = tool_name {
                 state.tool_usage_batcher.mark_used(user_id.clone(), tool);
@@ -1420,6 +1457,89 @@ mod tests {
             &parse_scopes("identity:read")
         )
         .is_err());
+    }
+
+    fn owner_headers(values: &[&'static str]) -> axum::http::HeaderMap {
+        let mut headers = axum::http::HeaderMap::new();
+        for value in values {
+            headers.append("X-User-Id", axum::http::HeaderValue::from_static(value));
+        }
+        headers
+    }
+
+    #[test]
+    fn owner_scoped_master_rejects_invalid_secret() {
+        let rejection = validate_owner_scoped_master_request(
+            "attacker-secret",
+            "expected-master",
+            &owner_headers(&["alice"]),
+        )
+        .unwrap_err();
+        assert_eq!(rejection.0, StatusCode::UNAUTHORIZED);
+
+        let rejection =
+            validate_owner_scoped_master_request("", "", &owner_headers(&["alice"])).unwrap_err();
+        assert_eq!(rejection.0, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn owner_scoped_master_requires_exactly_one_owner_header() {
+        let rejection =
+            validate_owner_scoped_master_request("master", "master", &owner_headers(&[]))
+                .unwrap_err();
+        assert_eq!(rejection.0, StatusCode::BAD_REQUEST);
+
+        let rejection = validate_owner_scoped_master_request(
+            "master",
+            "master",
+            &owner_headers(&["victim", "authenticated-user"]),
+        )
+        .unwrap_err();
+        assert_eq!(rejection.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn owner_scoped_master_enforces_storage_identity_width() {
+        let max_owner = "a".repeat(MAX_OWNER_SCOPED_USER_ID_LEN);
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("X-User-Id", max_owner.parse().unwrap());
+        assert_eq!(
+            validate_owner_scoped_master_request("master", "master", &headers).unwrap(),
+            max_owner
+        );
+
+        let oversized_owner = "a".repeat(MAX_OWNER_SCOPED_USER_ID_LEN + 1);
+        headers.insert("X-User-Id", oversized_owner.parse().unwrap());
+        let rejection =
+            validate_owner_scoped_master_request("master", "master", &headers).unwrap_err();
+        assert_eq!(rejection.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn owner_scoped_master_scopes_exclude_administration() {
+        use axum::http::Method;
+
+        let scopes = owner_scoped_master_scopes();
+        assert_eq!(
+            scopes,
+            OWNER_SCOPED_MASTER_SCOPES
+                .iter()
+                .map(|scope| (*scope).to_string())
+                .collect::<Vec<_>>()
+        );
+        assert!(!scopes.iter().any(|scope| scope == SCOPE_KEYS_MANAGE));
+        assert_eq!(
+            authorize_api_key_route(&Method::GET, "/admin/stats", &scopes)
+                .unwrap_err()
+                .0,
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            authorize_api_key_route(&Method::POST, "/auth/keys", &scopes)
+                .unwrap_err()
+                .0,
+            StatusCode::FORBIDDEN
+        );
     }
 
     #[test]

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -2946,8 +2946,12 @@ async fn test_owner_scoped_master_cannot_cross_user_memory_ids() {
         .await
         .unwrap();
     assert_eq!(response.status(), 200);
+    let corrected_user_a_memory = response.json::<Value>().await.unwrap()["memory_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
     let response = client
-        .delete(format!("{base}/v1/memories/{user_a_memory}"))
+        .delete(format!("{base}/v1/memories/{corrected_user_a_memory}"))
         .header("Authorization", &owner_auth)
         .header("X-User-Id", &user_a)
         .send()

--- a/memoria/crates/memoria-api/tests/api_e2e.rs
+++ b/memoria/crates/memoria-api/tests/api_e2e.rs
@@ -2867,6 +2867,113 @@ async fn test_master_key_can_impersonate_and_access_any_user() {
 }
 
 #[tokio::test]
+async fn test_owner_scoped_master_cannot_cross_user_memory_ids() {
+    let master = "test-master-key-owner-scoped";
+    let (base, client, _server) = spawn_server_with_master_key(master).await;
+    let user_a = uid();
+    let user_b = uid();
+    let owner_auth = format!("Memoria-Owner {master}");
+
+    let store = |user_id: &str, content: &str| {
+        client
+            .post(format!("{base}/v1/memories"))
+            .header("Authorization", &owner_auth)
+            .header("X-User-Id", user_id)
+            .json(&json!({"content": content, "memory_type": "semantic"}))
+            .send()
+    };
+    let response = store(&user_b, "user-b private memory").await.unwrap();
+    assert_eq!(response.status(), 201);
+    let user_b_memory = response.json::<Value>().await.unwrap()["memory_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let response = client
+        .get(format!("{base}/v1/memories/{user_b_memory}"))
+        .header("Authorization", &owner_auth)
+        .header("X-User-Id", &user_a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.json::<Value>().await.unwrap(), Value::Null);
+
+    let response = client
+        .put(format!("{base}/v1/memories/{user_b_memory}/correct"))
+        .header("Authorization", &owner_auth)
+        .header("X-User-Id", &user_a)
+        .json(&json!({"new_content": "cross-user overwrite"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 404);
+
+    let response = client
+        .delete(format!("{base}/v1/memories/{user_b_memory}"))
+        .header("Authorization", &owner_auth)
+        .header("X-User-Id", &user_a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 404);
+
+    let response = client
+        .get(format!("{base}/v1/memories/{user_b_memory}"))
+        .header("Authorization", &owner_auth)
+        .header("X-User-Id", &user_b)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        response.json::<Value>().await.unwrap()["content"],
+        "user-b private memory"
+    );
+
+    let response = store(&user_a, "user-a own memory").await.unwrap();
+    assert_eq!(response.status(), 201);
+    let user_a_memory = response.json::<Value>().await.unwrap()["memory_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let response = client
+        .put(format!("{base}/v1/memories/{user_a_memory}/correct"))
+        .header("Authorization", &owner_auth)
+        .header("X-User-Id", &user_a)
+        .json(&json!({"new_content": "user-a corrected own memory"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let response = client
+        .delete(format!("{base}/v1/memories/{user_a_memory}"))
+        .header("Authorization", &owner_auth)
+        .header("X-User-Id", &user_a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 204);
+
+    let response = client
+        .get(format!("{base}/admin/stats"))
+        .header("Authorization", &owner_auth)
+        .header("X-User-Id", &user_a)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 403);
+
+    let response = client
+        .get(format!("{base}/v1/memories"))
+        .header("Authorization", &owner_auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 400);
+}
+
+#[tokio::test]
 async fn test_non_master_cannot_probe_other_users_memory_ids() {
     let mk = "test-master-key-tenant-isolation";
     let (base, client, _server) = spawn_server_with_master_key(mk).await;

--- a/memoria/crates/memoria-api/tests/group_collab_api.rs
+++ b/memoria/crates/memoria-api/tests/group_collab_api.rs
@@ -378,6 +378,82 @@ async fn test_solo_owner_group_key_can_write_on_main() {
 
 #[tokio::test]
 #[serial]
+async fn test_owner_scoped_master_cannot_enter_group_database() {
+    let server = spawn_server().await;
+    let group = create_group(&server, "alice").await;
+    let group_id = group["group_id"].as_str().unwrap();
+    let raw_key = create_group_key(&server, "alice", group_id).await;
+    let group_auth = format!("Bearer {raw_key}");
+    let created = store_memory(&server, &group_auth, "group private memory").await;
+    let memory_id = created["memory_id"].as_str().unwrap();
+    let owner_auth = "Memoria-Owner master-group-test-key";
+
+    let response = server
+        .client
+        .get(format!("{}/v1/memories", server.base))
+        .header("Authorization", owner_auth)
+        .header("X-User-Id", group_id)
+        .send()
+        .await
+        .expect("owner-scoped group list attempt");
+    assert_eq!(response.status(), 400);
+
+    let response = server
+        .client
+        .get(format!("{}/v1/memories/{memory_id}", server.base))
+        .header("Authorization", owner_auth)
+        .header("X-User-Id", group_id)
+        .send()
+        .await
+        .expect("owner-scoped group read attempt");
+    assert_eq!(response.status(), 400);
+
+    let response = server
+        .client
+        .post(format!("{}/v1/memories", server.base))
+        .header("Authorization", owner_auth)
+        .header("X-User-Id", group_id)
+        .json(&json!({"content": "unauthorized group write", "memory_type": "semantic"}))
+        .send()
+        .await
+        .expect("owner-scoped group write attempt");
+    assert_eq!(response.status(), 400);
+
+    let response = server
+        .client
+        .put(format!("{}/v1/memories/{memory_id}/correct", server.base))
+        .header("Authorization", owner_auth)
+        .header("X-User-Id", group_id)
+        .json(&json!({"new_content": "unauthorized overwrite"}))
+        .send()
+        .await
+        .expect("owner-scoped group correction attempt");
+    assert_eq!(response.status(), 400);
+
+    let response = server
+        .client
+        .delete(format!("{}/v1/memories/{memory_id}", server.base))
+        .header("Authorization", owner_auth)
+        .header("X-User-Id", group_id)
+        .send()
+        .await
+        .expect("owner-scoped group delete attempt");
+    assert_eq!(response.status(), 400);
+
+    let memories = list_memories(&server, &group_auth).await;
+    let items = memories["items"].as_array().unwrap();
+    assert!(items.iter().any(|item| {
+        item["memory_id"] == memory_id && item["content"] == "group private memory"
+    }));
+    assert!(!items
+        .iter()
+        .any(|item| item["content"] == "unauthorized group write"));
+
+    server.cleanup().await;
+}
+
+#[tokio::test]
+#[serial]
 async fn test_create_group_can_seed_from_personal_db() {
     let server = spawn_server().await;
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [x] fix (bug fix)
- [x] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [x] test (adding or updating tests)
- [ ] chore (maintenance, tooling)
- [x] build / ci (build or CI changes)

## Which issue(s) this PR fixes

Supports the authorization fix requested in matrixorigin/Astra#750 review discussion `discussion_r3978409957`.

## What this PR does / why we need it

Trusted multi-user proxies previously had to send the deployment master key as `Bearer` together with `X-User-Id`. The header selected a routing owner but did not attenuate master authority, so ID-based handlers could still fall back to another user's record.

This PR adds a distinct fail-closed authorization scheme:

```text
Authorization: Memoria-Owner <master-key>
X-User-Id: <authenticated-owner>
```

- The master secret is checked with the existing constant-time comparison.
- Exactly one `X-User-Id` is required. Missing or duplicate headers, blank or padded values, control characters, and identities longer than the storage schema's 64-byte width are rejected.
- The resulting `AuthUser` is non-master and receives only identity/read/write memory scopes.
- Those scopes are constructed from the canonical scope constants rather than a second CSV literal.
- Existing owner enforcement in get/correct/delete handlers therefore remains authoritative and atomic.
- Admin, key-management, group, and unclassified routes are rejected.
- Invalid owner-scoped master credentials increment the authentication failure metric and emit a scheme/path warning without logging credential material.
- Older Memoria versions do not recognize `Memoria-Owner`, so updated clients fail closed with 401 rather than accidentally using unrestricted master authority.
- Ordinary `Bearer <master-key>` behavior remains unchanged for administrators.

## Verification

- `cargo +1.85.0 check` — passed with the repository CI toolchain.
- `cargo +1.85.0 clippy -- -D warnings` — passed with the repository CI toolchain.
- `cargo +1.85.0 test --lib -p memoria-api -p memoria-core -p memoria-service -p memoria-mcp` — 204 passed. The Unit Tests lane now includes `memoria-api`, so invalid/empty master credentials, missing/duplicate owner headers, the 64-byte boundary, least-privilege scopes, and admin/key-management denials execute without a database.
- GitHub Check & Clippy, Unit Tests, and DB Tests passed on `213b566`. The DB lane includes `test_owner_scoped_master_cannot_cross_user_memory_ids`: user A cannot read, correct, or delete user B's ID; B remains unchanged; A can modify and delete A's own memory; admin access and missing owner are rejected.
