### PR TITLE
chore(release): v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2] - 2026-09-11
+
+### 🐛 Bug Fixes
+
+- **auth**: Add owner-scoped master authority (#250) ([bc55ee3](https://github.com/matrixorigin/Memoria/commit/bc55ee355f236cafd0701a107f30e44b1711b3c8))
+- **openclaw**: Ship runnable npm package and preserve search scores (#249) ([61001bc](https://github.com/matrixorigin/Memoria/commit/61001bc8fa47e40eecf907812ad4a9932e59b275))
+- **snapshot**: Preserve data when restoring pre-subject_id snapshots (#248) ([a2e1e25](https://github.com/matrixorigin/Memoria/commit/a2e1e254060b72b74813387dcd357f53cdfeeb0a))
+- **mcp**: Handle ping requests (#237) ([6279342](https://github.com/matrixorigin/Memoria/commit/62793426103d772f856209a3bd4b3ac8fb783a24))
+
+### 📚 Documentation
+
+- Fix broken star history chart (#233) ([85f6c3f](https://github.com/matrixorigin/Memoria/commit/85f6c3fba0c939052500250c42375e460a0bca02))
+
+### 🚀 Features
+
+- **auth**: Add scoped API keys for Astra (#244) ([58012cf](https://github.com/matrixorigin/Memoria/commit/58012cffaea2ab610f4847a877a8dad2048d1eb5))
+
+### Release Notes
+
+- OpenClaw npm and Python SDK packages use separate release workflows; this release tag does not publish them.
+- The legacy snapshot restore fix does not resolve the MatrixOne upgrade failure observed on `v4.2.1-d2393868a-2026-08-28`. See [compatibility and verification notes](docs/legacy-snapshot-compatibility.md) before upgrading a production database.
+
 ## [0.5.1] - 2026-08-26
 
 ### 🐛 Bug Fixes

--- a/memoria/Cargo.lock
+++ b/memoria/Cargo.lock
@@ -2109,7 +2109,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoria-api"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "memoria-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "memoria-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "memoria-embedding"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "memoria-git"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "memoria-core",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "memoria-mcp"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "memoria-service"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "memoria-storage"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "memoria-test-utils"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "axum",
  "memoria-core",

--- a/memoria/Cargo.toml
+++ b/memoria/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 rust-version = "1.85"
 
 [workspace.dependencies]


### PR DESCRIPTION
## What type of PR is this?

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [x] docs (documentation)
- [ ] style (formatting, no code change)
- [ ] refactor (code change that neither fixes a bug nor adds a feature)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [x] chore (maintenance, tooling)
- [ ] build / ci (build or CI changes)

## Which issue(s) this PR fixes

None; prepares the v0.5.2 release.

## What this PR does / why we need it

Prepare v0.5.2 from main by bumping the Rust workspace version and its nine Cargo.lock package entries from 0.5.1 to 0.5.2. Dependency versions are unchanged.

Add the changelog for changes since v0.5.1: MCP ping support (#237), scoped API keys (#244), safe historical snapshot restoration (#248), OpenClaw packaging/search-score fixes (#249), owner-scoped master authority (#250), and the README chart fix (#233).

The release notes clarify that npm/Python packages have separate publication workflows and retain the documented MatrixOne upgrade limitation.

## Validation

- `SQLX_OFFLINE=true cargo +1.85.0 check --workspace` passed.
- `cargo +1.85.0 metadata --locked --no-deps --format-version 1` passed; all nine workspace packages report 0.5.2.
- Compared parsed Cargo.lock entries against main: only the nine workspace package versions changed.
- `git diff --check` passed.
- No local database tests were rerun for this version/documentation-only change; PR CI provides the regression checks.

## Release after merge

Create annotated tag `v0.5.2` on the merged release commit and push it to `matrixorigin/Memoria`. The tag triggers the existing Rust binary/GitHub Release and Docker publication workflows (Docker tags `0.5.2`, `0.5`, and `latest`). This PR does not create the tag or publish artifacts.
